### PR TITLE
VA-1372: Adding global password to VideosPreference object

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
@@ -22,6 +22,8 @@
 
 package com.vimeo.networking.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
@@ -33,7 +35,17 @@ public class VideosPreference implements Serializable {
 
     private static final long serialVersionUID = 1956447486226253433L;
     @Nullable
+    @SerializedName("privacy")
     protected String privacy;
+
+    @Nullable
+    @SerializedName("password")
+    protected String password;
+
+    @Nullable
+    public String getPassword() {
+        return password;
+    }
 
     @Nullable
     public String getPrivacy() {


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VA-1372](https://vimean.atlassian.net/browse/VA-1372)

#### Ticket Summary
Default password not displaying during upload.

#### Implementation Summary
Adding global password to VideosPreference object.

#### How to Test
Nothing specific to test with this networking ticket alone. Just make sure that video password privacy still works as it used to.

