### PR TITLE
ANDTV-281 adding support for terms and privacy

### DIFF
--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     compile 'com.intellij:annotations:12.0@jar'
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.vimeo.stag:stag-library:1.0.1'
-    apt 'com.vimeo.stag:stag-library-compiler:1.0.1'
+    compile 'com.vimeo.stag:stag-library:1.1.1'
+    apt 'com.vimeo.stag:stag-library-compiler:1.1.1'
 }
 
 group = 'com.vimeo.networking'

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -48,9 +48,9 @@ public final class Vimeo {
     // Endpoints
     public static final String ENDPOINT_ME = "me";
     public static final String ENDPOINT_RECOMMENDATIONS = "/recommendations";
-    public static final String ENDPOINT_TERMS_OF_SERVICE = "termsofservice";
-    public static final String ENDPOINT_PRIVACY_POLICY = "privacy";
-    public static final String ENDPOINT_PAYMENT_ADDENDUM = "paymentaddendum";
+    public static final String ENDPOINT_TERMS_OF_SERVICE = "documents/termsofservice";
+    public static final String ENDPOINT_PRIVACY_POLICY = "documents/privacy";
+    public static final String ENDPOINT_PAYMENT_ADDENDUM = "documents/paymentaddendum";
 
     // Parameters
     public static final String PARAMETER_REDIRECT_URI = "redirect_uri";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -27,7 +27,7 @@ package com.vimeo.networking;
  * <p/>
  * Created by kylevenn on 7/7/15.
  */
-public class Vimeo {
+public final class Vimeo {
 
     public static final String VIMEO_BASE_URL_STRING = "https://api.vimeo.com/";
 
@@ -48,6 +48,9 @@ public class Vimeo {
     // Endpoints
     public static final String ENDPOINT_ME = "me";
     public static final String ENDPOINT_RECOMMENDATIONS = "/recommendations";
+    public static final String ENDPOINT_TERMS_OF_SERVICE = "termsofservice";
+    public static final String ENDPOINT_PRIVACY_POLICY = "privacy";
+    public static final String ENDPOINT_PAYMENT_ADDENDUM = "paymentaddendum";
 
     // Parameters
     public static final String PARAMETER_REDIRECT_URI = "redirect_uri";
@@ -216,5 +219,8 @@ public class Vimeo {
     public enum LogLevel {
         // 0      1       2     3
         VERBOSE, DEBUG, ERROR, NONE
+    }
+
+    private Vimeo() {
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -992,8 +992,16 @@ public final class VimeoClient {
         return getDocument(Vimeo.ENDPOINT_PAYMENT_ADDENDUM, callback);
     }
 
+    /**
+     * Gets a {@link Document} at the provided uri. When finished, the callback will be invoked.
+     *
+     * @param uri      the uri of the Document
+     * @param callback the {@link ModelCallback} to be invoked when the request finishes
+     * @return a {@link Call} with the {@link Document} type. This can be used for request
+     * cancellation.
+     */
     @NotNull
-    private Call<Document> getDocument(@NotNull String uri, @NotNull ModelCallback<Document> callback) {
+    public Call<Document> getDocument(@NotNull String uri, @NotNull ModelCallback<Document> callback) {
         Call<Document> call = mVimeoService.getDocument(getAuthHeader(), uri);
         call.enqueue(callback);
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -30,6 +30,7 @@ import com.vimeo.networking.callbacks.VimeoCallback;
 import com.vimeo.networking.logging.ClientLogger;
 import com.vimeo.networking.logging.LoggingInterceptor;
 import com.vimeo.networking.model.Comment;
+import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
 import com.vimeo.networking.model.Privacy;
@@ -948,6 +949,56 @@ public final class VimeoClient {
         return call;
     }
 
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
+    // Documents
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Documents">
+
+    /**
+     * An asynchronous request to get a {@link Document} representing the Vimeo Terms of Service
+     *
+     * @param callback the {@link ModelCallback} to be invoked when the request finishes
+     * @return a {@link Call} with the {@link Document} type. This can be used for request
+     * cancellation.
+     */
+    @NotNull
+    public Call<Document> getTermsOfService(@NotNull ModelCallback<Document> callback) {
+        return getDocument(Vimeo.ENDPOINT_TERMS_OF_SERVICE, callback);
+    }
+
+    /**
+     * An asynchronous request to get a {@link Document} representing the Vimeo Privacy Policy
+     *
+     * @param callback the {@link ModelCallback} to be invoked when the request finishes
+     * @return a {@link Call} with the {@link Document} type. This can be used for request
+     * cancellation.
+     */
+    @NotNull
+    public Call<Document> getPrivacyPolicy(@NotNull ModelCallback<Document> callback) {
+        return getDocument(Vimeo.ENDPOINT_PRIVACY_POLICY, callback);
+    }
+
+    /**
+     * An asynchronous request to get a {@link Document} representing the Vimeo Payment Addendum
+     *
+     * @param callback the {@link ModelCallback} to be invoked when the request finishes
+     * @return a {@link Call} with the {@link Document} type. This can be used for request
+     * cancellation.
+     */
+    @NotNull
+    public Call<Document> getPaymentAddendum(@NotNull ModelCallback<Document> callback) {
+        return getDocument(Vimeo.ENDPOINT_PAYMENT_ADDENDUM, callback);
+    }
+
+    @NotNull
+    private Call<Document> getDocument(@NotNull String uri, @NotNull ModelCallback<Document> callback) {
+        Call<Document> call = mVimeoService.getDocument(getAuthHeader(), uri);
+        call.enqueue(callback);
+
+        return call;
+    }
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -23,6 +23,7 @@
 package com.vimeo.networking;
 
 import com.vimeo.networking.model.Comment;
+import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
 import com.vimeo.networking.model.Video;
@@ -162,6 +163,9 @@ public interface VimeoService {
     Call<Video> getVideo(@Header("Authorization") String authHeader,
                          @Header("Cache-Control") String cacheHeaderValue, @Url String uri,
                          @QueryMap Map<String, String> options);
+
+    @GET
+    Call<Document> getDocument(@Header("Authorization") String authHeader, @Url String uri);
     // </editor-fold>
 
     /**
@@ -189,8 +193,7 @@ public interface VimeoService {
 
     @POST
     Call<Object> POST(@Header("Authorization") String authHeader, @Url String uri,
-                      @Header("Cache-Control") String cacheHeaderValue,
-                      @Body ArrayList<Object> parameters);
+                      @Header("Cache-Control") String cacheHeaderValue, @Body ArrayList<Object> parameters);
     // </editor-fold>
 
     // -----------------------------------------------------------------------------------------------------

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Document.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Document.java
@@ -1,0 +1,27 @@
+package com.vimeo.networking.model;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A model used when retrieving documents from the API, such as Privacy Policy,
+ * Terms of Service, and Payment Addendum
+ * <p>
+ * Created by zetterstromk on 11/7/16.
+ */
+public class Document implements Serializable {
+
+    private static final long serialVersionUID = -8676604257868932660L;
+
+    @GsonAdapterKey("html")
+    @Nullable
+    String mHtml;
+
+    @Nullable
+    public String getHtml() {
+        return mHtml;
+    }
+}


### PR DESCRIPTION
#### Ticket
[ANDTV-281](https://vimean.atlassian.net/browse/ANDTV-281)

#### Ticket Summary
Add API support for several documents, including Terms of Service, Privacy Policy, and the Payment Addendum.

#### Implementation Summary
* Updated stag in order to take advantage of package-private members.
* Added a Document model representing the API responses for these documents
* Added a service method to fetch a Document
* Added several VimeoClient methods to fetch the different documents

TODO:
- [x] Update the URLs once the API changes them

#### How to Test
Use the branches of vimeo-kit and vimeo TV of the same name to verify the documents can be fetched and displayed

