### PR TITLE
VA-988: Password (shouldn't necessarily be) required to update your own video

### DIFF
--- a/VIMNetworking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/VIMNetworking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -644,7 +644,7 @@ public class VimeoClient {
         }
 
         // TODO: error text below suggests we need to check title == null here, do we? [AH] 12/10/2015
-        if (description == null && privacyValue == null) {
+        if (title == null && description == null && privacyValue == null) {
             // No point in editing video
             callback.failure(new VimeoError("title, description, and privacyValue cannot be empty!"));
 


### PR DESCRIPTION
https://vimean.atlassian.net/browse/VA-988

Only passing privacy value and password value to editVideo when necessary. 

The server allows you to make updates to your video without entering the password. Therefore password is only required when (1) changing the password for a video with privacy value of "password", or (2) when changing video's privacy value from something other than "password" to "password".
