### PR TITLE
VA-1728 Improving account manager code

### DIFF
--- a/example/src/main/java/com/vimeo/android/networking/example/vimeonetworking/TestAccountStore.java
+++ b/example/src/main/java/com/vimeo/android/networking/example/vimeonetworking/TestAccountStore.java
@@ -5,6 +5,7 @@ import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 
 import com.vimeo.android.networking.example.AccountPreferenceManager;
@@ -34,18 +35,20 @@ public class TestAccountStore implements AccountStore {
 //        mAccountManager = AccountManager.get(context);
     }
 
+    @Nullable
     @Override
     public VimeoAccount loadAccount() {
         return AccountPreferenceManager.getClientAccount();
     }
 
     @Override
-    public void saveAccount(@NonNull VimeoAccount vimeoAccount) {
+    public void saveNonUserAccount(@NonNull VimeoAccount vimeoAccount) {
         AccountPreferenceManager.setClientAccount(vimeoAccount);
     }
 
     @Override
-    public void saveAccount(@NonNull VimeoAccount vimeoAccount, @NonNull String email) {
+    public void saveAuthenticatedUserAccount(@NonNull VimeoAccount vimeoAccount,
+                                             @NonNull String accountName) {
         AccountPreferenceManager.setClientAccount(vimeoAccount);
     }
 

--- a/example/src/main/java/com/vimeo/android/networking/example/vimeonetworking/TestAccountStore.java
+++ b/example/src/main/java/com/vimeo/android/networking/example/vimeonetworking/TestAccountStore.java
@@ -42,13 +42,15 @@ public class TestAccountStore implements AccountStore {
     }
 
     @Override
-    public void saveNonUserAccount(@NonNull VimeoAccount vimeoAccount) {
+    public void saveAuthenticatedUserAccount(@NonNull VimeoAccount vimeoAccount,
+                                             @NonNull String accountName) {
+        // In non-demo code, you may want to store the account name. It is left off in
+        // this demo, but may be used as a key (such as in the Android Account Manager).
         AccountPreferenceManager.setClientAccount(vimeoAccount);
     }
 
     @Override
-    public void saveAuthenticatedUserAccount(@NonNull VimeoAccount vimeoAccount,
-                                             @NonNull String accountName) {
+    public void saveNonUserAccount(@NonNull VimeoAccount vimeoAccount) {
         AccountPreferenceManager.setClientAccount(vimeoAccount);
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -44,12 +44,23 @@ public interface AccountStore {
 
     /**
      * Saves a {@link VimeoAccount} for loading later.
+     * <p>
+     * Use this method for saving authenticated users that have an account name.
      *
      * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
      * @param accountName  the <i>name</i> of the account that helps uniquely identify it in account
      *                     stores, such as the Android AccountManager
      */
-    void saveAccount(@NotNull VimeoAccount vimeoAccount, String accountName);
+    void saveAccount(@NotNull VimeoAccount vimeoAccount, @NotNull String accountName);
+
+    /**
+     * Saves a {@link VimeoAccount} for loading later.
+     * <p>
+     * Use this method for saving client credential token when there is not account name.
+     *
+     * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
+     */
+    void saveAccount(@NotNull VimeoAccount vimeoAccount);
 
     /**
      * Removes the saved {@link VimeoAccount} from storage

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -51,7 +51,7 @@ public interface AccountStore {
      * @param accountName  the <i>name</i> of the account that helps uniquely identify it in account
      *                     stores, such as the Android AccountManager
      */
-    void saveAccount(@NotNull VimeoAccount vimeoAccount, @NotNull String accountName);
+    void saveAuthenticatedUserAccount(@NotNull VimeoAccount vimeoAccount, @NotNull String accountName);
 
     /**
      * Saves a {@link VimeoAccount} for loading later.
@@ -60,7 +60,7 @@ public interface AccountStore {
      *
      * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
      */
-    void saveAccount(@NotNull VimeoAccount vimeoAccount);
+    void saveNonUserAccount(@NotNull VimeoAccount vimeoAccount);
 
     /**
      * Removes the saved {@link VimeoAccount} from storage

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -46,7 +46,7 @@ public interface AccountStore {
      * Saves a {@link VimeoAccount} for loading later.
      *
      * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
-     * @param accountName  the <i>name</i> of the account that helps unique identify it in account
+     * @param accountName  the <i>name</i> of the account that helps uniquely identify it in account
      *                     stores, such as the Android AccountManager
      */
     void saveAccount(@NotNull VimeoAccount vimeoAccount, String accountName);

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -56,7 +56,7 @@ public interface AccountStore {
     /**
      * Saves a {@link VimeoAccount} for loading later.
      * <p>
-     * Use this method for saving client credential token when there is not account name.
+     * Use this method for saving client credential token when there is no account name.
      *
      * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
      */

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -34,10 +34,27 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface AccountStore {
 
+    /**
+     * Load the previously saved {@link VimeoAccount} and return it
+     *
+     * @return null if no VimeoAccount could be loaded
+     */
     @Nullable
     VimeoAccount loadAccount();
 
-    void saveAccount(@NotNull VimeoAccount vimeoAccount, String email);
+    /**
+     * Saves a {@link VimeoAccount} for loading later.
+     *
+     * @param vimeoAccount the VimeoAccount to save, should not be null when calling this method
+     * @param accountName  the <i>name</i> of the account that helps unique identify it in account
+     *                     stores, such as the Android AccountManager
+     */
+    void saveAccount(@NotNull VimeoAccount vimeoAccount, String accountName);
 
+    /**
+     * Removes the saved {@link VimeoAccount} from storage
+     *
+     * @param vimeoAccount the account to delete
+     */
     void deleteAccount(@NotNull VimeoAccount vimeoAccount);
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AccountStore.java
@@ -24,6 +24,9 @@ package com.vimeo.networking;
 
 import com.vimeo.networking.model.VimeoAccount;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Interface responsible for handling the creation, deletion, and loading of Vimeo accounts on the client.
  * <p/>
@@ -31,18 +34,10 @@ import com.vimeo.networking.model.VimeoAccount;
  */
 public interface AccountStore {
 
+    @Nullable
     VimeoAccount loadAccount();
 
-    /**
-     * @deprecated use {@link #saveAccount(VimeoAccount, String)} instead
-     * <p/>
-     * We find no use in storing the password when you can persist the {@link VimeoAccount} across
-     * application sessions.
-     */
-    @Deprecated
-    void saveAccount(VimeoAccount vimeoAccount, String email, String password);
+    void saveAccount(@NotNull VimeoAccount vimeoAccount, String email);
 
-    void saveAccount(VimeoAccount vimeoAccount, String email);
-
-    void deleteAccount(VimeoAccount vimeoAccount);
+    void deleteAccount(@NotNull VimeoAccount vimeoAccount);
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -101,7 +101,7 @@ public class Configuration {
      * Persist the {@link VimeoAccount} in the {@link AccountStore}
      *
      * @param account     the account to persist
-     * @param accountName the name of the account. Required for authenticated user account,
+     * @param accountName the name of the account. Required for authenticated user accounts,
      *                    but may be null for client credential accounts
      */
     public void saveAccount(@NotNull VimeoAccount account, String accountName) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -114,7 +114,7 @@ public class Configuration {
 
     /**
      * Persist the {@link VimeoAccount} in the {@link AccountStore} without an account
-     * name. For authenticated users, user {@link #saveAccount(VimeoAccount, String)},
+     * name. For authenticated users, use {@link #saveAccount(VimeoAccount, String)},
      * as this is meant for client credential saving, when an account name is not available.
      *
      * @param account the account to persist

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -101,27 +101,27 @@ public class Configuration {
      * Persist the {@link VimeoAccount} in the {@link AccountStore}
      * <p>
      * Account name is <b>required</b> for authenticated user accounts; for
-     * client credential account saving use {@link #saveAccount(VimeoAccount)}
+     * client credential account saving use {@link #saveNonUserAccount(VimeoAccount)}
      *
      * @param account     the account to persist
      * @param accountName the name of the account.
      */
-    public void saveAccount(@NotNull VimeoAccount account, @NotNull String accountName) {
+    public void saveAuthenticatedUserAccount(@NotNull VimeoAccount account, @NotNull String accountName) {
         if (accountStore != null) {
-            accountStore.saveAccount(account, accountName);
+            accountStore.saveAuthenticatedUserAccount(account, accountName);
         }
     }
 
     /**
      * Persist the {@link VimeoAccount} in the {@link AccountStore} without an account
-     * name. For authenticated users, use {@link #saveAccount(VimeoAccount, String)},
-     * as this is meant for client credential saving, when an account name is not available.
+     * name. For authenticated users, use {@link #saveAuthenticatedUserAccount(VimeoAccount, String)},
+     * as this is meant for client credential or code grant saving, when an account name is not available.
      *
      * @param account the account to persist
      */
-    public void saveAccount(@NotNull VimeoAccount account) {
+    public void saveNonUserAccount(@NotNull VimeoAccount account) {
         if (accountStore != null) {
-            accountStore.saveAccount(account);
+            accountStore.saveNonUserAccount(account);
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -97,18 +97,35 @@ public class Configuration {
         return new Cache(cacheDirectory, cacheSize);
     }
 
-    public void saveAccount(@NotNull VimeoAccount account, String email) {
+    /**
+     * Persist the {@link VimeoAccount} in the {@link AccountStore}
+     *
+     * @param account     the account to persist
+     * @param accountName the name of the account. Required for authenticated user account,
+     *                    but may be null for client credential accounts
+     */
+    public void saveAccount(@NotNull VimeoAccount account, String accountName) {
         if (accountStore != null) {
-            accountStore.saveAccount(account, email);
+            accountStore.saveAccount(account, accountName);
         }
     }
 
+    /**
+     * Remove the {@link VimeoAccount} from the {@link AccountStore}
+     *
+     * @param account the account to remove
+     */
     public void deleteAccount(@NotNull VimeoAccount account) {
         if (accountStore != null) {
             accountStore.deleteAccount(account);
         }
     }
 
+    /**
+     * Load the {@link VimeoAccount} from the {@link AccountStore}
+     *
+     * @return the loaded account, or null if none could be loaded
+     */
     @Nullable
     public VimeoAccount loadAccount() {
         if (accountStore == null) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -26,6 +26,7 @@ import com.vimeo.networking.Vimeo.LogLevel;
 import com.vimeo.networking.logging.LogProvider;
 import com.vimeo.networking.model.VimeoAccount;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -96,24 +97,13 @@ public class Configuration {
         return new Cache(cacheDirectory, cacheSize);
     }
 
-    /**
-     * @deprecated use {@link #saveAccount(VimeoAccount, String)} instead
-     * <p/>
-     * We find no use in storing the password when you can persist the {@link VimeoAccount} across
-     * application sessions.
-     */
-    @Deprecated
-    public void saveAccount(VimeoAccount account, String email, String password) {
-        saveAccount(account, email);
-    }
-
-    public void saveAccount(VimeoAccount account, String email) {
+    public void saveAccount(@NotNull VimeoAccount account, String email) {
         if (accountStore != null) {
             accountStore.saveAccount(account, email);
         }
     }
 
-    public void deleteAccount(VimeoAccount account) {
+    public void deleteAccount(@NotNull VimeoAccount account) {
         if (accountStore != null) {
             accountStore.deleteAccount(account);
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -99,14 +99,29 @@ public class Configuration {
 
     /**
      * Persist the {@link VimeoAccount} in the {@link AccountStore}
+     * <p>
+     * Account name is <b>required</b> for authenticated user accounts; for
+     * client credential account saving use {@link #saveAccount(VimeoAccount)}
      *
      * @param account     the account to persist
-     * @param accountName the name of the account. Required for authenticated user accounts,
-     *                    but may be null for client credential accounts
+     * @param accountName the name of the account.
      */
-    public void saveAccount(@NotNull VimeoAccount account, String accountName) {
+    public void saveAccount(@NotNull VimeoAccount account, @NotNull String accountName) {
         if (accountStore != null) {
             accountStore.saveAccount(account, accountName);
+        }
+    }
+
+    /**
+     * Persist the {@link VimeoAccount} in the {@link AccountStore} without an account
+     * name. For authenticated users, user {@link #saveAccount(VimeoAccount, String)},
+     * as this is meant for client credential saving, when an account name is not available.
+     *
+     * @param account the account to persist
+     */
+    public void saveAccount(@NotNull VimeoAccount account) {
+        if (accountStore != null) {
+            accountStore.saveAccount(account);
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -445,8 +445,6 @@ public final class VimeoClient {
 
         VimeoAccount vimeoAccount = executeAccountCall(call);
 
-        saveAccount(vimeoAccount, accountName);
-
         return vimeoAccount;
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -223,7 +223,12 @@ public final class VimeoClient {
 
     /**
      * Sets the {@link #mVimeoAccount} field as well as triggering the saveAccount event for the
-     * account store
+     * account store.
+     *
+     * @param vimeoAccount The account to save - this should be provided; if it is not, then one will
+     *                     be constructed using the access token set on the {@link Configuration}.
+     * @param email        Email should be provided if the account is for an authenticated user. It may
+     *                     be null if the account represents a client credentials grant.
      */
     public void saveAccount(@Nullable VimeoAccount vimeoAccount, String email) {
         setVimeoAccount(vimeoAccount);
@@ -417,7 +422,6 @@ public final class VimeoClient {
     /**
      * Synchronous version of {@link #singleSignOnTokenExchange(String, AuthCallback)}. This is useful
      * when already running in a background thread, such as when using the Android AccountManager.
-     * See the documentation of {@link #singleSignOnTokenExchange(String, AuthCallback)} for more info.
      *
      * @param token           the authenticated user access token from application A. This <b>cannot</b> be a client
      *                        credentials access token.
@@ -427,6 +431,7 @@ public final class VimeoClient {
      *                        account authenticator, which runs on the first app installed, we need
      *                        to pass in that token
      * @return A {@link VimeoAccount} if the sign on worked, or null
+     * @see #singleSignOnTokenExchange(String, AuthCallback)
      */
     @Nullable
     public VimeoAccount singleSignOnTokenExchange(@NotNull String token, @NotNull String accountName,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -127,7 +127,16 @@ public final class VimeoClient {
 
         VimeoAccount vimeoAccount = mConfiguration.loadAccount();
         if (vimeoAccount == null) {
-            configureAccessTokenAccount();
+            String accessToken = mConfiguration.accessToken;
+            // No need to have an else here - consumers should be
+            // checking to see if they are authenticated before making
+            // any requests. A use case is if the account could not
+            // be loaded due to lack of auth token, but other account
+            // details exist, for which the client can then use to
+            // get another token.
+            if (accessToken != null) {
+                configureAccessTokenAccount(accessToken);
+            }
         } else {
             setVimeoAccount(vimeoAccount);
         }
@@ -229,18 +238,18 @@ public final class VimeoClient {
     }
 
     /**
-     * This will configure a {@link VimeoAccount} using the access token provided to the
-     * {@link Configuration}.
+     * This will configure a {@link VimeoAccount} using the access token provided. This
+     * token should have been set on the {@link Configuration} before initializing this library.
+     *
+     * @param accessToken the access token to use.
      */
-    private void configureAccessTokenAccount() {
-        if (mConfiguration.accessToken != null) {
-            // If the provided account was null but we have an access token, persist the vimeo account with
-            // just a token in it. Otherwise we'll want to leave the persisted account as null.
-            VimeoAccount vimeoAccount = new VimeoAccount(mConfiguration.accessToken);
-            mConfiguration.saveNonUserAccount(vimeoAccount);
+    private void configureAccessTokenAccount(@NotNull String accessToken) {
+        // If the provided account was null but we have an access token, persist the vimeo account with
+        // just a token in it. Otherwise we'll want to leave the persisted account as null.
+        VimeoAccount vimeoAccount = new VimeoAccount(accessToken);
+        mConfiguration.saveNonUserAccount(vimeoAccount);
 
-            setVimeoAccount(vimeoAccount);
-        }
+        setVimeoAccount(vimeoAccount);
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -214,7 +214,7 @@ public final class VimeoClient {
             // just a token in it. Otherwise we'll want to leave the persisted account as null.
             vimeoAccount = new VimeoAccount(mConfiguration.accessToken);
             if (mConfiguration.accessToken != null) {
-                mConfiguration.saveAccount(vimeoAccount, null);
+                mConfiguration.saveAccount(vimeoAccount);
             }
         }
 
@@ -230,10 +230,14 @@ public final class VimeoClient {
      * @param accountName  accountName should be provided if the account is for an authenticated user. It may
      *                     be null if the account represents a client credentials grant.
      */
-    public void saveAccount(@Nullable VimeoAccount vimeoAccount, String accountName) {
+    public void saveAccount(@Nullable VimeoAccount vimeoAccount, @Nullable String accountName) {
         setVimeoAccount(vimeoAccount);
         if (vimeoAccount != null) {
-            mConfiguration.saveAccount(vimeoAccount, accountName);
+            if (accountName != null) {
+                mConfiguration.saveAccount(vimeoAccount, accountName);
+            } else {
+                mConfiguration.saveAccount(vimeoAccount);
+            }
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -427,14 +427,16 @@ public final class VimeoClient {
      * Synchronous version of {@link #singleSignOnTokenExchange(String, AuthCallback)}. This is useful
      * when already running in a background thread, such as when using the Android AccountManager.
      *
-     * @param token           the authenticated user access token from application A. This <b>cannot</b> be a client
-     *                        credentials access token.
+     * @param token           the authenticated user access token from application A. This <b>cannot</b> be
+     *                        a client credentials access token. It must be granted via password, Facebook,
+     *                        or another means of logging a specific user in.
      * @param accountName     the name of the account, usually the email
      * @param basicAuthHeader a "basic" auth header to pass in; the basic auth header should be from
      *                        the application that needs the new token. In the case of the Android
      *                        account authenticator, which runs on the first app installed, we need
-     *                        to pass in that token. If this is null, then {@link #getBasicAuthHeader()}
-     *                        will be used.
+     *                        to pass in the auth header for the app that needs the token swap, rather
+     *                        than the app the is executing this method. If this is null, then
+     *                        {@link #getBasicAuthHeader()} will be used.
      * @return A {@link VimeoAccount} if the sign on worked, or null
      * @see #singleSignOnTokenExchange(String, AuthCallback)
      */

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -227,13 +227,13 @@ public final class VimeoClient {
      *
      * @param vimeoAccount The account to save - this should be provided; if it is not, then one will
      *                     be constructed using the access token set on the {@link Configuration}.
-     * @param email        Email should be provided if the account is for an authenticated user. It may
+     * @param accountName  accountName should be provided if the account is for an authenticated user. It may
      *                     be null if the account represents a client credentials grant.
      */
-    public void saveAccount(@Nullable VimeoAccount vimeoAccount, String email) {
+    public void saveAccount(@Nullable VimeoAccount vimeoAccount, String accountName) {
         setVimeoAccount(vimeoAccount);
         if (vimeoAccount != null) {
-            mConfiguration.saveAccount(vimeoAccount, email);
+            mConfiguration.saveAccount(vimeoAccount, accountName);
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -419,16 +419,24 @@ public final class VimeoClient {
      * when already running in a background thread, such as when using the Android AccountManager.
      * See the documentation of {@link #singleSignOnTokenExchange(String, AuthCallback)} for more info.
      *
-     * @param token       the authenticated user access token from application A. This <b>cannot</b> be a client
-     *                    credentials access token.
-     * @param accountName the name of the account, usually the email
+     * @param token           the authenticated user access token from application A. This <b>cannot</b> be a client
+     *                        credentials access token.
+     * @param accountName     the name of the account, usually the email
+     * @param basicAuthHeader a "basic" auth header to pass in; the basic auth header should be from
+     *                        the application that needs the new token. In the case of the Android
+     *                        account authenticator, which runs on the first app installed, we need
+     *                        to pass in that token
      * @return A {@link VimeoAccount} if the sign on worked, or null
      */
     @Nullable
-    public VimeoAccount singleSignOnTokenExchange(@NotNull String token, @NotNull String accountName) {
+    public VimeoAccount singleSignOnTokenExchange(@NotNull String token, @NotNull String accountName,
+                                                  @Nullable String basicAuthHeader) {
 
+        if (basicAuthHeader == null) {
+            basicAuthHeader = getBasicAuthHeader();
+        }
         Call<VimeoAccount> call =
-                mVimeoService.ssoTokenExchange(getBasicAuthHeader(), token, mConfiguration.scope);
+                mVimeoService.ssoTokenExchange(basicAuthHeader, token, mConfiguration.scope);
 
         VimeoAccount vimeoAccount = executeAccountCall(call);
 
@@ -1516,7 +1524,7 @@ public final class VimeoClient {
         return credential;
     }
 
-    private String getBasicAuthHeader() {
+    public String getBasicAuthHeader() {
         return Credentials.basic(mConfiguration.clientID, mConfiguration.clientSecret);
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -429,7 +429,8 @@ public final class VimeoClient {
      * @param basicAuthHeader a "basic" auth header to pass in; the basic auth header should be from
      *                        the application that needs the new token. In the case of the Android
      *                        account authenticator, which runs on the first app installed, we need
-     *                        to pass in that token
+     *                        to pass in that token. If this is null, then {@link #getBasicAuthHeader()}
+     *                        will be used.
      * @return A {@link VimeoAccount} if the sign on worked, or null
      * @see #singleSignOnTokenExchange(String, AuthCallback)
      */
@@ -600,6 +601,11 @@ public final class VimeoClient {
             if (response.isSuccessful()) {
                 return response.body();
             }
+            String responseError = "";
+            if (response.errorBody() != null) {
+                responseError = response.errorBody().string();
+            }
+            ClientLogger.e("Unsuccessful response getting account: " + responseError);
         } catch (IOException e) {
             ClientLogger.e("Exception during executeAccountCall: " + e.getMessage(), e);
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -68,32 +68,34 @@ public class VimeoAccount implements Serializable {
      * Constructor for use for developers making requests with only one account. Provide your access
      * token to the Configuration Builder and this constructor will be used to set up your authentication.
      * <p>
-     * Providing a null access token will prevent your requests from succeeding.
-     * <p>
      * See the README of this library for more information.
      *
      * @param accessToken your access token.
      * @see "https://github.com/vimeo/vimeo-networking-java#initialization"
      */
-    public VimeoAccount(@Nullable String accessToken) {
+    public VimeoAccount(@NotNull String accessToken) {
+        //noinspection ConstantConditions
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new AssertionError("Account must be created with token");
+        }
+
         mAccessToken = accessToken;
     }
 
     /**
      * Using this constructor is to create an account manually. It is recommended that if you cannot obtain
-     * a valid access token, to have this class constructed automantically using one of the authentication
+     * a valid access token, to have this class constructed automatically using one of the authentication
      * methods in VimeoClient.
      *
-     * @param accessToken May be null here, but it <i>must</i> be set using {@link #setAccessToken(String)}
-     *                    <i>before</i> making any authenticated requests. Without passing in an access
-     *                    token, requests using this VimeoAccount will fail!
+     * @param accessToken The authentication token
      * @param tokenType   The token type. May be set to a value to pair with an access token.
      * @param scope       The scope of the access token
-     * @param userJSON    A {@link User} represented in a JSON string
+     * @param userJson    A {@link User} represented in a JSON string
      */
-    public VimeoAccount(@Nullable String accessToken, @NotNull String tokenType, @NotNull String scope,
-                        String userJSON) {
-        if ((accessToken != null && accessToken.isEmpty()) || tokenType == null || tokenType.isEmpty() ||
+    public VimeoAccount(@NotNull String accessToken, @NotNull String tokenType, @NotNull String scope,
+                        @Nullable String userJson) {
+        //noinspection ConstantConditions
+        if (accessToken == null || accessToken.isEmpty() || tokenType == null || tokenType.isEmpty() ||
             scope == null || scope.isEmpty()) {
             throw new AssertionError("Account can only be created with token, tokenType, scope");
         }
@@ -102,11 +104,11 @@ public class VimeoAccount implements Serializable {
         mTokenType = tokenType;
         mScope = scope;
 
-        if (userJSON != null) {
+        if (userJson != null) {
             Gson gson = VimeoNetworkUtil.getGson();
 
-            mUser = gson.fromJson(userJSON, User.class);
-            mUserJson = userJSON;
+            mUser = gson.fromJson(userJson, User.class);
+            mUserJson = userJson;
         }
     }
 
@@ -123,17 +125,6 @@ public class VimeoAccount implements Serializable {
     @Nullable
     public String getAccessToken() {
         return mAccessToken;
-    }
-
-    /**
-     * Sets the auth token. This should only be used when there is no auth token set, or it otherwise
-     * needs to change. If changed, this {@link VimeoAccount} should be set and saved in the client
-     * for use.
-     *
-     * @param accessToken the new auth token
-     */
-    public void setAccessToken(@Nullable String accessToken) {
-        mAccessToken = accessToken;
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -172,8 +172,9 @@ public class VimeoAccount implements Serializable {
     private void createUserJson() {
         if (mUser == null) {
             mUserJson = null;
+        } else {
+            Gson gson = VimeoNetworkUtil.getGson();
+            mUserJson = gson.toJson(mUser);
         }
-        Gson gson = VimeoNetworkUtil.getGson();
-        mUserJson = gson.toJson(mUserJson);
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -43,27 +43,29 @@ public class VimeoAccount implements Serializable {
 
     @Nullable
     @GsonAdapterKey("access_token")
-    public String accessToken;
+    public String mAccessToken;
 
     @Nullable
     @GsonAdapterKey("token_type")
-    public String tokenType;
+    public String mTokenType;
 
     @Nullable
     @GsonAdapterKey("scope")
-    public String scope;
+    public String mScope;
 
     @Nullable
     @GsonAdapterKey("user")
-    public User user;
-    private String userJSON;
+    public User mUser;
+
+    @Nullable
+    private String mUserJson;
 
     public VimeoAccount() {
         //constructor for stag TypeAdapter generation
     }
 
     public VimeoAccount(@Nullable String accessToken) {
-        this.accessToken = accessToken;
+        mAccessToken = accessToken;
     }
 
     public VimeoAccount(@Nullable String accessToken, @NotNull String tokenType, @NotNull String scope,
@@ -73,59 +75,105 @@ public class VimeoAccount implements Serializable {
             throw new AssertionError("Account can only be created with token, tokenType, scope");
         }
 
-        this.accessToken = accessToken;
-        this.tokenType = tokenType;
-        this.scope = scope;
+        mAccessToken = accessToken;
+        mTokenType = tokenType;
+        mScope = scope;
 
         if (userJSON != null) {
             Gson gson = VimeoNetworkUtil.getGson();
 
-            this.user = gson.fromJson(userJSON, User.class);
+            mUser = gson.fromJson(userJSON, User.class);
         }
     }
 
+    /**
+     * @return true if the access token is not empty, false if it is null or empty
+     */
     public boolean isAuthenticated() {
-        return (this.accessToken != null && !this.accessToken.isEmpty());
+        return (mAccessToken != null && !mAccessToken.isEmpty());
     }
 
+    /**
+     * @return the access (auth) token stored with this account
+     */
     @Nullable
     public String getAccessToken() {
-        return this.accessToken;
+        return mAccessToken;
     }
 
+    /**
+     * Sets the auth token. This should only be used when there is no auth token set, or it otherwise
+     * needs to change. If changed, this {@link VimeoAccount} should be set and saved in the client
+     * for use.
+     *
+     * @param accessToken the new auth token
+     */
+    public void setAccessToken(@Nullable String accessToken) {
+        mAccessToken = accessToken;
+    }
+
+    /**
+     * @return the token type that is stored with this account
+     */
     @Nullable
     public String getTokenType() {
-        return this.tokenType;
+        return mTokenType;
     }
 
+    /**
+     * @return The scope that is stored with this account
+     */
     @Nullable
     public String getScope() {
-        return this.scope;
+        return mScope;
     }
 
+    /**
+     * Get the user represented by this account
+     *
+     * @return the user, or null if no user is represented by the account
+     */
     @Nullable
     public User getUser() {
-        return this.user;
+        return mUser;
     }
 
+    /**
+     * Set the user on the account. When changing the user, the account should be set and saved by the client
+     *
+     * @param user the new user on the account
+     */
     public void setUser(@Nullable User user) {
-        this.user = user;
+        mUser = user;
+
+        createUserJson();
     }
 
+    /**
+     * Get the user represented as a JSON string
+     *
+     * @return the user in a JSON format, null if there is no user
+     */
     @Nullable
     public String getUserJSON() {
-        if (this.user == null) {
+        if (mUser == null) {
             return null;
         }
 
-        if (this.userJSON != null) {
-            return this.userJSON;
+        if (mUserJson != null) {
+            return mUserJson;
         }
 
+        createUserJson();
+
+        return mUserJson;
+    }
+
+    private void createUserJson() {
+        if (mUser == null) {
+            mUserJson = null;
+        }
         Gson gson = VimeoNetworkUtil.getGson();
-
-        this.userJSON = gson.toJson(this.user);
-
-        return this.userJSON;
+        mUserJson = gson.toJson(mUserJson);
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -83,9 +83,9 @@ public class VimeoAccount implements Serializable {
     }
 
     /**
-     * Using this constructor is to create an account manually. It is recommended that if you cannot obtain
-     * a valid access token, to have this class constructed automatically using one of the authentication
-     * methods in VimeoClient.
+     * Use this constructor to create an account manually. If you cannot obtain a valid access token,
+     * it is recommended to have a VimeoAccount constructed automatically using one of the
+     * authentication methods in VimeoClient rather than calling this constructor directly.
      *
      * @param accessToken The authentication token
      * @param tokenType   The token type. May be set to a value to pair with an access token.
@@ -190,6 +190,28 @@ public class VimeoAccount implements Serializable {
         } else {
             Gson gson = VimeoNetworkUtil.getGson();
             mUserJson = gson.toJson(mUser);
+        }
+    }
+
+    /**
+     * Copies one VimeoAccount into another
+     *
+     * @param other the account to copy
+     * @return a new VimeoAccount, with the details of the other
+     */
+    @Nullable
+    public static VimeoAccount copy(final VimeoAccount other) {
+        String accessToken = other.getAccessToken();
+        String tokenType = other.getTokenType();
+        String scope = other.getScope();
+        String userJson = other.getUserJSON();
+
+        if (accessToken != null && tokenType != null && scope != null) {
+            return new VimeoAccount(accessToken, tokenType, scope, userJson);
+        } else if (accessToken != null) {
+            return new VimeoAccount(accessToken);
+        } else {
+            return null;
         }
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
 import com.vimeo.stag.GsonAdapterKey;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
@@ -39,19 +40,25 @@ import java.io.Serializable;
 public class VimeoAccount implements Serializable {
 
     private static final long serialVersionUID = -8341071767843490585L;
-    //    private static final String TOKEN_TYPE_BEARER = "bearer";
 
+    @Nullable
     @GsonAdapterKey("access_token")
     public String accessToken;
+
+    @Nullable
     @GsonAdapterKey("token_type")
     public String tokenType;
+
+    @Nullable
     @GsonAdapterKey("scope")
     public String scope;
+
+    @Nullable
     @GsonAdapterKey("user")
     public User user;
     private String userJSON;
 
-    public VimeoAccount(){
+    public VimeoAccount() {
         //constructor for stag TypeAdapter generation
     }
 
@@ -59,9 +66,10 @@ public class VimeoAccount implements Serializable {
         this.accessToken = accessToken;
     }
 
-    public VimeoAccount(String accessToken, String tokenType, String scope, String userJSON) {
-        if (accessToken == null || accessToken.isEmpty() || tokenType == null ||
-            tokenType.isEmpty() || scope == null || scope.isEmpty()) {
+    public VimeoAccount(@Nullable String accessToken, @NotNull String tokenType, @NotNull String scope,
+                        String userJSON) {
+        if ((accessToken != null && accessToken.isEmpty()) || tokenType == null || tokenType.isEmpty() ||
+            scope == null || scope.isEmpty()) {
             throw new AssertionError("Account can only be created with token, tokenType, scope");
         }
 
@@ -69,23 +77,28 @@ public class VimeoAccount implements Serializable {
         this.tokenType = tokenType;
         this.scope = scope;
 
-        Gson gson = VimeoNetworkUtil.getGson();
+        if (userJSON != null) {
+            Gson gson = VimeoNetworkUtil.getGson();
 
-        this.user = gson.fromJson(userJSON, User.class);
+            this.user = gson.fromJson(userJSON, User.class);
+        }
     }
 
     public boolean isAuthenticated() {
         return (this.accessToken != null && !this.accessToken.isEmpty());
     }
 
+    @Nullable
     public String getAccessToken() {
         return this.accessToken;
     }
 
+    @Nullable
     public String getTokenType() {
         return this.tokenType;
     }
 
+    @Nullable
     public String getScope() {
         return this.scope;
     }
@@ -95,13 +108,12 @@ public class VimeoAccount implements Serializable {
         return this.user;
     }
 
-    public void setUser(User user) {
+    public void setUser(@Nullable User user) {
         this.user = user;
     }
 
     @Nullable
-    public String getUserJSON() // For AccountManager.userData [AH]
-    {
+    public String getUserJSON() {
         if (this.user == null) {
             return null;
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -83,6 +83,7 @@ public class VimeoAccount implements Serializable {
             Gson gson = VimeoNetworkUtil.getGson();
 
             mUser = gson.fromJson(userJSON, User.class);
+            mUserJson = userJSON;
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -64,10 +64,33 @@ public class VimeoAccount implements Serializable {
         //constructor for stag TypeAdapter generation
     }
 
+    /**
+     * Constructor for use for developers making requests with only one account. Provide your access
+     * token to the Configuration Builder and this constructor will be used to set up your authentication.
+     * <p>
+     * Providing a null access token will prevent your requests from succeeding.
+     * <p>
+     * See the README of this library for more information.
+     *
+     * @param accessToken your access token.
+     * @see "https://github.com/vimeo/vimeo-networking-java#initialization"
+     */
     public VimeoAccount(@Nullable String accessToken) {
         mAccessToken = accessToken;
     }
 
+    /**
+     * Using this constructor is to create an account manually. It is recommended that if you cannot obtain
+     * a valid access token, to have this class constructed automantically using one of the authentication
+     * methods in VimeoClient.
+     *
+     * @param accessToken May be null here, but it <i>must</i> be set using {@link #setAccessToken(String)}
+     *                    <i>before</i> making any authenticated requests. Without passing in an access
+     *                    token, requests using this VimeoAccount will fail!
+     * @param tokenType   The token type. May be set to a value to pair with an access token.
+     * @param scope       The scope of the access token
+     * @param userJSON    A {@link User} represented in a JSON string
+     */
     public VimeoAccount(@Nullable String accessToken, @NotNull String tokenType, @NotNull String scope,
                         String userJSON) {
         if ((accessToken != null && accessToken.isEmpty()) || tokenType == null || tokenType.isEmpty() ||


### PR DESCRIPTION
#### Ticket
[VA-1728](https://vimean.atlassian.net/browse/VA-1728)

#### Ticket Summary
We need to make a few adjustments to the networking code to improve auth within the apps

#### Implementation Summary
The main aspect of this ticket was to create a synchronous version of the single sign on method, that can be passed a basic auth string. This is needed since this will be called from a background thread within the Android AccountManager system (getAuthToken), and we need the basic auth header of the requesting app, not the basic auth header of the running app - the running app is always the first installed app with a Vimeo AccountManager (authenticator)

Side effect are cleaning up some of the deprecated methods around the AccountStore, and adding annotation.s

#### How to Test
Use the VA-1728 branches in vimeo-kit and VimeoMobile to test