### PR TITLE
VA-1963 wrapping date deserialization

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/logging/LoggingInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/logging/LoggingInterceptor.java
@@ -23,12 +23,12 @@
 package com.vimeo.networking.logging;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.vimeo.networking.Configuration;
 import com.vimeo.networking.Vimeo.LogLevel;
 import com.vimeo.networking.VimeoClient;
+import com.vimeo.networking.utils.VimeoNetworkUtil;
 
 import java.io.IOException;
 
@@ -125,7 +125,7 @@ public class LoggingInterceptor implements Interceptor {
                 JsonParser parser = new JsonParser();
                 JsonObject json = parser.parse(jsonString).getAsJsonObject();
 
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                Gson gson = VimeoNetworkUtil.getGsonBuilder().setPrettyPrinting().create();
                 prettyString = gson.toJson(json);
             } catch (Exception e) {
                 ClientLogger.e("Error making body pretty response/request");

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -22,9 +22,8 @@
 
 package com.vimeo.networking.model;
 
-import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.vimeo.networking.utils.VimeoNetworkUtil;
 import com.vimeo.stag.GsonAdapterKey;
 
 import org.jetbrains.annotations.Nullable;
@@ -70,8 +69,7 @@ public class VimeoAccount implements Serializable {
         this.tokenType = tokenType;
         this.scope = scope;
 
-        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
+        Gson gson = VimeoNetworkUtil.getGson();
 
         this.user = gson.fromJson(userJSON, User.class);
     }
@@ -112,8 +110,7 @@ public class VimeoAccount implements Serializable {
             return this.userJSON;
         }
 
-        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
+        Gson gson = VimeoNetworkUtil.getGson();
 
         this.userJSON = gson.toJson(this.user);
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601Wrapper.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601Wrapper.java
@@ -1,0 +1,55 @@
+package com.vimeo.networking.utils;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.internal.bind.util.ISO8601Utils;
+import com.vimeo.networking.logging.ClientLogger;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Date;
+
+/**
+ * A wrapper class that serializes and deserializes dates
+ * using the {@link ISO8601Utils} class that catches errors
+ * and reports them to the client application, allowing
+ * them to decide if they should crash or not. If we just
+ * rely on the default adapter used by JSON, we are unable
+ * to absorb date parsing errors or log them correctly.
+ */
+@SuppressWarnings("WeakerAccess")
+public final class ISO8601Wrapper {
+
+    private ISO8601Wrapper() {
+    }
+
+    public static JsonSerializer<Date> getDateSerializer() {
+        return new JsonSerializer<Date>() {
+            @Override
+            public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+                return src == null ? null : new JsonPrimitive(ISO8601Utils.format(src));
+            }
+        };
+    }
+
+    public static JsonDeserializer<Date> getDateDeserializer() {
+        return new JsonDeserializer<Date>() {
+            @Override
+            public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                    throws JsonParseException {
+                try {
+                    return json == null ? null : ISO8601Utils.parse(json.getAsString(), new ParsePosition(0));
+                } catch (ParseException e) {
+                    ClientLogger.e("Incorrectly formatted date sent from server: " + json.getAsString(), e);
+                    return null;
+                }
+            }
+        };
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601Wrapper.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/ISO8601Wrapper.java
@@ -20,8 +20,10 @@ import java.util.Date;
  * using the {@link ISO8601Utils} class that catches errors
  * and reports them to the client application, allowing
  * them to decide if they should crash or not. If we just
- * rely on the default adapter used by JSON, we are unable
+ * rely on the default adapter used by Gson, we are unable
  * to absorb date parsing errors or log them correctly.
+ * Additionally, the default adapter was not serializing the
+ * dates correctly.
  */
 @SuppressWarnings("WeakerAccess")
 public final class ISO8601Wrapper {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
@@ -32,6 +32,7 @@ import com.vimeo.stag.generated.Stag;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -69,11 +70,14 @@ public class VimeoNetworkUtil {
      * Static helper method that automatically applies the VimeoClient Gson preferences
      * </p>
      * This includes formatting for dates as well as a LOWER_CASE_WITH_UNDERSCORES field naming policy
+     *
      * @return GsonBuilder that can be built upon and then created
      */
     public static GsonBuilder getGsonBuilder() {
         // Example date: "2015-05-21T14:24:03+00:00"
         return new GsonBuilder().registerTypeAdapterFactory(new Stag.Factory())
+                .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateSerializer())
+                .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateDeserializer())
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);
     }
 


### PR DESCRIPTION
#### Ticket
[VA-1963](https://vimean.atlassian.net/browse/VA-1963)

#### Ticket Summary
The date deserialization is crashing sometimes because the API seems to send us bad dates.

#### Implementation Summary
Wrap the deserialization in a try catch so we can choose whether or not to crash on the client side.

#### How to Test
make sure dates still show up correctly