### PR TITLE
VA-1777 new search models, search class

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
@@ -1,0 +1,286 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking;
+
+import com.vimeo.networking.callbacks.ModelCallback;
+import com.vimeo.networking.model.search.SearchResponse;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import retrofit2.Call;
+
+/**
+ * Class to handle searching. To use this class, your app must be whitelisted. If you are not an approved app,
+ * you can still use the existing search mechanism {@link VimeoClient#search(String, String, ModelCallback, Map, String)}.
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public final class Search {
+
+    private Search() {
+    }
+
+    public enum FilterType {
+        VIDEO("clip"),
+        VOD("ondemand"),
+        USER("people"),
+        CHANNEL("channel"),
+        GROUP("group");
+
+        private final String mText;
+
+        FilterType(String text) {
+            this.mText = text;
+        }
+
+        public String getText() {
+            return this.mText;
+        }
+
+        public static FilterType fromString(String text) {
+            if (text != null) {
+                for (FilterType b : FilterType.values()) {
+                    if (text.equalsIgnoreCase(b.mText)) {
+                        return b;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No constant with text " + text + " found");
+        }
+    }
+
+    public enum FilterUpload {
+        TODAY("today"),
+        THIS_WEEK("this-week"),
+        THIS_MONTH("this-month"),
+        THIS_YEAR("this-year");
+
+        private final String mText;
+
+        FilterUpload(String text) {
+            this.mText = text;
+        }
+
+        public String getText() {
+            return this.mText;
+        }
+
+        public static FilterUpload fromString(String text) {
+            if (text != null) {
+                for (FilterUpload b : FilterUpload.values()) {
+                    if (text.equalsIgnoreCase(b.mText)) {
+                        return b;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No constant with text " + text + " found");
+        }
+    }
+
+    public enum Sort {
+        RELEVANCE("relevance"),
+        LATEST("latest"),
+        POPULARITY("popularity"),
+        DURATION("duration"),
+        JOIN_DATE("join_date"),
+        ALPHABETICAL("alphabetical");
+
+        private final String mText;
+
+        Sort(String text) {
+            this.mText = text;
+        }
+
+        public String getText() {
+            return this.mText;
+        }
+
+        public static Sort fromString(String text) {
+            if (text != null) {
+                for (Sort b : Sort.values()) {
+                    if (text.equalsIgnoreCase(b.mText)) {
+                        return b;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No constant with text " + text + " found");
+        }
+    }
+
+    public enum FilterDuration {
+        SHORT("short"),
+        MEDIUM("medium"),
+        LONG("long");
+
+        private final String mText;
+
+        FilterDuration(String text) {
+            this.mText = text;
+        }
+
+        public String getText() {
+            return this.mText;
+        }
+
+        public static FilterDuration fromString(String text) {
+            if (text != null) {
+                for (FilterDuration b : FilterDuration.values()) {
+                    if (text.equalsIgnoreCase(b.mText)) {
+                        return b;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No constant with text " + text + " found");
+        }
+    }
+
+    public enum FilterCategory {
+        ANIMATION("animation"),
+        ART("art"),
+        CAMERA_TECHNIQUES("cameratechniques"),
+        COMEDY("comedy"),
+        DOCUMENTARY("documentary"),
+        EXPERIMENTAL("experimental"),
+        FASHION("fashion"),
+        FOOD("food"),
+        INSTRUCTIONALS("instructionals"),
+        JOURNALISM("journalism"),
+        MUSIC("music"),
+        NARRATIVE("narrative"),
+        PERSONAL("personal"),
+        SPORTS("sports"),
+        TALKS("talks"),
+        TRAVEL("travel");
+
+        private final String mText;
+
+        FilterCategory(String text) {
+            this.mText = text;
+        }
+
+        public String getText() {
+            return this.mText;
+        }
+
+        public static FilterCategory fromString(String text) {
+            if (text != null) {
+                for (FilterCategory b : FilterCategory.values()) {
+                    if (text.equalsIgnoreCase(b.mText)) {
+                        return b;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No constant with text " + text + " found");
+        }
+    }
+
+    static final String FILTER_CATEGORY = "filter_category";
+    static final String FILTER_UPLOADED = "filter_uploaded";
+    static final String FILTER_DURATION = "filter_duration";
+    static final String FILTER_TYPE = "filter_type";
+    static final String FILTER_FEATURED_COUNT = "featured_clip_count";
+
+    public static Call<SearchResponse> search(@NotNull String query, @NotNull FilterType type,
+                                              @NotNull ModelCallback<SearchResponse> callback,
+                                              @Nullable Map<String, String> refinementMap,
+                                              @Nullable String fieldFilter) {
+        if (refinementMap == null) {
+            refinementMap = new HashMap<>();
+        }
+        refinementMap.put(FILTER_TYPE, type.getText());
+        Map<String, String> queryMap =
+                VimeoClient.getInstance().createQueryMap(query, refinementMap, fieldFilter);
+        // VimeoClient is the end-all interactor with the retrofit service
+        return VimeoClient.getInstance().search(queryMap, callback);
+    }
+
+    public static class QueryParameterProvider {
+
+        private final Map<String, String> mQueryParameters;
+
+        public QueryParameterProvider() {
+            mQueryParameters = new HashMap<>();
+        }
+
+        public QueryParameterProvider setSort(@Nullable Sort sort) {
+            if (sort != null) {
+                mQueryParameters.put(Vimeo.PARAMETER_GET_SORT, sort.getText());
+            } else {
+                mQueryParameters.remove(Vimeo.PARAMETER_GET_SORT);
+            }
+            return this;
+        }
+
+        public QueryParameterProvider setDirection(@Nullable String direction) {
+            if (Vimeo.SORT_DIRECTION_ASCENDING.equals(direction) ||
+                Vimeo.SORT_DIRECTION_DESCENDING.equals(direction)) {
+                mQueryParameters.put(Vimeo.PARAMETER_GET_DIRECTION, direction);
+            } else {
+                mQueryParameters.remove(Vimeo.PARAMETER_GET_DIRECTION);
+            }
+            return this;
+        }
+
+        public QueryParameterProvider setUploadDate(@Nullable FilterUpload filterUpload) {
+            if (filterUpload != null) {
+                mQueryParameters.put(FILTER_UPLOADED, filterUpload.getText());
+            } else {
+                mQueryParameters.remove(FILTER_UPLOADED);
+            }
+            return this;
+        }
+
+        public QueryParameterProvider setDuration(@Nullable FilterDuration filterDuration) {
+            if (filterDuration != null) {
+                mQueryParameters.put(FILTER_DURATION, filterDuration.getText());
+            } else {
+                mQueryParameters.remove(FILTER_DURATION);
+            }
+            return this;
+        }
+
+        public QueryParameterProvider setCategory(@Nullable FilterCategory filterCategory) {
+            if (filterCategory != null) {
+                mQueryParameters.put(FILTER_CATEGORY, filterCategory.getText());
+            } else {
+                mQueryParameters.remove(FILTER_CATEGORY);
+            }
+            return this;
+        }
+
+        public QueryParameterProvider setFeaturedVideoCount(int count) {
+            mQueryParameters.put(FILTER_FEATURED_COUNT, String.valueOf(count));
+            return this;
+        }
+
+        public Map<String, String> getQueryParameters() {
+            return mQueryParameters;
+        }
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
@@ -222,11 +222,8 @@ public final class Search {
 
     public static class QueryParameterProvider {
 
-        private final Map<String, String> mQueryParameters;
-
-        public QueryParameterProvider() {
-            mQueryParameters = new HashMap<>();
-        }
+        @NotNull
+        private final Map<String, String> mQueryParameters = new HashMap<>();
 
         public QueryParameterProvider setSort(@Nullable Sort sort) {
             if (sort != null) {
@@ -279,6 +276,7 @@ public final class Search {
             return this;
         }
 
+        @NotNull
         public Map<String, String> getQueryParameters() {
             return mQueryParameters;
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -23,6 +23,7 @@
 package com.vimeo.networking;
 
 import com.google.gson.Gson;
+import com.vimeo.networking.Search.FilterType;
 import com.vimeo.networking.callbacks.AuthCallback;
 import com.vimeo.networking.callbacks.ModelCallback;
 import com.vimeo.networking.callbacks.VimeoCallback;
@@ -37,6 +38,7 @@ import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.VimeoAccount;
 import com.vimeo.networking.model.error.ErrorCode;
 import com.vimeo.networking.model.error.VimeoError;
+import com.vimeo.networking.model.search.SearchResponse;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
 
 import org.jetbrains.annotations.NotNull;
@@ -1115,6 +1117,23 @@ public final class VimeoClient {
         return fetchContent(uri, CacheControl.FORCE_NETWORK, callback, query, searchRefinement, fieldFilter);
     }
 
+    /**
+     * A package private search method: use {@link Search#search(String, FilterType, ModelCallback, Map, String)}
+     * which relies on this method.
+     *
+     * @param queryMap the query parameters
+     * @param callback the callback to be invoked when the call finishes
+     * @return the Call object provided by the Retrofit service
+     */
+    @Nullable
+    Call<SearchResponse> search(@NotNull Map<String, String> queryMap,
+                                @NotNull ModelCallback<SearchResponse> callback) {
+
+        Call<SearchResponse> call = mVimeoService.search(getAuthHeader(), queryMap);
+        call.enqueue(callback);
+        return call;
+    }
+
     public void fetchCurrentUser(ModelCallback<User> callback) {
         // Endpoints
         fetchContent(Vimeo.ENDPOINT_ME, CacheControl.FORCE_NETWORK, callback);
@@ -1398,9 +1417,8 @@ public final class VimeoClient {
     }
 
     @NotNull
-    private Map<String, String> createQueryMap(@Nullable String query,
-                                               @Nullable Map<String, String> refinementMap,
-                                               @Nullable String fieldFilter) {
+    Map<String, String> createQueryMap(@Nullable String query, @Nullable Map<String, String> refinementMap,
+                                       @Nullable String fieldFilter) {
         Map<String, String> queryMap = new HashMap<>();
         if (refinementMap != null && !refinementMap.isEmpty()) {
             queryMap = refinementMap;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -27,6 +27,7 @@ import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
 import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.VimeoAccount;
+import com.vimeo.networking.model.search.SearchResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -107,7 +108,7 @@ public interface VimeoService {
 
     @FormUrlEncoded
     @Headers("Cache-Control: no-cache, no-store")
-    @POST("/oauth/device/authorize")
+    @POST("oauth/device/authorize")
     Call<VimeoAccount> logInWithPinCode(@Header("Authorization") String authHeader,
                                         @Field("grant_type") String grantType,
                                         @Field("user_code") String pinCode,
@@ -178,5 +179,15 @@ public interface VimeoService {
     Call<Object> POST(@Header("Authorization") String authHeader, @Url String uri,
                       @Header("Cache-Control") String cacheHeaderValue,
                       @Body HashMap<String, String> parameters);
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Search - new search, for whitelisted apps only
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Search">
+    @Headers("Cache-Control: no-cache, no-store")
+    @GET("search")
+    Call<SearchResponse> search(@Header("Authorization") String authHeader,
+                                @QueryMap Map<String, String> queryParams);
     // </editor-fold>
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptions.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptions.java
@@ -38,8 +38,10 @@ import java.io.Serializable;
 public class FacetOptions implements Serializable {
 
     private static final long serialVersionUID = 6525562797608669182L;
+
     @GsonAdapterKey("total")
     public int mTotal;
+
     @Nullable
     @GsonAdapterKey("uri")
     public String uri;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptions.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptions.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Model representing a facets options
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class FacetOptions implements Serializable {
+
+    private static final long serialVersionUID = 6525562797608669182L;
+    @GsonAdapterKey("total")
+    public int mTotal;
+    @Nullable
+    @GsonAdapterKey("uri")
+    public String uri;
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptionsCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOptionsCollection.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import java.io.Serializable;
+
+/**
+ * A set of all FacetOption objects
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class FacetOptionsCollection implements Serializable {
+
+    private static final long serialVersionUID = -4855836791704928736L;
+    // -----------------------------------------------------------------------------------------------------
+    // Type Options
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Type Options">
+    @GsonAdapterKey("clip")
+    public FacetOptions mVideoOptions;
+    @GsonAdapterKey("ondemand")
+    public FacetOptions mVodOptions;
+    @GsonAdapterKey("people")
+    public FacetOptions mUserOptions;
+    @GsonAdapterKey("channel")
+    public FacetOptions mChannelOptions;
+    @GsonAdapterKey("group")
+    public FacetOptions mGroupOptions;
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Duration options
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Duration options">
+    @GsonAdapterKey("short")
+    public FacetOptions mDurationShortOptions;
+    @GsonAdapterKey("medium")
+    public FacetOptions mDurationMediumOptions;
+    @GsonAdapterKey("long")
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Upload options
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Upload options">
+    public FacetOptions mDurationLogOptions;
+    @GsonAdapterKey("this-year")
+    public FacetOptions mUploadedYearOptions;
+    @GsonAdapterKey("this-month")
+    public FacetOptions mUploadedMonthOptions;
+    @GsonAdapterKey("this-week")
+    public FacetOptions mUploadedWeekOptions;
+    @GsonAdapterKey("today")
+    public FacetOptions mUploadedTodayOptions;
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // License options
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="License options">
+    @GsonAdapterKey("by")
+    public FacetOptions mLicenseAttributionOptions;
+    @GsonAdapterKey("by-nc")
+    public FacetOptions mLicenseNonCommercialOptions;
+    @GsonAdapterKey("by-nc-nd")
+    public FacetOptions mLicenseNonCommericalNoDerivativesOptions;
+    @GsonAdapterKey("by-nc-sa")
+    public FacetOptions mLicenseNonCommercialShareAlikeOptions;
+    @GsonAdapterKey("by-nd")
+    public FacetOptions mLicenseNoDerivativesOptions;
+    @GsonAdapterKey("by-sa")
+    public FacetOptions mLicenseShareAlikeOptions;
+    @GsonAdapterKey("cc0")
+    public FacetOptions mLicensePublicDomainOptions;
+    // </editor-fold>
+
+    // TODO: category facet options 6/27/16 [KZ]
+    // TODO: people/vod/channel/group facet options 6/27/16 [KZ]
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
@@ -36,8 +36,10 @@ import java.io.Serializable;
 public class SearchFacet implements Serializable {
 
     private static final long serialVersionUID = -6507918911819851151L;
+
     @GsonAdapterKey("name")
     public String mName;
+
     @GsonAdapterKey("options")
     public FacetOptionsCollection mOptions;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import java.io.Serializable;
+
+/**
+ * Search Facet
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class SearchFacet implements Serializable {
+
+    private static final long serialVersionUID = -6507918911819851151L;
+    @GsonAdapterKey("name")
+    public String mName;
+    @GsonAdapterKey("options")
+    public FacetOptionsCollection mOptions;
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
 public class SearchFacetCollection implements Serializable {
 
     private static final long serialVersionUID = 3340976215489066653L;
+
     @Nullable
     @GsonAdapterKey("type")
     public SearchFacet mTypeFacet;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A grouping of all facets
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class SearchFacetCollection implements Serializable {
+
+    private static final long serialVersionUID = 3340976215489066653L;
+    @Nullable
+    @GsonAdapterKey("type")
+    public SearchFacet mTypeFacet;
+    @Nullable
+    @GsonAdapterKey("category")
+    public SearchFacet mCategoryFacet;
+    @Nullable
+    @GsonAdapterKey("duration")
+    public SearchFacet mDurationFacet;
+    @Nullable
+    @GsonAdapterKey("license")
+    public SearchFacet mLicenseFacet;
+    @Nullable
+    @GsonAdapterKey("uploaded")
+    public SearchFacet mUploadedFacet;
+    // TODO: VOD facets 6/27/16 [KZ]
+    // TODO: People facets 6/27/16 [KZ]
+    // TODO: Channel facets 6/27/16 [KZ]
+    // TODO: Group facets 6/27/16 [KZ]
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.BaseResponseList;
+
+/**
+ * Response of /search
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class SearchResponse extends BaseResponseList<SearchResult> {
+
+    private static final long serialVersionUID = -7915082057592438294L;
+
+    @SerializedName("facets")
+    public SearchFacetCollection mFacetCollection;
+
+    @Override
+    public Class getModelClass() {
+        return SearchResponse.class;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
@@ -41,6 +41,6 @@ public class SearchResponse extends BaseResponseList<SearchResult> {
 
     @Override
     public Class getModelClass() {
-        return SearchResponse.class;
+        return SearchResult.class;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.vimeo.networking.model.Channel;
+import com.vimeo.networking.model.Group;
+import com.vimeo.networking.model.User;
+import com.vimeo.networking.model.Video;
+import com.vimeo.networking.model.VodItem;
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * An individual search response item
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public class SearchResult implements Serializable {
+
+    private static final long serialVersionUID = -1607389617833091383L;
+
+    @GsonAdapterKey("is_staffpick")
+    public boolean mIsStaffPick;
+    @GsonAdapterKey("is_featured")
+    public boolean mIsFeatured;
+    @GsonAdapterKey("type")
+    public SearchType mSearchType;
+
+    /**
+     * Non-null when {@link #mSearchType} is {@link SearchType#VIDEO}
+     */
+    @Nullable
+    @GsonAdapterKey("clip")
+    public Video mVideo;
+
+    /**
+     * Non-null when {@link #mSearchType} is {@link SearchType#USER}
+     */
+    @Nullable
+    @GsonAdapterKey("people")
+    public User mUser;
+
+    /**
+     * Non-null when {@link #mSearchType} is {@link SearchType#CHANNEL}
+     */
+    @Nullable
+    @GsonAdapterKey("channel")
+    public Channel mChannel;
+
+    /**
+     * Non-null when {@link #mSearchType} is {@link SearchType#GROUP}
+     */
+    @Nullable
+    @GsonAdapterKey("group")
+    public Group mGroup;
+
+    /**
+     * Non-null when {@link #mSearchType} is {@link SearchType#VOD}
+     */
+    @Nullable
+    @GsonAdapterKey("ondemand")
+    public VodItem mVod;
+
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchType.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enum representing types of searches.
+ * <p/>
+ * Created by zetterstromk on 6/27/16.
+ */
+public enum SearchType {
+
+    @SerializedName("clip")
+    VIDEO("clip"),
+    @SerializedName("ondemand")
+    VOD("ondemand"),
+    @SerializedName("people")
+    USER("people"),
+    @SerializedName("channel")
+    CHANNEL("channel"),
+    @SerializedName("group")
+    GROUP("group");
+
+    private final String string;
+
+    SearchType(String string) {
+        this.string = string;
+    }
+
+    @Override
+    public String toString() {
+        return this.string;
+    }
+}


### PR DESCRIPTION
#### Ticket
[VA-1777](https://vimean.atlassian.net/browse/VA-1777)

#### Ticket Summary
We are introducing a new search endpoint ```/search``` for whitelisted apps. This ticket is about integrating that into the mobile app.

#### Implementation Summary
I created new models for the search representations, and placed them in a ```model.search``` package. I then created a new Retrofit service, which is accessed through a package-private VimeoClient ```search``` method. The way to access this is through the ```Search``` class.
In order to search you call upon the static ````Search.search()``` method, passing it certain parameters. Similar to the existing ```SearchRefinementBuilder```, there is a ```QueryParameterProvider``` to set parameters and generate a Map.

I left the existing search functionality in place and am not deprecating anything, since this new search is only for whitelisted apps - other apps can continue to use the existing search mechanisms.

I have TODOs sprinkled throughout some of the classes, as I mainly focused on upgrading the existing app functionality to this new search; I left out adding new features - such as Category filtering in app, which is being ticketed for future development.

#### How to Test
Test using the Android PR.

