### PR TITLE
VA-1984 add VOD season models, move VOD models, add VideoBadge

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
@@ -36,18 +36,64 @@ import java.util.ArrayList;
 public class Connection implements Serializable {
 
     private static final long serialVersionUID = -840088720891343176L;
+
     @Nullable
     @GsonAdapterKey("uri")
     public String uri;
+
     @Nullable
     @GsonAdapterKey("options")
     public ArrayList<String> options;
+
     @GsonAdapterKey("total")
     public int total;
+
     @GsonAdapterKey("main_total")
     public int mainTotal;
+
     @GsonAdapterKey("extra_total")
     public int extraTotal;
+
     @GsonAdapterKey("viewable_total")
     public int viewableTotal;
+
+    @Nullable
+    @GsonAdapterKey("name")
+    public String name;
+
+    // -----------------------------------------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Getters">
+    @Nullable
+    public String getUri() {
+        return uri;
+    }
+
+    @Nullable
+    public ArrayList<String> getOptions() {
+        return options;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public int getMainTotal() {
+        return mainTotal;
+    }
+
+    public int getExtraTotal() {
+        return extraTotal;
+    }
+
+    public int getViewableTotal() {
+        return viewableTotal;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+    // </editor-fold>
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -109,6 +109,9 @@ public class ConnectionCollection implements Serializable {
     @GsonAdapterKey("ondemand")
     public Connection ondemand;
     @Nullable
+    @GsonAdapterKey("season")
+    public Connection season;
+    @Nullable
     @GsonAdapterKey("trailer")
     public Connection trailer;
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -176,6 +176,9 @@ public class Video implements Serializable {
     @Nullable
     @GsonAdapterKey("download")
     public ArrayList<VideoFile> download;
+    @Nullable
+    @GsonAdapterKey("badge")
+    public VideoBadge videoBadge;
 
     /**
      * The resource_key field is the unique identifier for a Video object. It may be used for object
@@ -374,6 +377,7 @@ public class Video implements Serializable {
      * <ol>The user making the request owns the video</ol>
      * <ol>The application making the request is granted access to view this field</ol>
      * </ul>
+     *
      * @return the password if applicable
      */
     @Nullable
@@ -463,6 +467,7 @@ public class Video implements Serializable {
      * 3) both rental and subscription? choose the later expiration, expirations equal? choose subscription
      * 4) subscription
      * 5) rental
+     *
      * @return the VodVideoType of the video or {@code VodVideoType.NONE} if it is not a VOD video or
      * {@code VodVideoType.UNKNOWN} if it is a VOD video that is not marked as rented, subscribed or bought
      */
@@ -503,6 +508,7 @@ public class Video implements Serializable {
     /**
      * Returns the date the VOD video will expire. In the event that a video is both rented and subscribed,
      * this will return the later expiration date. If they are equal, subscription date will be returned.
+     *
      * @return the expiration date or null if there is no expiration
      */
     @Nullable
@@ -585,6 +591,20 @@ public class Video implements Serializable {
             return metadata.connections.trailer.uri;
         }
         return null;
+    }
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Badge
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Badge">
+
+    /**
+     * @return the badge associated with this video, null if there is no badge
+     */
+    @Nullable
+    public VideoBadge getVideoBadge() {
+        return videoBadge;
     }
     // </editor-fold>
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoBadge.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoBadge.java
@@ -1,0 +1,91 @@
+package com.vimeo.networking.model;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A model representing a "badge" that a video can display. The badge represents
+ * an award, and is usually displayed over the thumbnail of the video, or near
+ * video data (name, description, etc)
+ * Created by zetterstromk on 10/4/16.
+ */
+public class VideoBadge implements Serializable {
+
+    private static final long serialVersionUID = -5343389171512787927L;
+
+    @Nullable
+    @GsonAdapterKey("type")
+    public String mType;
+
+    @Nullable
+    @GsonAdapterKey("festival")
+    public String mFestival;
+
+    @Nullable
+    @GsonAdapterKey("link")
+    public String mLink;
+
+    @Nullable
+    @GsonAdapterKey("text")
+    public String mText;
+
+    @Nullable
+    @GsonAdapterKey("pictures")
+    public PictureCollection mPictureCollection;
+
+    // -----------------------------------------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Getters">
+
+    /**
+     * A type of the badge, such as "staffpick", "vod", or "weekendchallenge". These are
+     * not meant to be user-facing. These types may change over time, which is why this is
+     * a string rather than an enum.
+     *
+     * @return The non-user-facing name of the badge
+     */
+    @Nullable
+    public String getType() {
+        return mType;
+    }
+
+    /**
+     * @return The non-user-facing festival description, null if the award is not from a festival
+     */
+    @Nullable
+    public String getFestival() {
+        return mFestival;
+    }
+
+    /**
+     * @return A link to this content - may be generic (such as "https://vimeo.com/ondemand)
+     * or specific (such as "https://vimeo.com/channels/staffpicks/12345")
+     */
+    @Nullable
+    public String getLink() {
+        return mLink;
+    }
+
+    /**
+     * @return The human-readable name of the badge such as "Staff Pick",
+     * "Vimeo On Demand" or "Weekend Challenge"
+     */
+    @Nullable
+    public String getText() {
+        return mText;
+    }
+
+    /**
+     * @return The {@link PictureCollection} representing
+     * the badge - it should be used to show badge's image
+     */
+    @Nullable
+    public PictureCollection getPictureCollection() {
+        return mPictureCollection;
+    }
+    // </editor-fold>
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
@@ -28,7 +28,7 @@ import com.vimeo.networking.model.Channel;
 import com.vimeo.networking.model.Group;
 import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
-import com.vimeo.networking.model.VodItem;
+import com.vimeo.networking.model.vod.VodItem;
 import com.vimeo.stag.GsonAdapterKey;
 
 import org.jetbrains.annotations.Nullable;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
@@ -136,4 +136,27 @@ public class Season implements Serializable {
     }
 
     // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Comparison methods
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Comparison methods">
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || !(obj instanceof Season)) {
+            return false;
+        }
+        Season that = (Season) obj;
+
+        return (mUri != null && that.getUri() != null) && mUri.equals(that.getUri());
+    }
+
+    @Override
+    public int hashCode() {
+        return mUri != null ? mUri.hashCode() : 0;
+    }
+    // </editor-fold>
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
@@ -1,0 +1,139 @@
+package com.vimeo.networking.model.vod;
+
+import com.vimeo.networking.model.Metadata;
+import com.vimeo.networking.model.User;
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * This model represents a "season" of content. Seasons are logical groupings
+ * of videos set up by creators. All VODs will have a Season, even if it is
+ * a feature film - the season would contain the film in this case.
+ * <p>
+ * Created by zetterstromk on 10/4/16.
+ */
+public class Season implements Serializable {
+
+    private static final String SEASON_TYPE_MAIN = "main";
+    private static final String SEASON_TYPE_EXTRAS = "extras";
+
+    public enum SeasonType {
+        MAIN,
+        EXTRAS
+    }
+
+    private static final long serialVersionUID = 2770200708069413413L;
+
+    @Nullable
+    @GsonAdapterKey("uri")
+    public String mUri;
+
+    @Nullable
+    @GsonAdapterKey("name")
+    public String mName;
+
+    @Nullable
+    @GsonAdapterKey("type")
+    public String mType;
+
+    @Nullable
+    @GsonAdapterKey("description")
+    public String mDescription;
+
+    @Nullable
+    @GsonAdapterKey("user")
+    public User mUser;
+
+    @GsonAdapterKey("position")
+    public int mPosition;
+
+    @Nullable
+    @GsonAdapterKey("metadata")
+    public Metadata mMetadata;
+
+    @Nullable
+    @GsonAdapterKey("resource_key")
+    public String mResourceKey;
+
+    // -----------------------------------------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Getters">
+
+    @Nullable
+    public String getUri() {
+        return mUri;
+    }
+
+    /**
+     * @return the name of this season
+     */
+    @Nullable
+    public String getName() {
+        return mName;
+    }
+
+    /**
+     * Seasons can be either "main" or "extras", and the type
+     * is always provided.
+     *
+     * @return the {@link SeasonType}
+     */
+    @NotNull
+    public SeasonType getSeasonType() {
+        if (SEASON_TYPE_EXTRAS.equals(mType)) {
+            return SeasonType.EXTRAS;
+        }
+        return SeasonType.MAIN;
+    }
+
+    /**
+     * @return the description of this season
+     */
+    @Nullable
+    public String getDescription() {
+        return mDescription;
+    }
+
+    /**
+     * @return the Creator of this content
+     */
+    @Nullable
+    public User getUser() {
+        return mUser;
+    }
+
+    /**
+     * Seasons are given a position that details the order in which they
+     * should be shown. The lower the position, the sooner the content should
+     * be made available to show to the consumer.
+     *
+     * @return the position of the season
+     */
+    public int getPosition() {
+        return mPosition;
+    }
+
+    /**
+     * There will be a ConnectionCollection object holding a "videos" connection
+     * for this season, as well as an InteractionCollection holding
+     * possible purchase data
+     *
+     * @return the {@link Metadata}
+     */
+    @Nullable
+    public Metadata getMetadata() {
+        return mMetadata;
+    }
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    // </editor-fold>
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/SeasonList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/SeasonList.java
@@ -1,0 +1,17 @@
+package com.vimeo.networking.model.vod;
+
+import com.vimeo.networking.model.BaseResponseList;
+
+/**
+ * A list of {@link Season} items
+ * Created by zetterstromk on 10/4/16.
+ */
+public class SeasonList extends BaseResponseList<Season> {
+
+    private static final long serialVersionUID = -2072805722241898821L;
+
+    @Override
+    public Class<Season> getModelClass() {
+        return Season.class;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
@@ -22,9 +22,15 @@
  * SOFTWARE.
  */
 
-package com.vimeo.networking.model;
+package com.vimeo.networking.model.vod;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.ConnectionCollection;
+import com.vimeo.networking.model.InteractionCollection;
+import com.vimeo.networking.model.Metadata;
+import com.vimeo.networking.model.PictureCollection;
+import com.vimeo.networking.model.User;
+import com.vimeo.networking.model.Video;
 import com.vimeo.stag.GsonAdapterKey;
 
 import org.jetbrains.annotations.NotNull;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodList.java
@@ -22,8 +22,9 @@
  * SOFTWARE.
  */
 
-package com.vimeo.networking.model;
+package com.vimeo.networking.model.vod;
 
+import com.vimeo.networking.model.BaseResponseList;
 import com.vimeo.stag.GsonAdapterKey;
 
 /**


### PR DESCRIPTION
#### Ticket
[VA-1984](https://vimean.atlassian.net/browse/VA-1984)

#### Ticket Summary
For VOD Season support, we need to add some models. Also, as a bonus, add the Video Badge representation.

#### Implementation Summary
I created 3 models - a ```Season```, ```SeasonList```, and ```VideoBadge```. Since the main model package is growing and we want to do a bunch of refactoring for 2.0.0, I made a vod package for the season models, and moved ```VodItem``` and ```VodList``` into it.

#### How to Test
We aren't using the new models anywhere yet, but verify that the app doesn't crash with the package moves - use the mobile PR for that.

