### PR TITLE
VA-1712 robust parsing handling

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/GsonDeserializer.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/GsonDeserializer.java
@@ -24,6 +24,9 @@ package com.vimeo.networking;
 
 import com.google.gson.Gson;
 import com.vimeo.networking.callbacks.ModelCallback;
+import com.vimeo.networking.logging.ClientLogger;
+
+import org.jetbrains.annotations.Nullable;
 
 /**
  * To be able to keep our api calls generic, we need to handle deserialization ourselves (Retrofit calls
@@ -56,8 +59,14 @@ public class GsonDeserializer {
         callback.success(result);
     }
 
+    @Nullable
     protected Object deserializeObject(Gson gson, Object object, ModelCallback<Object> callback) {
-        String JSON = gson.toJson(object);
-        return gson.fromJson(JSON, callback.getObjectType());
+        try {
+            String JSON = gson.toJson(object);
+            return gson.fromJson(JSON, callback.getObjectType());
+        } catch (Exception e) {
+            ClientLogger.e("Error when deserializing object!", e);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
#### Ticket
[VA-1712](https://vimean.atlassian.net/browse/VA-1712)

#### Ticket Summary
Add more robust logic around parsing objects from the API

#### Implementation Summary
While stag adds extra parsing protection, we need to catch errors being thrown by Gson still. The networking layer has a logging system that will use a provider logger or system.out; we can use that to log any errors encountered in stag. 

#### How to Test
Change an object to an array, or vice versa.

