### PR TITLE
VA-581 Stream Caching

### DIFF
--- a/VIMNetworking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/VIMNetworking/src/main/java/com/vimeo/networking/Configuration.java
@@ -22,6 +22,9 @@
 
 package com.vimeo.networking;
 
+import com.vimeo.networking.logging.NetworkingLogger;
+import com.vimeo.networking.logging.NetworkingLoggerInterface;
+
 import java.io.File;
 
 /**
@@ -52,6 +55,7 @@ public class Configuration {
     public String userAgentString;
 
     public boolean certPinningEnabled;
+    public NetworkingLoggerInterface networkingLogger;
 
     private Boolean isValid() {
         return (this.baseURLString != null && this.baseURLString.length() != 0 &&
@@ -80,6 +84,8 @@ public class Configuration {
         private String userAgentString;
 
         private boolean certPinningEnabled = true;
+        // Default to the stock logger which just prints - this makes it optional
+        public NetworkingLoggerInterface networkingLogger = new NetworkingLogger();
 
         public Builder(String baseURLString, String clientID, String clientSecret, String scope,
                        AccountStore accountStore, GsonDeserializer deserializer) {
@@ -121,6 +127,11 @@ public class Configuration {
             return this;
         }
 
+        public Builder networkingLogger(NetworkingLoggerInterface networkingLogger) {
+            this.networkingLogger = networkingLogger;
+            return this;
+        }
+
         public Configuration build() throws Exception {
             return new Configuration(this);
         }
@@ -147,5 +158,6 @@ public class Configuration {
         this.userAgentString = builder.userAgentString;
 
         this.certPinningEnabled = builder.certPinningEnabled;
+        this.networkingLogger = builder.networkingLogger;
     }
 }

--- a/VIMNetworking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/VIMNetworking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -115,7 +115,7 @@ public class VimeoClient {
         try {
             this.cache = new Cache(this.configuration.cacheDirectory, this.configuration.cacheSize);
         } catch (IOException e) {
-            System.out.println("Exception when creating cache: " + e.getMessage());
+            this.configuration.networkingLogger.e("Exception when creating cache: " + e.getMessage(), e);
         }
 
         RetrofitClientBuilder retrofitClientBuilder = new RetrofitClientBuilder();
@@ -125,8 +125,8 @@ public class VimeoClient {
             try {
                 retrofitClientBuilder.pinCertificates();
             } catch (Exception e) {
-                // TODO: Do something louder with the possible NullPointerException from a null InputStream
-                System.out.println("Exception when pinning certificate: " + e.getMessage());
+                this.configuration.networkingLogger
+                        .e("Exception when pinning certificate: " + e.getMessage(), e);
             }
         }
 
@@ -147,7 +147,7 @@ public class VimeoClient {
         try {
             this.cache.evictAll();
         } catch (IOException e) {
-            e.printStackTrace();
+            configuration.networkingLogger.e("Cache clearing error: " + e.getMessage(), e);
         }
     }
 

--- a/VIMNetworking/src/main/java/com/vimeo/networking/logging/NetworkingLogger.java
+++ b/VIMNetworking/src/main/java/com/vimeo/networking/logging/NetworkingLogger.java
@@ -1,0 +1,23 @@
+package com.vimeo.networking.logging;
+
+/**
+ * Created by kylevenn on 10/9/15.
+ */
+public class NetworkingLogger implements NetworkingLoggerInterface {
+
+    @Override
+    public void e(String error) {
+        System.out.println(error);
+    }
+
+    @Override
+    public void e(String error, Exception exception) {
+        System.out.println(error);
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void i(String info) {
+        System.out.println(info);
+    }
+}

--- a/VIMNetworking/src/main/java/com/vimeo/networking/logging/NetworkingLoggerInterface.java
+++ b/VIMNetworking/src/main/java/com/vimeo/networking/logging/NetworkingLoggerInterface.java
@@ -1,0 +1,13 @@
+package com.vimeo.networking.logging;
+
+/**
+ * Created by kylevenn on 10/9/15.
+ */
+public interface NetworkingLoggerInterface {
+
+    void e(String error);
+
+    void e(String error, Exception exception);
+
+    void i(String info);
+}


### PR DESCRIPTION
[VA-581 Stream Caching](https://vimean.atlassian.net/browse/VA-581)
- Added an option to clear the cache since it lives in the networking library since it is specific to requests
- Incremented max to 2 hours - but there was discussion around this so we should just be consistent with iOS

[Android PR here](https://github.vimeows.com/MobileApps/Vimeo-Android/pull/185)
