### PR TITLE
VA-1453 Skip Welcome Crash

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -196,8 +196,12 @@ public class VimeoClient {
 
     public void setVimeoAccount(@Nullable VimeoAccount vimeoAccount) {
         if (vimeoAccount == null) {
+            // If the provided account was null but we have an access token, persist the vimeo account with
+            // just a token in it. Otherwise we'll want to leave the persisted account as null.
             vimeoAccount = new VimeoAccount(this.configuration.accessToken);
-            this.configuration.saveAccount(vimeoAccount, null, null);
+            if (this.configuration.accessToken != null) {
+                this.configuration.saveAccount(vimeoAccount, null, null);
+            }
         }
 
         this.vimeoAccount = vimeoAccount;


### PR DESCRIPTION
#### Ticket
[VA-1453](https://vimean.atlassian.net/browse/VA-1453)

#### Ticket Summary
Clicking skip on first welcome screen caused crash

#### Implementation Summary
We used to persist to accountstore very selectively. I switched it so everything routes through the method that persists to the account store, but it looks like the one circumstance we don't want to persist is when it's a totally empty Account (happens the first time if there is no access token or on any subsequent logout).
Now we only save if the vimeo account isn't totally empty.

I'll also have to change the SHA on client app

#### How to Test
* Test a lot of auth flows - log in, log out, close app, log in, close app, open app, logout.
* Test skipping the welcome screen
* Test logging in on the welcome screen
* Ensure that you can still make requests for explore
* Ensure that the correct account shows on the ME page
