### PR TITLE
VA-1418 changes for empty post responses

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1051,10 +1051,12 @@ public class VimeoClient {
      * Example: Forgot password call
      *
      * @param uri      URI of the resource to POST
+     * @param postBody The body of the POST request
      * @param callback The callback for the specific model type of the resource
      */
     @Nullable
-    public Call<Void> emptyResponsePost(String uri, VimeoCallback<Void> callback) {
+    public Call<Void> emptyResponsePost(String uri, @Nullable HashMap<String, String> postBody,
+                                        VimeoCallback<Void> callback) {
         if (callback == null) {
             throw new AssertionError("Callback cannot be null");
         }
@@ -1065,7 +1067,11 @@ public class VimeoClient {
             return null;
         }
 
-        Call<Void> call = this.vimeoService.emptyResponsePost(getAuthHeader(), uri);
+        if (postBody == null) {
+            postBody = new HashMap<>();
+        }
+
+        Call<Void> call = this.vimeoService.emptyResponsePost(getAuthHeader(), uri, postBody);
         callback.setCall(call);
         call.enqueue(callback);
         return call;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -22,9 +22,9 @@
 
 package com.vimeo.networking;
 
-import com.vimeo.networking.model.VimeoAccount;
 import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.PictureResource;
+import com.vimeo.networking.model.VimeoAccount;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -59,30 +59,31 @@ public interface VimeoService {
     @FormUrlEncoded
     @POST("oauth/access_token")
     Call<VimeoAccount> authenticateWithCodeGrant(@Header("Authorization") String authHeader,
-                                            @Field("redirect_uri") String redirectURI,
-                                            @Field("code") String code,
-                                            @Field("grant_type") String grantType);
+                                                 @Field("redirect_uri") String redirectURI,
+                                                 @Field("code") String code,
+                                                 @Field("grant_type") String grantType);
 
     @FormUrlEncoded
     @POST("oauth/authorize/client")
     Call<VimeoAccount> authorizeWithClientCredentialsGrant(@Header("Authorization") String authHeader,
-                                                      @Field("grant_type") String grantType,
-                                                      @Field("scope") String scope);
+                                                           @Field("grant_type") String grantType,
+                                                           @Field("scope") String scope);
 
     @POST("users")
-    Call<VimeoAccount> join(@Header("Authorization") String authHeader, @Body HashMap<String, String> parameters);
+    Call<VimeoAccount> join(@Header("Authorization") String authHeader,
+                            @Body HashMap<String, String> parameters);
 
     @FormUrlEncoded
     @POST("oauth/authorize/password")
     Call<VimeoAccount> logIn(@Header("Authorization") String authHeader, @Field("username") String email,
-                        @Field("password") String password, @Field("grant_type") String grantType,
-                        @Field("scope") String scope);
+                             @Field("password") String password, @Field("grant_type") String grantType,
+                             @Field("scope") String scope);
 
     @FormUrlEncoded
     @POST("oauth/authorize/facebook")
     Call<VimeoAccount> logInWithFacebook(@Header("Authorization") String authHeader,
-                                    @Field("grant_type") String grantType, @Field("token") String token,
-                                    @Field("scope") String scope);
+                                         @Field("grant_type") String grantType, @Field("token") String token,
+                                         @Field("scope") String scope);
 
     @Headers("Cache-Control: no-cache, no-store")
     @DELETE("tokens")
@@ -91,9 +92,10 @@ public interface VimeoService {
     @FormUrlEncoded
     @POST("oauth/authorize/vimeo_oauth1")
     Call<VimeoAccount> exchangeOAuthOneToken(@Header("Authorization") String authHeader,
-                                        @Field("grant_type") String grantType, @Field("token") String token,
-                                        @Field("token_secret") String tokenSecret,
-                                        @Field("scope") String scope);
+                                             @Field("grant_type") String grantType,
+                                             @Field("token") String token,
+                                             @Field("token_secret") String tokenSecret,
+                                             @Field("scope") String scope);
     // </editor-fold>
 
     /**
@@ -123,7 +125,8 @@ public interface VimeoService {
     Call<PictureResource> createPictureResource(@Header("Authorization") String authHeader, @Url String uri);
 
     @POST
-    Call<Void> emptyResponsePost(@Header("Authorization") String authHeader, @Url String uri);
+    Call<Void> emptyResponsePost(@Header("Authorization") String authHeader, @Url String uri,
+                                 @Body HashMap<String, String> parameters);
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/logging/LoggingInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/logging/LoggingInterceptor.java
@@ -128,14 +128,16 @@ public class LoggingInterceptor implements Interceptor {
      */
     private String toPrettyFormat(String jsonString) {
         String prettyString = "";
-        try {
-            JsonParser parser = new JsonParser();
-            JsonObject json = parser.parse(jsonString).getAsJsonObject();
+        if (jsonString != null && !jsonString.isEmpty()) {
+            try {
+                JsonParser parser = new JsonParser();
+                JsonObject json = parser.parse(jsonString).getAsJsonObject();
 
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
-            prettyString = gson.toJson(json);
-        } catch (Exception e) {
-            logger.e("Error making body pretty response/request");
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                prettyString = gson.toJson(json);
+            } catch (Exception e) {
+                logger.e("Error making body pretty response/request");
+            }
         }
         return prettyString;
     }


### PR DESCRIPTION
#### Ticket
[VA-1418](https://vimean.atlassian.net/browse/VA-1418)

#### Ticket Summary
POST responses are throwing errors

#### Implementation Summary
Retrofit can not handle empty responses without the Void type in the Call. Updated our current empty post method to take parameters to be more widely used. Also beefed up the logging - instead of logging an error when there is no body to parse, just don't even attempt to parse.

#### How to Test
Run the app and check the logs.

