### PR TITLE
DTA-26 add single sign on token exchange

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -397,6 +397,30 @@ public final class VimeoClient {
         return call;
     }
 
+    /**
+     * This method is used to exchange a user access token from app A for a token for app B.
+     * <p/>
+     * An app can use this to exchange an authenticated user's access token from app A for a new access
+     * token for app B, using the scope associated with app B. The caller of this method will be app B.
+     * <p/>
+     * <b>This method is application restricted, and not meant to be consumed by the general public.</b>
+     *
+     * @param token    the authenticated user access token from application A. This <b>cannot</b> be a client
+     *                 credentials access token.
+     * @param callback Callback invoked upon success/fail of the service
+     * @return A Call object
+     */
+    public Call<VimeoAccount> singleSignOnTokenExchange(String token, AuthCallback callback) {
+        if (callback == null) {
+            throw new AssertionError("Callback cannot be null");
+        }
+
+        Call<VimeoAccount> call =
+                mVimeoService.ssoTokenExchange(getBasicAuthHeader(), token, mConfiguration.scope);
+        call.enqueue(new AccountCallback(this, callback));
+        return call;
+    }
+
     @Nullable
     public Call<VimeoAccount> join(String displayName, String email, String password, AuthCallback callback) {
         if (callback == null) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -410,7 +410,7 @@ public final class VimeoClient {
      * @param callback Callback invoked upon success/fail of the service
      * @return A Call object
      */
-    public Call<VimeoAccount> singleSignOnTokenExchange(String token, AuthCallback callback) {
+    public Call<VimeoAccount> singleSignOnTokenExchange(@NotNull String token, AuthCallback callback) {
         if (callback == null) {
             throw new AssertionError("Callback cannot be null");
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -101,6 +101,11 @@ public interface VimeoService {
                                              @Field("scope") String scope);
 
     @FormUrlEncoded
+    @POST("oauth/appexchange")
+    Call<VimeoAccount> ssoTokenExchange(@Header("Authorization") String basicAuth,
+                                        @Field("access_token") String token, @Field("scope") String scope);
+
+    @FormUrlEncoded
     @Headers("Cache-Control: no-cache, no-store")
     @POST("oauth/device")
     Call<PinCodeInfo> getPinCodeInfo(@Header("Authorization") String authHeader,


### PR DESCRIPTION
#### Ticket
[DTA-26](https://vimean.atlassian.net/browse/DTA-26)

#### Ticket Summary
When introducing multiple apps that may be authenticated, we need a way to exchange tokens from one app for another, so users do not need to enter their credentials again.

#### Implementation Summary
The API provides a single-sign-on token exchange endpoint, for use by Vimeo's iOS and Android apps. I added a client and service method to support this.

