### PR TITLE
VA-1891 get v1.1.0 release ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For a more in depth look at the usage, refer to the [example Android app](exampl
 ### Gradle
 Specify the dependency in your `build.gradle` file (make sure `jcenter()` is included as a repository)
 ```groovy
-compile 'com.vimeo.networking:vimeo-networking:1.0.1'
+compile 'com.vimeo.networking:vimeo-networking:1.1.0'
 ```
 
 ### Submodule
@@ -168,15 +168,16 @@ You can access the below methods through `VimeoClient.getInstance()`.
 
 For making GET requests:
 ```java
-public Call<Object> fetchContent(String uri, CacheControl cacheControl, ModelCallback callback,
-                                 @Nullable String query, @Nullable Map<String, String> refinementMap,
+public Call<Object> fetchContent(@NotNull String uri, CacheControl cacheControl,
+                                 @NotNull ModelCallback callback, @Nullable String query,
+                                 @Nullable Map<String, String> refinementMap,
                                  @Nullable String fieldFilter)
 ```
 
 For making POST requests:
 ```java
-public Call<Object> postContent(String uri, CacheControl cacheControl, HashMap<String, String> postBody,
-                                VimeoCallback callback)
+public Call<Object> postContent(@NotNull String uri, CacheControl cacheControl,
+                                HashMap<String, String> postBody, @NotNull VimeoCallback callback)
 ```
 
 For making PUT requests:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7"
     }
 }
 
@@ -15,6 +15,10 @@ allprojects {
         jcenter()
     }
     apply plugin: "com.jfrog.bintray"
+
+    tasks.withType(Javadoc).all { enabled = false }
+
+    tasks.withType(JavaCompile) { options.fork = true }
 }
 
 task clean(type: Delete) {

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.intellij:annotations:12.0@jar'
-    compile 'com.squareup.retrofit2:retrofit:2.0.2'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.2'
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
     compile project(':stag-library')
     apt project(':stag-library-compiler')
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.utils;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+
+/**
+ * <b>This class is now deprecated</b>
+ * <br>
+ * Gson has  added support for parsing ISO 8601 strings into Date objects, removing the need for this class.
+ * This class will be removed in release 2.0.0 of vimeo-networking.
+ * <p/>
+ * <b>Original JavaDoc:</b>
+ * <br>
+ * We have to write our own serializer and deserializer because Android doesn't currently
+ * support ISO 8601. The SimpleDateFormat link below shows 'ZZZZZ' as what we want for timezone
+ * but this is only available in Android 4.3 and up. Java 7 has the 'X' character to represent
+ * ISO 8601 but Android treats this differently. So in the mean time the ISO8601 class will convert
+ * the strings to RFC 822 which is something the DateFormatter can handle regardless of version.
+ * <p/>
+ * {@link <a href="http://developer.android.com/reference/java/text/SimpleDateFormat.html">Android SimpleDateFormat</a>}
+ * {@link <a href="https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">Oracle SimpleDateFormat</a>}
+ * {@link <a href="http://stackoverflow.com/questions/2201925/converting-iso-8601-compliant-string-to-java-util-date">Stack Overflow</a>}
+ * <p/>
+ * Created by kylevenn on 8/26/15.
+ */
+@SuppressWarnings({"UtilityClassWithoutPrivateConstructor", "unused", "NonFinalUtilityClass", "MagicNumber"})
+@Deprecated
+public class ISO8601 {
+
+    // There was a bug in Android 2.1 that looks like it would arbitrary GC a static SDF
+    // If supporting Android 2.1, be aware of this [KV]
+    // Using RFC 822 since we can't use ISO 8601
+    private static final SimpleDateFormat dateFormat =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH);
+
+    public static JsonSerializer<Date> getDateSerializer() {
+        return new JsonSerializer<Date>() {
+            @Override
+            public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+                return src == null ? null : new JsonPrimitive(fromDate(src));
+            }
+        };
+    }
+
+    public static JsonDeserializer<Date> getDateDeserializer() {
+        return new JsonDeserializer<Date>() {
+            @Override
+            public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                    throws JsonParseException
+
+            {
+                try {
+                    return json == null ? null : toDate(json.getAsString());
+                } catch (ParseException e) {
+                    // Return an null date if it is formatted incorrectly
+                    System.out.println("Incorrectly formatted date sent from server");
+                    return null;
+                }
+            }
+        };
+    }
+
+    /** Transform Date to ISO 8601 string. */
+    public static String fromDate(final Date date) {
+        String formatted = dateFormat.format(date);
+        return formatted.substring(0, 22) + ":" + formatted.substring(22);
+    }
+
+    /** Get current date and time formatted as ISO 8601 string. */
+    public static String now() {
+        return fromDate(new Date());
+    }
+
+    /** Transform ISO 8601 string to Date. */
+    public static Date toDate(final String iso8601string) throws ParseException {
+        // Account for ISO 8601 standard of using the character 'Z' to represent UTC
+        String s = iso8601string.replace("Z", "+00:00");
+        try {
+            if (s.charAt(22) != ':') {
+                throw new ParseException("Invalid ISO 8601 format", 0);
+            }
+            s = s.substring(0, 22) + s.substring(23);  // To get rid of the ":" to conform to RFC 822
+        } catch (IndexOutOfBoundsException e) {
+            // Throw a ParseException because all ISO 8601 strings should be of the same length
+            throw new ParseException("Invalid length", 0);
+        }
+
+        return dateFormat.parse(s);
+    }
+}
+

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.internal.bind.util.ISO8601Utils;
 
 import java.lang.reflect.Type;
 import java.text.ParseException;
@@ -43,7 +44,7 @@ import java.util.Locale;
  * <b>This class is now deprecated</b>
  * <br>
  * Gson has  added support for parsing ISO 8601 strings into Date objects, removing the need for this class.
- * This class will be removed in release 2.0.0 of vimeo-networking.
+ * This class will be removed in release 2.0.0 of vimeo-networking. See {@link ISO8601Utils}
  * <p/>
  * <b>Original JavaDoc:</b>
  * <br>


### PR DESCRIPTION
#### Ticket
[VA-1891](https://vimean.atlassian.net/browse/VA-1891)

#### Ticket Summary
Get v1.1.0 release ready

#### Implementation Summary
* Added back in ISO8601, deprecated it, and updated its javadoc - this helps prevent a breaking change.
* Updated the ReadMe to show updated method params.
* Updated the ReadMe with new version
* Bump retrofit version to latest
* Tweak gradle to prevent build fail when uploading to bintray

#### How to Test
* Verify cert pinning still works with new retrofit update
