### PR TITLE
VA-1304 Access Token Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ compile project(':vimeo-networking-java:vimeo-networking')
 ```
 
 ### Initialization
+
+The `VimeoClient` instance is highly customizable through the use of the `Configuration.Builder` class. There are a few different default `Builder` constructors that cover core functionality.
+In the below sections, we cover examples of ways to customize your `VimeoClient` instance. Full implementations are in the example app.
+
+#### Configuration Builder for Apps with Account Management
 On app launch, configure `VimeoClient` with your client key, secret, and scope strings. And once initialization is complete, authenticate if necessary. This authentication can include [client credentials](#client-credentials-grant) or authentication via [code grant](#oauth-authorization-code-grant). 
 
 If you choose to pass in an `AccountStore`, the authenticated account will automatically be persisted. Once authentication is complete, you can access the persisted `VimeoAccount` object through `VimeoClient#getVimeoAccount()`. For a basic implementation of an `AccountStore`, please refer to [this file in the example app](example/src/main/java/com/vimeo/android/networking/example/vimeonetworking/TestAccountStore.java)
@@ -70,6 +75,20 @@ Configuration.Builder configBuilder =
 Setting the cache directory and deserializer are optional but highly recommended.
 * The deserializer allows for deserialization on a background thread. Without it, object deserialization will occur on the main (UI) thread. This can be bad for performance if the API response bodies are large.
 * The cache directory is to allow caching of requests. Without it, no requests will be cached and all other cache settings will be ignored.
