### PR TITLE
VA-1622 Adding release_time to video

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -127,6 +127,7 @@ public class Video implements Serializable {
     public String language;
     public Date createdTime;
     public Date modifiedTime;
+    public Date releaseTime;
     public ArrayList<String> contentRating;
     public String license;
     public Privacy privacy;


### PR DESCRIPTION
#### Ticket
[VA-1622](https://vimean.atlassian.net/browse/VA-1622)

#### Ticket Summary
API is adding release_time to the video object for video returned from series connection endpoints. We need to expose this from the networking model so that series videos can display the expected release date.

#### Implementation Summary
Added the releaseTime field to the video object.

#### How to Test
Nothing to test here.

