### PR TITLE
VA-1890 Patch requests for notifications

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -112,6 +112,7 @@ public final class Vimeo {
     public static final String PARAMETER_GET_FILTER = "filter";
     public static final String PARAMETER_GET_UPLOAD_DATE_FILTER = "filter_upload_date";
     public static final String PARAMETER_GET_NOTIFICATION_TYPES_FILTER = "filter_notification_types";
+    public static final String PARAMETER_PATCH_LATEST_NOTIFICATION_URI = "latest_notification_uri";
 
     // Sorting (sort) Values
     public static final String SORT_DEFAULT = "default";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -111,6 +111,7 @@ public final class Vimeo {
     public static final String PARAMETER_GET_LENGTH_MAX_DURATION = "max_duration";
     public static final String PARAMETER_GET_FILTER = "filter";
     public static final String PARAMETER_GET_UPLOAD_DATE_FILTER = "filter_upload_date";
+    public static final String PARAMETER_GET_NOTIFICATION_TYPES_FILTER = "filter_notification_types";
 
     // Sorting (sort) Values
     public static final String SORT_DEFAULT = "default";
@@ -134,6 +135,7 @@ public final class Vimeo {
     public static final String FILTER_VOD_RENTALS = "rented";
     public static final String FILTER_VOD_SUBSCRIPTIONS = "subscription";
     public static final String FILTER_VOD_PURCHASES = "purchased";
+    public static final String FILTER_NOTIFICATION_TYPES = "notification_types";
     // Filter Upload Date Values
     public static final String FILTER_UPLOAD_DATE_TODAY = "day";
     public static final String FILTER_UPLOAD_DATE_WEEK = "week";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -34,12 +34,12 @@ import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
 import com.vimeo.networking.model.Privacy;
-import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.VimeoAccount;
 import com.vimeo.networking.model.error.ErrorCode;
 import com.vimeo.networking.model.error.VimeoError;
+import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.search.SearchResponse;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
 
@@ -1484,6 +1484,37 @@ public final class VimeoClient {
         }
 
         Call<Void> call = mVimeoService.emptyResponsePost(getAuthHeader(), uri, postBody);
+        call.enqueue(callback);
+        return call;
+    }
+
+    /**
+     * A PACTH call where the API doesn't return any response body. This is only handled by Retrofit
+     * if you specify a Void object response type.
+     *
+     * @param uri         URI of the resource to PATCH to
+     * @param queryParams any query parameters of the PATCH
+     * @param patchBody   the body of the PATCH, it is likely a List or a Map
+     * @param callback    the callback to be invoked upon request completion
+     */
+    @Nullable
+    public Call<Void> emptyResponsePatch(String uri, @Nullable Map<String, String> queryParams,
+                                         @Nullable Object patchBody, VimeoCallback<Void> callback) {
+        if (callback == null) {
+            throw new AssertionError("Callback cannot be null");
+        }
+
+        if (uri == null) {
+            callback.failure(new VimeoError("uri cannot be empty!"));
+
+            return null;
+        }
+
+        if (queryParams == null) {
+            queryParams = new HashMap<>();
+        }
+
+        Call<Void> call = mVimeoService.emptyResponsePatch(getAuthHeader(), uri, queryParams, patchBody);
         call.enqueue(callback);
         return call;
     }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1489,7 +1489,7 @@ public final class VimeoClient {
     }
 
     /**
-     * A PACTH call where the API doesn't return any response body. This is only handled by Retrofit
+     * A PATCH call where the API doesn't return any response body. This is only handled by Retrofit
      * if you specify a Void object response type.
      *
      * @param uri         URI of the resource to PATCH to
@@ -1497,25 +1497,16 @@ public final class VimeoClient {
      * @param patchBody   the body of the PATCH, it is likely a List or a Map
      * @param callback    the callback to be invoked upon request completion
      */
-    @Nullable
-    public Call<Void> emptyResponsePatch(String uri, @Nullable Map<String, String> queryParams,
-                                         @Nullable Object patchBody, VimeoCallback<Void> callback) {
-        if (callback == null) {
-            throw new AssertionError("Callback cannot be null");
-        }
-
-        if (uri == null) {
-            callback.failure(new VimeoError("uri cannot be empty!"));
-
-            return null;
-        }
-
+    @NotNull
+    public Call<Void> emptyResponsePatch(@NotNull String uri, @Nullable Map<String, String> queryParams,
+                                         @NotNull Object patchBody, @NotNull VimeoCallback<Void> callback) {
         if (queryParams == null) {
             queryParams = new HashMap<>();
         }
 
         Call<Void> call = mVimeoService.emptyResponsePatch(getAuthHeader(), uri, queryParams, patchBody);
         call.enqueue(callback);
+
         return call;
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -26,9 +26,9 @@ import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
-import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.VimeoAccount;
+import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.search.SearchResponse;
 
 import java.util.ArrayList;
@@ -138,6 +138,10 @@ public interface VimeoService {
     @PATCH("me/notifications/subscriptions")
     Call<SubscriptionCollection> editSubscriptions(@Header("Authorization") String authHeader,
                                                    @Body Map<String, Boolean> parameters);
+
+    @PATCH
+    Call<Void> emptyResponsePatch(@Header("Authorization") String authHeader, @Url String uri,
+                                  @QueryMap Map<String, String> options, @Body Object parameters);
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -139,6 +139,7 @@ public interface VimeoService {
     Call<SubscriptionCollection> editSubscriptions(@Header("Authorization") String authHeader,
                                                    @Body Map<String, Boolean> parameters);
 
+    @Headers("Cache-Control: no-cache, no-store")
     @PATCH
     Call<Void> emptyResponsePatch(@Header("Authorization") String authHeader, @Url String uri,
                                   @QueryMap Map<String, String> options, @Body Object parameters);


### PR DESCRIPTION
#### Ticket
[VA-1890](https://vimean.atlassian.net/browse/VA-1890)

#### Ticket Summary
We need to issue patch requests for notifications. One of the bodies contains a map, the other a list. Neither request has a return object.

#### Implementation Summary
I created a generic `Void` `Call` for patches. I use an `Object` as the body to let it be decided by the consumer what type to pass. I also added a few parameter constants.
