### PR TITLE
Adding more robust logic around purchase expiration

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
@@ -75,6 +75,6 @@ public class Interaction implements Serializable {
     @SerializedName("stream")
     public Stream stream;
     @Nullable
-    @SerializedName("expiration")
+    @SerializedName("expires_time")
     public Date expiration;
 }


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VA-1622](https://vimean.atlassian.net/browse/VA-1622)

#### Ticket Summary
It is possible for VOD objects to have multiple purchase states set simultaneously. We need to account for this and arbitrate properly. A VOD video's purchase type is chosen based on the following priority:
     1) trailer
     2) purchased
     3) both rental and subscription? choose the later expiration, expirations equal? choose subscription
     4) subscription
     5) rental
The ticket itself doesn't address this, but it is a bucket that I am attaching remaining VOD work to. 

#### Implementation Summary
Modified the video.java model object's convenience methods to arbitrate the purchase type and date according to more complex rules. Also, removed some lint errors.

#### How to Test
Nothing to test independently here. The changes will have to be tested in conjunction with changes to the app that will be layered in later.

