### PR TITLE
VA-1309 - unlisted privacy

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
@@ -39,6 +39,7 @@ public class Privacy implements Serializable {
     private static final String PRIVACY_CONTACTS = "contacts";
     private static final String PRIVACY_PASSWORD = "password";
     private static final String PRIVACY_DISABLE = "disable";
+    private static final String PRIVACY_UNLISTED = "unlisted";
 
     public enum PrivacyValue {
         @SerializedName(PRIVACY_NOBODY)
@@ -53,6 +54,8 @@ public class Privacy implements Serializable {
         CONTACTS(PRIVACY_CONTACTS),
         @SerializedName(PRIVACY_PASSWORD)
         PASSWORD(PRIVACY_PASSWORD),
+        @SerializedName(PRIVACY_UNLISTED)
+        UNLISTED(PRIVACY_UNLISTED),
         @SerializedName(PRIVACY_DISABLE)
         DISABLE(PRIVACY_DISABLE);
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -255,10 +255,12 @@ public class Video implements Serializable {
     }
 
     /**
-     * The password for the video, only sent when the following conditions are true
-     * 1. The privacy is set to password
-     * 2. The user making the request owns the video
-     * 3. The application making the request is granted access to view this field
+     * The password for the video, only sent when the following conditions are true:
+     * <ul>
+     * <ol>The privacy is set to password</ol>
+     * <ol>The user making the request owns the video</ol>
+     * <ol>The application making the request is granted access to view this field</ol>
+     * </ul>
      *
      * @return the password if applicable
      */

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -123,6 +123,8 @@ public class Video implements Serializable {
     private Status status;
     public VideoLog log;
     public List<Category> categories;
+    @Nullable
+    private String password;
 
     /**
      * This will return the value as it's given to us from the API (or {@link Status#NONE if null}). Unlike
@@ -250,6 +252,19 @@ public class Video implements Serializable {
             recommendationsUri = uri + Vimeo.ENDPOINT_RECOMMENDATIONS;
         }
         return recommendationsUri;
+    }
+
+    /**
+     * The password for the video, only sent when the following conditions are true
+     * 1. The privacy is set to password
+     * 2. The user making the request owns the video
+     * 3. The application making the request is granted access to view this field
+     *
+     * @return the password if applicable
+     */
+    @Nullable
+    public String getPassword() {
+        return password;
     }
 
     @Override


### PR DESCRIPTION
#### Ticket
[VA-1309](https://vimean.atlassian.net/browse/VA-1309)

#### Ticket Summary
https://vimeo.com/blog/post/share-unlisted-videos-with-private-links Vimeo recently introduced Unlisted privacy for Pro/Plus users. We need to reflect that in the app and this library. 

#### Implementation Summary
Added the unlisted privacy option. Also added in the password field for password protected videos.

#### How to Test
Set a video to unlisted privacy and verify it we can see that new privacy in the app.

