### PR TITLE
VA-1322 New Status: transcode_starting

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -116,15 +116,27 @@ public class Video implements Serializable {
     public List<Category> categories;
 
     /**
+     * This will return the value as it's given to us from the API (or {@link Status#NONE if null}). Unlike
+     * {@link Video#getStatus()}, this will return all known statuses for a video (including {@link Status#TRANSCODE_STARTING}.
+     * <p/>
+     * For a more simplified representation of the video status, use {@link Video#getStatus()}.
+     */
+    public Status getRawStatus() {
+        return status == null ? Status.NONE : status;
+    }
+
+    /**
      * This getter is always guaranteed to return a {@link Status}, {@link Status#NONE if null}. If the Status
      * is equal to {@link Status#TRANSCODE_STARTING} then we'll just return the Status {@link Status#TRANSCODING}
      * since they're functionally equivalent from a client-side perspective.
+     * <p/>
+     * For an all-inclusive getter of the video status, use {@link Video#getRawStatus()}.
      */
     public Status getStatus() {
         if (status == Status.TRANSCODE_STARTING) {
             return Status.TRANSCODING;
         }
-        return status == null ? Status.NONE : status;
+        return getRawStatus();
     }
 
     public void setStatus(Status status) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -66,8 +66,11 @@ public class Video implements Serializable {
         AVAILABLE("available"),
         @SerializedName("uploading")
         UPLOADING("uploading"),
+        @SerializedName("transcode_starting")
+        TRANSCODE_STARTING("transcode_starting"),
         @SerializedName("transcoding")
         TRANSCODING("transcoding"),
+        // Errors
         @SerializedName("uploading_error")
         UPLOADING_ERROR("uploading_error"),
         @SerializedName("transcoding_error")
@@ -102,17 +105,25 @@ public class Video implements Serializable {
     public Date modifiedTime;
     public ArrayList<String> contentRating;
     public String license;
-    public com.vimeo.networking.model.Privacy privacy;
+    public Privacy privacy;
     public PictureCollection pictures;
     public ArrayList<Tag> tags;
     public StatsCollection stats;
     public Metadata metadata;
-    public com.vimeo.networking.model.User user;
+    public User user;
     private Status status;
     public VideoLog log;
     public List<Category> categories;
 
+    /**
+     * This getter is always guaranteed to return a {@link Status}, {@link Status#NONE if null}. If the Status
+     * is equal to {@link Status#TRANSCODE_STARTING} then we'll just return the Status {@link Status#TRANSCODING}
+     * since they're functionally equivalent from a client-side perspective.
+     */
     public Status getStatus() {
+        if (status == Status.TRANSCODE_STARTING) {
+            return Status.TRANSCODING;
+        }
         return status == null ? Status.NONE : status;
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -60,23 +60,32 @@ public class Video implements Serializable {
         PUBLIC_DOMAIN_DEDICATION
     }
 
+    private static final String STATUS_NONE = "N/A";
+    private static final String STATUS_AVAILABLE = "available";
+    private static final String STATUS_UPLOADING = "uploading";
+    private static final String STATUS_TRANSCODE_STARTING = "transcode_starting";
+    private static final String STATUS_TRANSCODING = "transcoding";
+    private static final String STATUS_UPLOADING_ERROR = "uploading_error";
+    private static final String STATUS_TRANSCODING_ERROR = "transcoding_error";
+    private static final String STATUS_QUOTA_EXCEEDED = "quota_exceeded";
+
     public enum Status {
-        NONE("N/A"),
-        @SerializedName("available")
-        AVAILABLE("available"),
-        @SerializedName("uploading")
-        UPLOADING("uploading"),
-        @SerializedName("transcode_starting")
-        TRANSCODE_STARTING("transcode_starting"),
-        @SerializedName("transcoding")
-        TRANSCODING("transcoding"),
+        NONE(STATUS_NONE),
+        @SerializedName(STATUS_AVAILABLE)
+        AVAILABLE(STATUS_AVAILABLE),
+        @SerializedName(STATUS_UPLOADING)
+        UPLOADING(STATUS_UPLOADING),
+        @SerializedName(STATUS_TRANSCODE_STARTING)
+        TRANSCODE_STARTING(STATUS_TRANSCODE_STARTING),
+        @SerializedName(STATUS_TRANSCODING)
+        TRANSCODING(STATUS_TRANSCODING),
         // Errors
-        @SerializedName("uploading_error")
-        UPLOADING_ERROR("uploading_error"),
-        @SerializedName("transcoding_error")
-        TRANSCODING_ERROR("transcoding_error"),
-        @SerializedName("quota_exceeded")
-        QUOTA_EXCEEDED("quota_exceeded");
+        @SerializedName(STATUS_UPLOADING_ERROR)
+        UPLOADING_ERROR(STATUS_UPLOADING_ERROR),
+        @SerializedName(STATUS_TRANSCODING_ERROR)
+        TRANSCODING_ERROR(STATUS_TRANSCODING_ERROR),
+        @SerializedName(STATUS_QUOTA_EXCEEDED)
+        QUOTA_EXCEEDED(STATUS_QUOTA_EXCEEDED);
 
         private String string;
 


### PR DESCRIPTION
#### Ticket
[VA-1322](https://vimean.atlassian.net/browse/VA-1322)


#### Ticket Summary
There is a status that was added to the `clip` object back in November which we weren't accounting for called `transcode_starting`. It would have just been treated as `NONE` which was probably getting treated similarly to AVAILABLE (or whatever the implementation was in our `default` case).
[The original API Git issue](https://github.vimeows.com/Vimeo/vimeo/issues/17447)


#### Implementation Summary
Instead of added a fall through to all of our switch statements (and various `if` statements), we're just adding in a check in the getter method we were already using.
After speaking with @alfiehanssen it seems to make the most sense to just put it right in the getter since `transcode_starting` will always have the same UI implication as `transcoding` (which is mentioned in the JavaDoc so consumers of the library aren't totally in the dark).


#### How to Test
This one is pretty hard to test exactly - Brian Cooper recommended just hardcoding the value to test which isn't totally guaranteed to be accurate. The hardcode did prove to work on all of our conditional statements though.
For QA - best way to test would just be to hammer on the upload feature.

My beautiful hardcode:
![screen shot 2016-02-16 at 11 26 58 am](https://cloud.githubusercontent.com/assets/1782467/13083595/bcd4285a-d4a3-11e5-9831-097147f1cd75.png)
