### PR TITLE
VA-1881 adding sync method for client creds

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -356,6 +356,7 @@ public final class VimeoClient {
      * WARNING: This contains a synchronous network call. Use {@link #authorizeWithClientCredentialsGrant(AuthCallback)}
      * for asynchronous use.
      */
+    @Nullable
     public VimeoAccount authorizeWithClientCredentialsGrantSync() {
 
         Call<VimeoAccount> call = mVimeoService.authorizeWithClientCredentialsGrant(getBasicAuthHeader(),
@@ -365,7 +366,7 @@ public final class VimeoClient {
         VimeoAccount vimeoAccount = null;
         try {
             retrofit2.Response<VimeoAccount> response = call.execute();
-             if (response.isSuccessful()) {
+            if (response.isSuccessful()) {
                 vimeoAccount = response.body();
                 saveAccount(vimeoAccount, null);
             }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -348,6 +348,35 @@ public final class VimeoClient {
     }
 
     /**
+     * Authorizes users of the app who are not signed in. This call requires a client id and client secret
+     * to be set on the initial Configuration.
+     * <p/>
+     * Leaves User as null in {@link VimeoAccount} model and populates the rest.
+     * <p/>
+     * WARNING: This contains a synchronous network call. Use {@link #authorizeWithClientCredentialsGrant(AuthCallback)}
+     * for asynchronous use.
+     */
+    public VimeoAccount authorizeWithClientCredentialsGrantSync() {
+
+        Call<VimeoAccount> call = mVimeoService.authorizeWithClientCredentialsGrant(getBasicAuthHeader(),
+                                                                                    Vimeo.CLIENT_CREDENTIALS_GRANT_TYPE,
+                                                                                    mConfiguration.scope);
+
+        VimeoAccount vimeoAccount = null;
+        try {
+            retrofit2.Response<VimeoAccount> response = call.execute();
+             if (response.isSuccessful()) {
+                vimeoAccount = response.body();
+                saveAccount(vimeoAccount, null);
+            }
+        } catch (IOException e) {
+            ClientLogger.e("Exception during authorizeWithClientCredentialsGrantSync: " + e.getMessage(), e);
+        }
+
+        return vimeoAccount;
+    }
+
+    /**
      * Exchange OAuth1 token/secret combination for a new OAuth2 token
      *
      * @param callback    Callback pertaining to authentication


### PR DESCRIPTION
#### Ticket
[VA-1881](https://vimean.atlassian.net/browse/VA-1881)

#### Ticket Summary
BlinkFeed content never loads

#### Implementation Summary
The issue is that when fresh installed and never going into the app, a client credentials token is never issued - thus leaving BlinkFeed to try and make requests using basic auth, which fail.


