### PR TITLE
Smarter error handling

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/callbacks/VimeoCallback.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/callbacks/VimeoCallback.java
@@ -55,7 +55,7 @@ public abstract class VimeoCallback<T> implements Callback<T> {
             success(t);
         } else {
             VimeoError vimeoError = null;
-            if (response.errorBody() != null) {
+            if (response.errorBody() != null && response.errorBody().contentLength() > 0) {
                 try {
                     Converter<ResponseBody, VimeoError> errorConverter = VimeoClient.getInstance()
                             .getRetrofit()


### PR DESCRIPTION
#### Summary
Sometimes when we get an error back from a response, we have a non null but empty error response body. In this case, we throw an exception (and catch it) as we try to parse the empty error.

#### Implementation Summary
I am tired of seeing this exception in my logs, so to fix it, I am checking whether the error response is empty, and not trying to parse it if it is. The reason it is empty is that we try to pull from cache and get an error if it is empty or invalid, and since the cache is not sending any sort of response code, the error response is empty.

#### How to Test
From a cold start with cache cleared, start the app. Without this change, two or three exceptions will be logged to `System.out` as the error converter is unable to convert empty errors.