### PR TITLE
VA-2112 Add toString for notification analytics

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
@@ -36,11 +36,6 @@ public enum NotificationType {
         }
     }
 
-    @Override
-    public String toString() {
-        return stringFromNotificationType(this);
-    }
-
     @Nullable
     public static String stringFromNotificationType(@NotNull NotificationType type) {
         switch (type) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
@@ -1,6 +1,7 @@
 package com.vimeo.networking.model.notifications;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A simple enum describing notification types
@@ -32,6 +33,32 @@ public enum NotificationType {
                 return NOTIFICATION_TYPE_VIDEO_AVAILABLE;
             default:
                 return NOTIFICATION_TYPE_UNKNOWN;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return stringFromNotificationType(this);
+    }
+
+    @Nullable
+    public static String stringFromNotificationType(@NotNull NotificationType type) {
+        switch (type) {
+            case NOTIFICATION_TYPE_COMMENT:
+                return NotificationConstants.NOTIFICATION_COMMENT;
+            case NOTIFICATION_TYPE_CREDIT:
+                return NotificationConstants.NOTIFICATION_CREDIT;
+            case NOTIFICATION_TYPE_FOLLOW:
+                return NotificationConstants.NOTIFICATION_FOLLOW;
+            case NOTIFICATION_TYPE_LIKE:
+                return NotificationConstants.NOTIFICATION_LIKE;
+            case NOTIFICATION_TYPE_REPLY:
+                return NotificationConstants.NOTIFICATION_REPLY;
+            case NOTIFICATION_TYPE_VIDEO_AVAILABLE:
+                return NotificationConstants.NOTIFICATION_VIDEO_AVAILABLE;
+            case NOTIFICATION_TYPE_UNKNOWN:
+            default:
+                return null;
         }
     }
 


### PR DESCRIPTION
#### Ticket
[VA-2112](https://vimean.atlassian.net/browse/VA-2112)

#### Ticket Summary
Adding a toString method to NotificationType enum for analytics

#### Implementation Summary
I created a toString and a static method for getting a string key from an enum value for `NotificationType`. I opted for this approach versus a string constructor for the enum values due to the future expansion of types - I don't want the app to crash if we get additional types, instead, the type will be converted to Unknown using this approach.