### PR TITLE
ANDTV-224 Vod Seasons 

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -112,6 +112,9 @@ public class ConnectionCollection implements Serializable {
     @GsonAdapterKey("season")
     public Connection season;
     @Nullable
+    @GsonAdapterKey("seasons")
+    public Connection seasons;
+    @Nullable
     @GsonAdapterKey("trailer")
     public Connection trailer;
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
@@ -1,5 +1,7 @@
 package com.vimeo.networking.model.vod;
 
+import com.vimeo.networking.model.Connection;
+import com.vimeo.networking.model.ConnectionCollection;
 import com.vimeo.networking.model.Metadata;
 import com.vimeo.networking.model.User;
 import com.vimeo.stag.GsonAdapterKey;
@@ -135,6 +137,29 @@ public class Season implements Serializable {
         return mResourceKey;
     }
 
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Helpers">
+
+    @Nullable
+    public ConnectionCollection getConnections() {
+        return mMetadata != null ? mMetadata.connections : null;
+    }
+
+    @Nullable
+    public Connection getVideosConnection() {
+        ConnectionCollection connections = getConnections();
+        return connections != null ? connections.videos : null;
+    }
+
+    @Nullable
+    public String getVideosUri() {
+        Connection videos = getVideosConnection();
+        return videos != null ? videos.getUri() : null;
+    }
     // </editor-fold>
 
     // -----------------------------------------------------------------------------------------------------

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
@@ -25,6 +25,7 @@
 package com.vimeo.networking.model.vod;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.Connection;
 import com.vimeo.networking.model.ConnectionCollection;
 import com.vimeo.networking.model.InteractionCollection;
 import com.vimeo.networking.model.Metadata;
@@ -185,18 +186,32 @@ public class VodItem implements Serializable {
     }
 
     public int getViewableVideoCount() {
-        if (mMetadata != null && mMetadata.connections != null && mMetadata.connections.videos != null) {
-            return mMetadata.connections.videos.viewableTotal;
-        }
-        return 0;
+        Connection videos = getVideosConnection();
+        return videos != null ? videos.getViewableTotal() : 0;
     }
 
     @Nullable
     public String getVideosUri() {
-        if (mMetadata != null && mMetadata.connections != null && mMetadata.connections.videos != null) {
-            return mMetadata.connections.videos.uri;
-        }
-        return null;
+        Connection videos = getVideosConnection();
+        return videos != null ? videos.getUri() : null;
+    }
+
+    @Nullable
+    public Connection getVideosConnection() {
+        ConnectionCollection connections = getConnections();
+        return connections != null ? connections.videos : null;
+    }
+
+    @Nullable
+    public Connection getSeasonsConnection() {
+        ConnectionCollection connections = getConnections();
+        return connections != null ? connections.seasons : null;
+    }
+
+    @Nullable
+    public String getSeasonsUri() {
+        Connection seasons = getSeasonsConnection();
+        return seasons != null ? seasons.getUri() : null;
     }
 
     public void setName(@Nullable String name) {


### PR DESCRIPTION
#### Ticket
[ANDTV-224](https://vimean.atlassian.net/browse/ANDTV-224)

#### Ticket Summary
In order to dynamically add seasons to the rows fragment on tv, we will need to get the seasons uri from the API. Also we should have simple helper accessing methods for this.

#### Implementation Summary
I added in the connection and some simple helpers for ```VodItem``` and ```Season```

#### How to Test
Nothing to test
