### PR TITLE
Va-1827 add failure playback connection

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -86,6 +86,10 @@ public class Vimeo {
     public static final String PARAMETER_SESSION_TIME = "session_time";
     public static final String PARAMETER_VUID = "vuid";
     public static final String PARAMETER_LOCALE = "locale";
+    @Deprecated
+    public static final String PARAMETER_TIME = "time";
+    @Deprecated
+    public static final String PARAMETER_QUALITY = "quality";
     public static final String PARAMETER_DURATION = "duration";
     public static final String PARAMETER_PROGRESS = "progress";
     public static final String PARAMETER_BUTTON_STATE = "button_state";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -101,4 +101,7 @@ public class ConnectionCollection implements Serializable {
     @Nullable
     @GsonAdapterKey("trailer")
     public Connection trailer;
+    @Nullable
+    @GsonAdapterKey("playback")
+    public Connection playbackFailureReason;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -460,6 +460,7 @@ public class Video implements Serializable {
     /**
      * Returns the date the VOD video will expire. In the event that a video is both rented and subscribed,
      * this will return the later expiration date. If they are equal, subscription date will be returned.
+     *
      * @return the expiration date or null if there is no expiration
      */
     @Nullable
@@ -524,6 +525,21 @@ public class Video implements Serializable {
 
     public boolean isVod() {
         return (metadata != null && metadata.connections != null && metadata.connections.ondemand != null);
+    }
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Playback failure Endpoint
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Playback failure Endpoint">
+    @Nullable
+    public String getPlaybackFailureUri() {
+        String playbackFailureUri = null;
+        if (metadata != null && metadata.connections != null &&
+            metadata.connections.playbackFailureReason != null) {
+            playbackFailureUri = metadata.connections.playbackFailureReason.uri;
+        }
+        return playbackFailureUri;
     }
     // </editor-fold>
 


### PR DESCRIPTION
#### Ticket
[Va-1827](https://vimean.atlassian.net/browse/Va-1827)

#### Ticket Summary
Add the playback connection for DRM failure errors

#### Implementation Summary
Add the connection as well as a helper to obtain it. Also added back in two constants I removed for 2.3.2, since 2.3.1 needs them still! I added the Deprecated annotation to them to remind us to remove.
