### PR TITLE
DTA-31 add lazy library loading

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitClientBuilder.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitClientBuilder.java
@@ -22,6 +22,8 @@
 
 package com.vimeo.networking;
 
+import com.vimeo.networking.logging.ClientLogger;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyManagementException;
@@ -126,6 +128,13 @@ public class RetrofitClientBuilder {
         sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 
         sSLSocketFactory = sslContext.getSocketFactory();
+        if (inputStream != null) {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                ClientLogger.d("pinCertificates: Could not close keystore InputStream");
+            }
+        }
 
         return this;
     }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -115,20 +115,20 @@ public final class VimeoClient {
     }
 
     private static LazyInitializationProvider sLazyInitializationProvider;
-    private static VimeoClient mSharedInstance;
+    private static VimeoClient sSharedInstance;
 
     public static VimeoClient getInstance() {
-        if (mSharedInstance == null) {
+        if (sSharedInstance == null) {
             if (sLazyInitializationProvider != null) {
                 initialize(sLazyInitializationProvider.getConfiguration());
-                if (mSharedInstance != null) {
-                    return mSharedInstance;
+                if (sSharedInstance != null) {
+                    return sSharedInstance;
                 }
             }
             throw new AssertionError("Instance must be configured before use");
         }
 
-        return mSharedInstance;
+        return sSharedInstance;
     }
 
     public static void initializeLazily(@NotNull Configuration configuration) {
@@ -136,7 +136,7 @@ public final class VimeoClient {
     }
 
     public static void initialize(@NotNull Configuration configuration) {
-        mSharedInstance = new VimeoClient(configuration);
+        sSharedInstance = new VimeoClient(configuration);
     }
 
     private VimeoClient(@NotNull Configuration configuration) {
@@ -801,7 +801,7 @@ public final class VimeoClient {
                 VimeoClient.mContinuePinCodeAuthorizationRefreshCycle = true;
                 mPinCodeAuthorizationTimer.scheduleAtFixedRate(
                         new PinCodePollingTimerTask(pinCodeInfo, mPinCodeAuthorizationTimer,
-                                                    pinCodeInfo.getExpiresIn(), authCallback, mSharedInstance,
+                                                    pinCodeInfo.getExpiresIn(), authCallback, sSharedInstance,
                                                     SCOPE), 0,
                         SECONDS_TO_MILLISECONDS * pinCodeInfo.getInterval());
             }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -99,17 +99,43 @@ public final class VimeoClient {
      */
     // <editor-fold desc="Configuration">
 
+    private static class LazyInitializationProvider {
+
+        @NotNull
+        private final Configuration mConfiguration;
+
+        public LazyInitializationProvider(@NotNull Configuration configuration) {
+            mConfiguration = configuration;
+        }
+
+        @NotNull
+        public Configuration getConfiguration() {
+            return mConfiguration;
+        }
+    }
+
+    private static LazyInitializationProvider sLazyInitializationProvider;
     private static VimeoClient mSharedInstance;
 
     public static VimeoClient getInstance() {
         if (mSharedInstance == null) {
+            if (sLazyInitializationProvider != null) {
+                initialize(sLazyInitializationProvider.getConfiguration());
+                if (mSharedInstance != null) {
+                    return mSharedInstance;
+                }
+            }
             throw new AssertionError("Instance must be configured before use");
         }
 
         return mSharedInstance;
     }
 
-    public static void initialize(Configuration configuration) {
+    public static void initializeLazily(@NotNull Configuration configuration) {
+        sLazyInitializationProvider = new LazyInitializationProvider(configuration);
+    }
+
+    public static void initialize(@NotNull Configuration configuration) {
         mSharedInstance = new VimeoClient(configuration);
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -117,7 +117,7 @@ public final class VimeoClient {
     private static LazyInitializationProvider sLazyInitializationProvider;
     private static VimeoClient sSharedInstance;
 
-    public static VimeoClient getInstance() {
+    public static synchronized VimeoClient getInstance() {
         if (sSharedInstance == null) {
             if (sLazyInitializationProvider != null) {
                 initialize(sLazyInitializationProvider.getConfiguration());


### PR DESCRIPTION
#### Ticket
[DTA-31](https://vimean.atlassian.net/browse/DTA-31)

#### Ticket Summary
For Day Tripper, we want to combine the splash and launch screen, effectively removing the splash screen. A part of this is then to defer library initialization from application onCreate until the launch screen, effectively letting the "splash" show quicker, and then hiding once initialization completes.

#### Implementation Summary
I created a lazy load initialization, which effectively waits until the first call to ```getInstance``` to initialize. Also, I fixed an input stream that needed to be closed.

#### How to Test
Using method tracing, see how app startup time is reduced

