### PR TITLE
VA-1829 update fetch video to not pull from cache

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -1062,11 +1063,27 @@ public final class VimeoClient {
         return call;
     }
 
+    /**
+     * This will fetch a video synchronously by-passing the cache. To fetch from cache, use
+     * {@link #fetchVideoSync(String, CacheControl, String)}
+     *
+     * @param uri         the uri of the video to fetch
+     * @param fieldFilter any field filters to apply for the video response, may be null
+     * @return a Retrofit response object with the Video as the body
+     */
     @Nullable
     public retrofit2.Response<Video> fetchVideoSync(String uri, @Nullable String fieldFilter) {
         return fetchVideoSync(uri, CacheControl.FORCE_NETWORK, fieldFilter);
     }
 
+    /**
+     * This will fetch a video synchronously
+     *
+     * @param uri          the uri of the video to fetch
+     * @param cacheControl the cache control
+     * @param fieldFilter  any field filters to apply for the video response, may be null
+     * @return a Retrofit response object with the Video as the body
+     */
     @Nullable
     public retrofit2.Response<Video> fetchVideoSync(String uri, CacheControl cacheControl,
                                                     @Nullable String fieldFilter) {
@@ -1125,7 +1142,7 @@ public final class VimeoClient {
     }
 
     /**
-     * A package private search method: use {@link Search#search(String, FilterType, ModelCallback, Map, String)}
+     * A package private search method: use {@link Search#search(String, FilterType, ModelCallback, Map, List, String, String)}
      * which relies on this method.
      *
      * @param queryMap the query parameters

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1064,9 +1064,16 @@ public final class VimeoClient {
 
     @Nullable
     public retrofit2.Response<Video> fetchVideoSync(String uri, @Nullable String fieldFilter) {
+        return fetchVideoSync(uri, CacheControl.FORCE_NETWORK, fieldFilter);
+    }
+
+    @Nullable
+    public retrofit2.Response<Video> fetchVideoSync(String uri, CacheControl cacheControl,
+                                                    @Nullable String fieldFilter) {
+        String cacheHeaderValue = createCacheControlString(cacheControl);
         try {
-            return mVimeoService.getVideo(getAuthHeader(), uri, createQueryMap(null, null, fieldFilter))
-                    .execute();
+            return mVimeoService.getVideo(getAuthHeader(), cacheHeaderValue, uri,
+                                          createQueryMap(null, null, fieldFilter)).execute();
         } catch (IOException e) {
             return null;
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -153,7 +153,8 @@ public interface VimeoService {
     // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Concrete Region">
     @GET
-    Call<Video> getVideo(@Header("Authorization") String authHeader, @Url String uri,
+    Call<Video> getVideo(@Header("Authorization") String authHeader,
+                         @Header("Cache-Control") String cacheHeaderValue, @Url String uri,
                          @QueryMap Map<String, String> options);
     // </editor-fold>
 


### PR DESCRIPTION
#### Ticket
[VA-1829](https://vimean.atlassian.net/browse/VA-1829)

#### Ticket Summary
In the fetchVideoSync method, there was no cache control param, so it is defaults to cache. This is bad, because we cannot truly refresh a video.

#### Implementation Summary
I overloaded the fetchVideoSync method, so the existing method pulls from network, and there is another method that will allow users to stipulate the cache control.

#### How to Test
Download a video from deeplink. Try it again the next day. The video files should not be expired.