+
+#### Configuration Builder for Apps with Only One Developer Account
+You can skip the need for [client credentials](#client-credentials-grant) or [code grant](#oauth-authorization-code-grant) requests if you provide an access token up front. With this access token you'll be able to make any requests that the access token's scope allows.
+
+You can generate an access token in the Authentication tab once you select your app from the [list here](https://developer.vimeo.com/apps).
+
+Once you have the access token, you can easily initialize your `VimeoClient` instance with the below builder.
+ 
+```java
+String accessToken = getString(R.string.access_token);
+return new Configuration.Builder(Vimeo.VIMEO_BASE_URL_STRING, accessToken);
+```
+
+*Note: You will not be able to log out of the account associated with the access token provided to the `Configuration.Builder`
 
 ### Authentication 
 All calls to the Vimeo API must be [authenticated](https://developer.vimeo.com/api/authentication). This means that before making requests to the API you must authenticate and obtain an access token. Two authentication methods are provided: 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ String accessToken = getString(R.string.access_token);
 return new Configuration.Builder(Vimeo.VIMEO_BASE_URL_STRING, accessToken);
 ```
 
+After providing the access token, if you'd like to have access to the associated `User` object you'll need to make a call to `VimeoClient#fetchCurrentUser`. If you're using an account store, you can update the `VimeoAccount` with the new `User` object.
+
 *Note: You will not be able to log out of the account associated with the access token provided to the `Configuration.Builder`
 
 ### Authentication 

--- a/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
+++ b/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
@@ -22,7 +22,8 @@ public class TestApp extends Application {
     private static final String SCOPE = "private public create edit delete interact";
 
     private static final boolean IS_DEBUG_BUILD = false;
-    private static final boolean ACCESS_TOKEN_PROVIDED = true;
+    // Switch to true to see how access token auth works.
+    private static final boolean ACCESS_TOKEN_PROVIDED = false;
 
     private static Context mContext;
 

--- a/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
+++ b/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
@@ -21,6 +21,9 @@ public class TestApp extends Application {
 
     private static final String SCOPE = "private public create edit delete interact";
 
+    private static final boolean IS_DEBUG_BUILD = false;
+    private static final boolean ACCESS_TOKEN_PROVIDED = true;
+
     private static Context mContext;
 
     @Override
@@ -28,10 +31,32 @@ public class TestApp extends Application {
         super.onCreate();
 
         mContext = this;
-
         AccountPreferenceManager.initializeInstance(mContext);
 
         // <editor-fold desc="Vimeo API Library Initialization">
+        Configuration.Builder configBuilder;
+        // This check is just as for the example. In practice, you'd use one technique or the other.
+        if (ACCESS_TOKEN_PROVIDED) {
+            configBuilder = getAccessTokenBuilder();
+        } else {
+            configBuilder = getIdAndSecretBuilder();
+        }
+        if (IS_DEBUG_BUILD) {
+            // Disable cert pinning if debugging (so we can intercept packets)
+            configBuilder.enableCertPinning(false);
+            configBuilder.setLogLevel(LogLevel.VERBOSE);
+        }
+        VimeoClient.initialize(configBuilder.build());
+        // </editor-fold>
+    }
+
+    public Configuration.Builder getAccessTokenBuilder() {
+        // The values file is left out of git, so you'll have to provide your own access token
+        String accessToken = getString(R.string.access_token);
+        return new Configuration.Builder(Vimeo.VIMEO_BASE_URL_STRING, accessToken);
+    }
+
+    public Configuration.Builder getIdAndSecretBuilder() {
         // The values file is left out of git, so you'll have to provide your own id and secret
         String clientId = getString(R.string.client_id);
         String clientSecret = getString(R.string.client_secret);
@@ -46,13 +71,7 @@ public class TestApp extends Application {
                 // Used for oauth flow
                 .setCodeGrantRedirectUri(codeGrantRedirectUri);
 
-        if (/*isDebugBuild*/false) {
-            // Disable cert pinning if debugging (so we can intercept packets)
-            configBuilder.enableCertPinning(false);
-            configBuilder.setLogLevel(LogLevel.VERBOSE);
-        }
-        VimeoClient.initialize(configBuilder.build());
-        // </editor-fold>
+        return configBuilder;
     }
 
     public static Context getAppContext() {

--- a/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
+++ b/example/src/main/java/com/vimeo/android/networking/example/TestApp.java
@@ -10,7 +10,6 @@ import com.vimeo.android.networking.example.vimeonetworking.AndroidGsonDeseriali
 import com.vimeo.android.networking.example.vimeonetworking.NetworkingLogger;
 import com.vimeo.android.networking.example.vimeonetworking.TestAccountStore;
 import com.vimeo.networking.Configuration;
-import com.vimeo.networking.Vimeo;
 import com.vimeo.networking.Vimeo.LogLevel;
 import com.vimeo.networking.VimeoClient;
 
@@ -40,7 +39,7 @@ public class TestApp extends Application {
         if (ACCESS_TOKEN_PROVIDED) {
             configBuilder = getAccessTokenBuilder();
         } else {
-            configBuilder = getIdAndSecretBuilder();
+            configBuilder = getClientIdAndClientSecretBuilder();
         }
         if (IS_DEBUG_BUILD) {
             // Disable cert pinning if debugging (so we can intercept packets)
@@ -54,10 +53,10 @@ public class TestApp extends Application {
     public Configuration.Builder getAccessTokenBuilder() {
         // The values file is left out of git, so you'll have to provide your own access token
         String accessToken = getString(R.string.access_token);
-        return new Configuration.Builder(Vimeo.VIMEO_BASE_URL_STRING, accessToken);
+        return new Configuration.Builder(accessToken);
     }
 
-    public Configuration.Builder getIdAndSecretBuilder() {
+    public Configuration.Builder getClientIdAndClientSecretBuilder() {
         // The values file is left out of git, so you'll have to provide your own id and secret
         String clientId = getString(R.string.client_id);
         String clientSecret = getString(R.string.client_secret);
@@ -65,8 +64,8 @@ public class TestApp extends Application {
                                       getString(R.string.deeplink_redirect_host);
         TestAccountStore testAccountStore = new TestAccountStore(this.getApplicationContext());
         Configuration.Builder configBuilder =
-                new Configuration.Builder(Vimeo.VIMEO_BASE_URL_STRING, clientId, clientSecret, SCOPE,
-                                          testAccountStore, new AndroidGsonDeserializer());
+                new Configuration.Builder(clientId, clientSecret, SCOPE, testAccountStore,
+                                          new AndroidGsonDeserializer());
         configBuilder.setCacheDirectory(this.getCacheDir())
                 .setUserAgentString(getUserAgentString(this)).setDebugLogger(new NetworkingLogger())
                 // Used for oauth flow

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -161,7 +161,7 @@ public class Configuration {
      */
     public static class Builder {
 
-        private String baseURLString;
+        private String baseURLString = Vimeo.VIMEO_BASE_URL_STRING;
         private String clientID;
         private String clientSecret;
         private String scope;
@@ -189,19 +189,28 @@ public class Configuration {
          * The most basic builder constructor. If you've only provided an access token, you'll only be able to
          * make requests for the given access token's account.
          * <p/>
-         * If you'd like the ability to switch accounts, you'll have to set a client id and client secret.
-         * If you'd like the ability to persist accounts, you'll have to set an account store
+         * If you'd like the ability to switch accounts or request a client credentials grant, you'll have to set a client id and client secret.
+         * If you'd like the ability to persist accounts, you'll have to set an account store.
+         * If you'd like the ability to issue code grant, you'll have to set a code grant redirect uri.
          *
-         * @param baseURLString The base url pointing to the Vimeo api. Something like: {@link Vimeo#VIMEO_BASE_URL_STRING}
-         * @param accessToken   Token provided by the Vimeo developer console
+         * @param accessToken Token provided by the Vimeo developer console
          */
-        public Builder(String baseURLString, String accessToken) {
-            this.baseURLString = baseURLString;
+        public Builder(String accessToken) {
             this.accessToken = accessToken;
         }
 
+        public Builder(String clientID, String clientSecret, String scope) {
+            this(null, clientID, clientSecret, scope, null, null);
+        }
+
+        @Deprecated
         public Builder(String baseURLString, String clientID, String clientSecret, String scope) {
             this(baseURLString, clientID, clientSecret, scope, null, null);
+        }
+
+        public Builder(String clientId, String clientSecret, String scope,
+                       @Nullable AccountStore accountStore, @Nullable GsonDeserializer deserializer) {
+            this(null, clientId, clientSecret, scope, accountStore, deserializer);
         }
 
         /**
@@ -218,14 +227,20 @@ public class Configuration {
          * @param accountStore  (Optional, Recommended) An implementation that can be used to interface with Androids <a href="http://developer.android.com/reference/android/accounts/AccountManager.html">Account Manager</a>
          * @param deserializer  (Optional, Recommended) Extend GsonDeserializer to allow for deserialization on a background thread
          */
-        public Builder(String baseURLString, String clientId, String clientSecret, String scope,
+        @Deprecated
+        public Builder(@Nullable String baseURLString, String clientId, String clientSecret, String scope,
                        @Nullable AccountStore accountStore, @Nullable GsonDeserializer deserializer) {
-            this.baseURLString = baseURLString;
+            this.baseURLString = baseURLString == null ? this.baseURLString : baseURLString;
             this.clientID = clientId;
             this.clientSecret = clientSecret;
             this.scope = scope;
             this.accountStore = accountStore;
             this.deserializer = deserializer;
+        }
+
+        public Builder setBaseUrl(String baseUrl) {
+            this.baseURLString = baseUrl;
+            return this;
         }
 
         /** If you used the basic Builder access token constructor but have the intent of */
@@ -242,6 +257,11 @@ public class Configuration {
 
         public Builder setGsonDeserializer(GsonDeserializer deserializer) {
             this.deserializer = deserializer;
+            return this;
+        }
+
+        public Builder setAccessToken(String accessToken) {
+            this.accessToken = accessToken;
             return this;
         }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -55,6 +55,8 @@ public class Configuration {
     public String clientSecret;
     public String scope;
 
+    public String accessToken;
+
     @Nullable
     private AccountStore accountStore;
     public GsonDeserializer deserializer;
@@ -100,6 +102,7 @@ public class Configuration {
         }
     }
 
+    @Nullable
     public VimeoAccount loadAccount() {
         if (accountStore == null) {
             return null;
@@ -119,6 +122,9 @@ public class Configuration {
         this.clientID = builder.clientID;
         this.clientSecret = builder.clientSecret;
         this.scope = builder.scope;
+
+        this.accessToken = builder.accessToken;
+
         this.accountStore = builder.accountStore;
         this.deserializer = builder.deserializer;
 
@@ -142,10 +148,12 @@ public class Configuration {
     }
 
     private boolean isValid() {
-        return (this.baseURLString != null && !this.baseURLString.trim().isEmpty() &&
-                this.clientID != null && !this.clientID.trim().isEmpty() &&
-                this.clientSecret != null && !this.clientSecret.trim().isEmpty() &&
-                this.scope != null && !this.scope.trim().isEmpty());
+        return this.baseURLString != null && (!this.baseURLString.trim().isEmpty() &&
+                                              this.clientID != null && !this.clientID.trim().isEmpty() &&
+                                              this.clientSecret != null &&
+                                              !this.clientSecret.trim().isEmpty() &&
+                                              this.scope != null && !this.scope.trim().isEmpty()) ||
+               (this.accessToken != null && !this.accessToken.trim().isEmpty());
     }
 
     /**
@@ -157,6 +165,9 @@ public class Configuration {
         private String clientID;
         private String clientSecret;
         private String scope;
+
+        private String accessToken;
+
         private AccountStore accountStore;
         private GsonDeserializer deserializer = new GsonDeserializer();
 
@@ -173,6 +184,21 @@ public class Configuration {
         // Default to the stock logger which just prints - this makes it optional
         public DebugLoggerInterface debugLogger = new DebugLogger();
         public LogLevel logLevel = LogLevel.DEBUG;
+
+        /**
+         * The most basic builder constructor. If you've only provided an access token, you'll only be able to
+         * make requests for the given access token's account.
+         * <p/>
+         * If you'd like the ability to switch accounts, you'll have to set a client id and client secret.
+         * If you'd like the ability to persist accounts, you'll have to set an account store
+         *
+         * @param baseURLString The base url pointing to the Vimeo api. Something like: {@link Vimeo#VIMEO_BASE_URL_STRING}
+         * @param accessToken   Token provided by the Vimeo developer console
+         */
+        public Builder(String baseURLString, String accessToken) {
+            this.baseURLString = baseURLString;
+            this.accessToken = accessToken;
+        }
 
         public Builder(String baseURLString, String clientID, String clientSecret, String scope) {
             this(baseURLString, clientID, clientSecret, scope, null, null);
@@ -200,6 +226,13 @@ public class Configuration {
             this.scope = scope;
             this.accountStore = accountStore;
             this.deserializer = deserializer;
+        }
+
+        /** If you used the basic Builder access token constructor but have the intent of */
+        public Builder setClientIdAndSecret(String clientId, String clientSecret) {
+            this.clientID = clientId;
+            this.clientSecret = clientSecret;
+            return this;
         }
 
         public Builder setAccountStore(AccountStore accountStore) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -499,7 +499,8 @@ public class VimeoClient {
     public Call<Object> logOut(@Nullable final VimeoCallback<Object> callback) {
         // If you've provided an access token to the configuration builder, we're assuming that you wouldn't
         // want to be able to log out of it, because this would invalidate the constant you've provided us.
-        if (configuration.accessToken.equals(vimeoAccount.getAccessToken())) {
+        if (configuration.accessToken != null &&
+            configuration.accessToken.equals(vimeoAccount.getAccessToken())) {
             if (callback != null) {
                 callback.failure(new VimeoError(
                         "You can't log out of the account provided through the configuration builder"));

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -66,6 +66,7 @@ import retrofit2.Retrofit;
  */
 public class VimeoClient {
 
+    @NotNull
     private Configuration configuration;
     private VimeoService vimeoService;
     @Nullable
@@ -195,10 +196,17 @@ public class VimeoClient {
 
     public void setVimeoAccount(@Nullable VimeoAccount vimeoAccount) {
         if (vimeoAccount == null) {
-            vimeoAccount = new VimeoAccount();
+            vimeoAccount = new VimeoAccount(this.configuration.accessToken);
+            this.configuration.saveAccount(vimeoAccount, null, null);
         }
 
         this.vimeoAccount = vimeoAccount;
+    }
+
+    /** Sets the {@link #vimeoAccount} field as well as triggering the saveAccount event for the account store */
+    public void saveAccount(@Nullable VimeoAccount vimeoAccount, String email, String password) {
+        setVimeoAccount(vimeoAccount);
+        this.configuration.saveAccount(vimeoAccount, email, password);
     }
 
     public Configuration getConfiguration() {
@@ -451,9 +459,7 @@ public class VimeoClient {
             e.printStackTrace();
         }
 
-        this.setVimeoAccount(vimeoAccount);
-
-        this.configuration.saveAccount(vimeoAccount, email, password);
+        saveAccount(vimeoAccount, email, password);
 
         return vimeoAccount;
     }
@@ -491,7 +497,15 @@ public class VimeoClient {
      * @param callback Callback for handling logout
      */
     public Call<Object> logOut(@Nullable final VimeoCallback<Object> callback) {
-
+        // If you've provided an access token to the configuration builder, we're assuming that you wouldn't
+        // want to be able to log out of it, because this would invalidate the constant you've provided us.
+        if (configuration.accessToken.equals(vimeoAccount.getAccessToken())) {
+            if (callback != null) {
+                callback.failure(new VimeoError(
+                        "You can't log out of the account provided through the configuration builder"));
+            }
+            return null;
+        }
         Call<Object> call = this.vimeoService.logOut(getAuthHeader());
         if (callback != null) {
             callback.setCall(call);
@@ -562,15 +576,14 @@ public class VimeoClient {
 
         @Override
         public void success(VimeoAccount vimeoAccount) {
-            this.client.setVimeoAccount(vimeoAccount);
             if (vimeoAccount.getUser() != null && (this.email == null || this.email.isEmpty())) {
                 // We must always have a `name` field, which is used by the Android Account Manager for
                 // display in the device Settings -> Accounts [KZ] 12/17/15
                 String name = (vimeoAccount.getUser().name !=
                                null) ? vimeoAccount.getUser().name : vimeoAccount.getUser().uri;
-                this.client.configuration.saveAccount(vimeoAccount, name, null);
+                this.client.saveAccount(vimeoAccount, name, null);
             } else {
-                this.client.configuration.saveAccount(vimeoAccount, this.email, this.password);
+                this.client.saveAccount(vimeoAccount, this.email, this.password);
             }
             this.callback.success();
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -297,9 +297,10 @@ public class VimeoClient {
     }
 
     /**
-     * Authorizes users of the app who are not signed in.
+     * Authorizes users of the app who are not signed in. This call requires a client id and client secret to be
+     * set on the initial Configuration.
      * <p/>
-     * Leaves User as null in {@link VimeoAccount} model and populates the rest
+     * Leaves User as null in {@link VimeoAccount} model and populates the rest.
      *
      * @param callback Callback pertaining to authentication
      */
@@ -503,7 +504,8 @@ public class VimeoClient {
             configuration.accessToken.equals(vimeoAccount.getAccessToken())) {
             if (callback != null) {
                 callback.failure(new VimeoError(
-                        "You can't log out of the account provided through the configuration builder"));
+                        "You can't log out of the account provided through the configuration builder. " +
+                        "This is to ensure the access token generated in the developer console isn't accidentally invalidated. "));
             }
             return null;
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -26,6 +26,8 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -45,24 +47,8 @@ public class VimeoAccount implements Serializable {
     private User user;
     private String userJSON;
 
-    public VimeoAccount() {
-
-    }
-
-    public VimeoAccount(String accessToken, String tokenType, String scope, String userJSON) {
-        if (accessToken == null || accessToken.isEmpty() || tokenType == null ||
-            tokenType.isEmpty() || scope == null || scope.isEmpty()) {
-            throw new AssertionError("Account can only be created with token, tokenType, scope");
-        }
-
+    public VimeoAccount(@Nullable String accessToken) {
         this.accessToken = accessToken;
-        this.tokenType = tokenType;
-        this.scope = scope;
-
-        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
-
-        this.user = gson.fromJson(userJSON, User.class);
     }
 
     public boolean isAuthenticated() {
@@ -81,6 +67,7 @@ public class VimeoAccount implements Serializable {
         return this.scope;
     }
 
+    @Nullable
     public User getUser() {
         return this.user;
     }
@@ -89,6 +76,7 @@ public class VimeoAccount implements Serializable {
         this.user = user;
     }
 
+    @Nullable
     public String getUserJSON() // For AccountManager.userData [AH]
     {
         if (this.user == null) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -51,6 +51,22 @@ public class VimeoAccount implements Serializable {
         this.accessToken = accessToken;
     }
 
+    public VimeoAccount(String accessToken, String tokenType, String scope, String userJSON) {
+        if (accessToken == null || accessToken.isEmpty() || tokenType == null ||
+            tokenType.isEmpty() || scope == null || scope.isEmpty()) {
+            throw new AssertionError("Account can only be created with token, tokenType, scope");
+        }
+
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+        this.scope = scope;
+
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+
+        this.user = gson.fromJson(userJSON, User.class);
+    }
+
     public boolean isAuthenticated() {
         return (this.accessToken != null && !this.accessToken.isEmpty());
     }


### PR DESCRIPTION
#### Ticket
[VA-1304](https://vimean.atlassian.net/browse/VA-1304)

#### Ticket Summary
We wanted a simple way for consumers of the library to provide an auth token (provided from the developer console) which would remove the need to make client credentials requests.

#### Implementation Summary
* Added an access token to the configuration builder.
* Moved around account setting so the vimeoAccount on the vimeo client has a tighter coupling to the configurationbuilder.accountStore callbacks.
* Added section to the README

#### How to Test
* Test the VimeoApp to ensure nothing broke (log in, log out, change users, get client credentials)
* Use the example app and go through some weird auth flows