### PR TITLE
Updating to Stag 2.0.0

### DIFF
--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -27,10 +27,14 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.intellij:annotations:12.0@jar'
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.vimeo.stag:stag-library:2.0.0'
-    apt 'com.vimeo.stag:stag-library-compiler:1.1.2'
+
+    def retrofitVersion = '2.1.0'
+    compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+
+    def stagVersion = '2.0.0'
+    compile "com.vimeo.stag:stag-library:$stagVersion"
+    apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }
 
 group = 'com.vimeo.networking'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'com.intellij:annotations:12.0@jar'
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.vimeo.stag:stag-library:1.2.1'
+    compile 'com.vimeo.stag:stag-library:2.0.0'
     apt 'com.vimeo.stag:stag-library-compiler:1.1.2'
 }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/BaseResponseList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/BaseResponseList.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,6 +32,7 @@ import java.util.ArrayList;
 /**
  * Created by kylevenn on 5/28/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public abstract class BaseResponseList<T> implements Serializable {
 
     private static final long serialVersionUID = -1641146617506148394L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 /**
  * Created by zetterstromk on 8/20/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Category implements Serializable, Followable {
 
     private static final long serialVersionUID = 441419347585215353L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/CategoryList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/CategoryList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by zetterstromk on 8/20/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class CategoryList extends BaseResponseList<Category> {
 
     private static final long serialVersionUID = 6478758702787753766L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import java.util.Date;
 /**
  * Created by zetterstromk on 6/11/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Channel implements Serializable, Followable {
 
     private static final long serialVersionUID = 3190410523525111858L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ChannelList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ChannelList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by zetterstromk on 6/11/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class ChannelList extends BaseResponseList<Channel> {
 
     private static final long serialVersionUID = -6382319292336453350L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.Vimeo;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -32,6 +34,7 @@ import java.util.Date;
 /**
  * Created by zetterstromk on 7/31/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Comment implements Serializable {
 
     private static final long serialVersionUID = -7716027694845877155L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/CommentList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/CommentList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by zetterstromk on 7/31/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class CommentList extends BaseResponseList<Comment> {
 
     private static final long serialVersionUID = -5092384010058406105L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -33,6 +35,7 @@ import java.util.ArrayList;
  * This model object represents a Connection.
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Connection implements Serializable {
 
     private static final long serialVersionUID = -840088720891343176L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -33,6 +35,7 @@ import java.io.Serializable;
  * Created by hanssena on 4/23/15.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class ConnectionCollection implements Serializable {
 
     private static final long serialVersionUID = -4523270955994232839L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Credit.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Credit.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -10,6 +12,7 @@ import java.io.Serializable;
  * A model representing a credit.
  * Created by zetterstromk on 1/11/17.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Credit implements Serializable {
 
     private static final long serialVersionUID = 6037404487282167384L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Document.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Document.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,7 @@ import java.io.Serializable;
  * <p>
  * Created by zetterstromk on 11/7/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Document implements Serializable {
 
     private static final long serialVersionUID = -8676604257868932660L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Email.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Email.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
@@ -9,6 +11,7 @@ import java.io.Serializable;
  * <p/>
  * Created by anthonyrestaino on 6/16/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Email implements Serializable {
 
     private static final long serialVersionUID = -4112910222188194649L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Embed.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Embed.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
@@ -34,6 +36,7 @@ import java.io.Serializable;
  * Created by hanssena on 4/23/15.
  */
 @Deprecated
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Embed implements Serializable {
 
     private static final long serialVersionUID = 7145437300195734964L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/FeedItem.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/FeedItem.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -30,6 +32,7 @@ import java.util.Date;
 /**
  * Created by zetterstromk on 6/24/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class FeedItem implements Serializable {
 
     private static final long serialVersionUID = -8744477085158366576L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/FeedList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/FeedList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by zetterstromk on 6/24/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class FeedList extends BaseResponseList<FeedItem> {
 
     private static final long serialVersionUID = 5489148474407186588L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -30,6 +32,7 @@ import java.util.Date;
 /**
  * Created by zetterstromk on 6/26/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Group implements Serializable {
 
     private static final long serialVersionUID = -3604741570351063891L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
@@ -24,6 +24,8 @@ package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +36,7 @@ import java.util.Date;
  * This model object represents an Interaction.
  * Created by zetterstromk on 6/5/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Interaction implements Serializable {
 
     private static final long serialVersionUID = 2033767841952340400L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import java.io.Serializable;
  * A collection of Interaction objects.
  * Created by zetterstromk on 6/5/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class InteractionCollection implements Serializable {
 
     private static final long serialVersionUID = 489519386122782640L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Metadata.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Metadata.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Metadata implements Serializable {
 
     private static final long serialVersionUID = 6626539965452151962L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Paging.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Paging.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Paging implements Serializable {
 
     private static final long serialVersionUID = -8547699448016693035L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Picture implements Serializable {
 
     private static final long serialVersionUID = -2933756384207338583L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureCollection.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +37,7 @@ import java.util.ArrayList;
  * of {@link Picture}s
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class PictureCollection implements Serializable {
 
     private static final long serialVersionUID = -4495146309328278574L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureResource.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureResource.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by zetterstromk on 10/6/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class PictureResource implements Serializable {
 
     private static final long serialVersionUID = -495204863230150919L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/PinCodeInfo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/PinCodeInfo.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -33,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
  * Created by rigbergh on 6/16/16.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class PinCodeInfo {
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Preferences.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Preferences.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +36,7 @@ import java.io.Serializable;
  * <p>
  * Created by zetterstromk on 1/28/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Preferences implements Serializable {
 
     private static final long serialVersionUID = -251634859829805204L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
@@ -24,6 +24,8 @@ package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import java.io.Serializable;
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Privacy implements Serializable {
 
     private static final long serialVersionUID = -1679908652622815871L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Quota.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Quota.java
@@ -25,12 +25,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by kylevenn on 8/19/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Quota implements Serializable {
 
     private static final long serialVersionUID = -9173641301792409558L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,6 +15,7 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 8/15/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Recommendation implements Serializable {
 
     private static final long serialVersionUID = -1451431453348153582L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/RecommendationList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/RecommendationList.java
@@ -1,9 +1,13 @@
 package com.vimeo.networking.model;
 
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
 /**
  * A {@link BaseResponseList} for {@link Recommendation} objects
  * Created by zetterstromk on 8/15/16.
  */
+@UseStag(FieldOption.NONE)
 public class RecommendationList extends BaseResponseList<Recommendation> {
 
     private static final long serialVersionUID = -1488717279892501485L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Space.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Space.java
@@ -25,12 +25,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by kylevenn on 8/19/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Space implements Serializable {
 
     private static final long serialVersionUID = -1985382617862372889L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Spatial.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Spatial.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -13,6 +15,7 @@ import java.io.Serializable;
  * Created by restainoa on 1/3/17.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Spatial implements Serializable {
 
     private static final long serialVersionUID = 5660325676029549468L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/StatsCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/StatsCollection.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -31,6 +33,7 @@ import java.io.Serializable;
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class StatsCollection implements Serializable {
 
     private static final long serialVersionUID = -348202198117360187L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Tag implements Serializable {
 
     private static final long serialVersionUID = 3388947522077930006L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/UploadQuota.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/UploadQuota.java
@@ -27,12 +27,15 @@ package com.vimeo.networking.model;
 
 import com.vimeo.networking.Vimeo;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by kylevenn on 8/19/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class UploadQuota implements Serializable {
 
     private static final long serialVersionUID = 4050488085481972886L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
@@ -26,6 +26,8 @@ import com.vimeo.networking.Vimeo;
 import com.vimeo.networking.model.Privacy.PrivacyValue;
 import com.vimeo.networking.model.UserBadge.UserBadgeType;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,7 +39,7 @@ import java.util.Date;
 /**
  * Created by alfredhanssen on 4/12/15.
  */
-
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class User implements Serializable, Followable {
 
     private static final long serialVersionUID = -4112910222188194647L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/UserBadge.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/UserBadge.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
@@ -36,6 +38,7 @@ import java.io.Serializable;
  * Created by zetterstromk on 7/18/16.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class UserBadge implements Serializable {
 
     private static final long serialVersionUID = 927892812790804141L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/UserList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/UserList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by hanssena on 4/23/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class UserList extends BaseResponseList<User> {
 
     private static final long serialVersionUID = -4188665245239932555L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -28,6 +28,8 @@ import com.vimeo.networking.model.Interaction.Stream;
 import com.vimeo.networking.model.playback.Play;
 import com.vimeo.networking.model.playback.PlayProgress;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeUnit;
  * Created by alfredhanssen on 4/12/15.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Video implements Serializable {
 
     private static final long serialVersionUID = -1282907783845240057L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoBadge.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoBadge.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,7 @@ import java.io.Serializable;
  * video data (name, description, etc)
  * Created by zetterstromk on 10/4/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VideoBadge implements Serializable {
 
     private static final long serialVersionUID = -5343389171512787927L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFile.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFile.java
@@ -24,6 +24,8 @@ package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +37,7 @@ import java.util.Date;
  * <p/>
  * Created by alfredhanssen on 4/25/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VideoFile implements Serializable {
 
     public enum MimeType {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoList.java
@@ -22,12 +22,13 @@
 
 package com.vimeo.networking.model;
 
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Created by alfredhanssen on 4/12/15.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class VideoList extends BaseResponseList<Video> {
 
     private static final long serialVersionUID = -5034081563847270372L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import java.io.Serializable;
  * A model representing default preferences that a user has for their videos
  * Created by zetterstromk on 1/28/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VideosPreference implements Serializable {
 
     private static final long serialVersionUID = 1956447486226253433L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VimeoAccount.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model;
 import com.google.gson.Gson;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +38,7 @@ import java.io.Serializable;
  * <p/>
  * Created by alfredhanssen on 4/12/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VimeoAccount implements Serializable {
 
     private static final long serialVersionUID = -8341071767843490585L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Website.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Website.java
@@ -23,12 +23,15 @@
 package com.vimeo.networking.model;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
 /**
  * Created by hanssena on 4/23/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Website implements Serializable {
 
     private static final long serialVersionUID = -1672589618654261644L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model.error;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * All the error codes that can come back from the Vimeo Api.
@@ -30,6 +32,7 @@ import com.google.gson.annotations.SerializedName;
  * Vimean reference: {@link <a href="https://docs.google.com/a/vimeo.com/spreadsheets/d/1DlkbeOFDuogvwyG2QDqExqBd_Yb3M7w7ku25AJN7QU0/edit?usp=sharing">Spreadsheet</a>}
  * Created by kylevenn on 7/15/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public enum ErrorCode {
     // The default code that will be returned if the code returned from the server isn't enumerated below
     // If that is the case, check the raw response for the code [KV]

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/InvalidParameter.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/InvalidParameter.java
@@ -23,6 +23,8 @@
 package com.vimeo.networking.model.error;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Similar to {@link VimeoError} object, this holds error codes/error messages relevant to a specific invalid field.
@@ -33,16 +35,20 @@ import com.google.gson.annotations.SerializedName;
  * <p/>
  * Created by kylevenn on 7/15/15.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class InvalidParameter {
 
     @SerializedName("field")
-    private String field;
+    protected String field;
     @SerializedName("error_code")
-    private ErrorCode errorCode;
+    protected ErrorCode errorCode;
     @SerializedName("user_message")
-    private String userMessage;
+    protected String userMessage;
     @SerializedName("developer_message")
-    private String developerMessage;
+    protected String developerMessage;
+
+    InvalidParameter() {
+    }
 
     public InvalidParameter(String field, ErrorCode errorCode, String developerMessage) {
         this.field = field;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Notification.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Notification.java
@@ -5,6 +5,8 @@ import com.vimeo.networking.model.Credit;
 import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,6 +18,7 @@ import java.util.Date;
  * A model representing activity that a user may be notified about.
  * Created by zetterstromk on 1/11/17.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Notification implements Serializable {
 
     private static final long serialVersionUID = -68262442832775695L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationList.java
@@ -1,14 +1,15 @@
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.networking.model.BaseResponseList;
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * The response from the notifications endpoint
  * <p>
  * Created by zetterstromk on 1/11/17.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class NotificationList extends BaseResponseList<Notification> {
 
     private static final long serialVersionUID = -6084940916920098832L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
@@ -1,5 +1,8 @@
 package com.vimeo.networking.model.notifications;
 
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -7,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
  * A simple enum describing notification types
  * Created by zetterstromk on 1/11/17.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public enum NotificationType {
     NOTIFICATION_TYPE_COMMENT,
     NOTIFICATION_TYPE_CREDIT,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/SubscriptionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/SubscriptionCollection.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -14,6 +16,7 @@ import java.util.Date;
  * <p>
  * Created by zetterstromk on 12/15/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class SubscriptionCollection implements Serializable {
 
     private static final long serialVersionUID = -6392190720319669273L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Subscriptions.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Subscriptions.java
@@ -1,6 +1,8 @@
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -15,6 +17,7 @@ import java.util.Map;
  * <p>
  * Created by zetterstromk on 12/15/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Subscriptions implements Serializable {
 
     private static final long serialVersionUID = 3088065484753327987L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Drm.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Drm.java
@@ -26,6 +26,8 @@ package com.vimeo.networking.model.playback;
 
 import com.vimeo.networking.model.VideoFile;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -40,6 +42,7 @@ import java.io.Serializable;
  * Created by zetterstromk on 6/22/16.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Drm implements Serializable {
 
     private static final long serialVersionUID = 3048847922257143776L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
@@ -28,6 +28,8 @@ import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.model.VideoFile;
 import com.vimeo.networking.model.playback.embed.Embed;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -39,6 +41,7 @@ import java.util.ArrayList;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Play implements Serializable {
 
     private static final long serialVersionUID = -7429617944240759711L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/PlayProgress.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/PlayProgress.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +37,7 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class PlayProgress implements Serializable {
 
     private static final long serialVersionUID = -3745271302058282379L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/Embed.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/Embed.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -39,29 +41,30 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Embed implements Serializable {
 
     private static final long serialVersionUID = -4708548576616330795L;
 
     @Nullable
     @SerializedName("uri")
-    private String mUri;
+    String mUri;
     @Nullable
     @SerializedName("html")
-    private EmbedHtml mHtml;
+    EmbedHtml mHtml;
     @Nullable
     @SerializedName("buttons")
-    private EmbedButtons mButtons;
+    EmbedButtons mButtons;
     @Nullable
     @SerializedName("title")
-    private EmbedTitle mTitle;
+    EmbedTitle mTitle;
     @SerializedName("playbar")
-    private boolean mPlayBar;
+    boolean mPlayBar;
     @SerializedName("volume")
-    private boolean mVolume;
+    boolean mVolume;
     @Nullable
     @SerializedName("color")
-    private String mColor;
+    String mColor;
 
     @Nullable
     public String getUri() {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedButtons.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedButtons.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import java.io.Serializable;
 
@@ -34,23 +36,24 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class EmbedButtons implements Serializable {
 
     private static final long serialVersionUID = 6724361702326756097L;
     @SerializedName("like")
-    private boolean mLike;
+    boolean mLike;
     @SerializedName("watchlater")
-    private boolean mWatchLater;
+    boolean mWatchLater;
     @SerializedName("share")
-    private boolean mShare;
+    boolean mShare;
     @SerializedName("embed")
-    private boolean mEmbed;
+    boolean mEmbed;
     @SerializedName("hd")
-    private boolean mHd;
+    boolean mHd;
     @SerializedName("fullscreen")
-    private boolean mFullscreen;
+    boolean mFullscreen;
     @SerializedName("scaling")
-    private boolean mScaling;
+    boolean mScaling;
 
     public boolean isLike() {
         return mLike;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedCustomLogos.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedCustomLogos.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,16 +37,17 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class EmbedCustomLogos implements Serializable {
 
     private static final long serialVersionUID = -8919686101651093878L;
     @SerializedName("active")
-    private boolean mActive;
+    boolean mActive;
     @Nullable
     @SerializedName("link")
-    private String mLink;
+    String mLink;
     @SerializedName("sticky")
-    private boolean mSticky;
+    boolean mSticky;
 
     public boolean isActive() {
         return mActive;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedHtml.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedHtml.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -36,17 +38,18 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class EmbedHtml implements Serializable {
 
     private static final long serialVersionUID = 3752755790501317766L;
 
     @SerializedName("width")
-    private int mWidth;
+    int mWidth;
     @SerializedName("height")
-    private int mHeight;
+    int mHeight;
     @Nullable
     @SerializedName("html")
-    private String mHtml;
+    String mHtml;
 
     public int getWidth() {
         return mWidth;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedLogos.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedLogos.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,14 +37,15 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class EmbedLogos implements Serializable {
 
     private static final long serialVersionUID = -6946192139468749658L;
     @SerializedName("vimeo")
-    private boolean mVimeoLogoVisible;
+    boolean mVimeoLogoVisible;
     @Nullable
     @SerializedName("custom")
-    private EmbedCustomLogos mCustom;
+    EmbedCustomLogos mCustom;
 
     public boolean isVimeoLogoVisible() {
         return mVimeoLogoVisible;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedTitle.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/embed/EmbedTitle.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.playback.embed;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,18 +37,19 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 4/25/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class EmbedTitle implements Serializable {
 
     private static final long serialVersionUID = -2543724237726304625L;
     @Nullable
     @SerializedName("name")
-    private String mName;
+    String mName;
     @Nullable
     @SerializedName("owner")
-    private String mOwner;
+    String mOwner;
     @Nullable
     @SerializedName("portrait")
-    private String mPortrait;
+    String mPortrait;
 
     @Nullable
     public String getName() {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOption.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/FacetOption.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.search;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +37,7 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 6/27/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class FacetOption implements Serializable {
 
     private static final long serialVersionUID = 6525562797608669182L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacet.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.search;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +38,7 @@ import java.util.ArrayList;
  * <p/>
  * Created by zetterstromk on 6/27/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class SearchFacet implements Serializable {
 
     private static final long serialVersionUID = -6507918911819851151L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchFacetCollection.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking.model.search;
 
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +38,7 @@ import java.io.Serializable;
  * Created by zetterstromk on 6/27/16.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class SearchFacetCollection implements Serializable {
 
     private static final long serialVersionUID = 3340976215489066653L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResponse.java
@@ -24,8 +24,9 @@
 
 package com.vimeo.networking.model.search;
 
+import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.model.BaseResponseList;
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,15 +36,16 @@ import org.jetbrains.annotations.Nullable;
  * Created by zetterstromk on 6/27/16.
  */
 @SuppressWarnings("unused")
+@UseStag
 public class SearchResponse extends BaseResponseList<SearchResult> {
 
     private static final long serialVersionUID = -7915082057592438294L;
 
     @Nullable
-    @GsonAdapterKey("facets")
+    @SerializedName("facets")
     public SearchFacetCollection mFacetCollection;
 
-    @GsonAdapterKey("mature_hidden_count")
+    @SerializedName("mature_hidden_count")
     public int mMatureHiddenCount;
 
     @Override

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchResult.java
@@ -30,6 +30,8 @@ import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.vod.VodItem;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -40,6 +42,7 @@ import java.io.Serializable;
  * <p/>
  * Created by zetterstromk on 6/27/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class SearchResult implements Serializable {
 
     private static final long serialVersionUID = -1607389617833091383L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SearchType.java
@@ -25,12 +25,15 @@
 package com.vimeo.networking.model.search;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * Enum representing types of searches.
  * <p/>
  * Created by zetterstromk on 6/27/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public enum SearchType {
 
     @SerializedName("clip")

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/Season.java
@@ -5,6 +5,8 @@ import com.vimeo.networking.model.ConnectionCollection;
 import com.vimeo.networking.model.Metadata;
 import com.vimeo.networking.model.User;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -18,6 +20,7 @@ import java.io.Serializable;
  * <p>
  * Created by zetterstromk on 10/4/16.
  */
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Season implements Serializable {
 
     private static final String SEASON_TYPE_MAIN = "main";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/SeasonList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/SeasonList.java
@@ -1,11 +1,14 @@
 package com.vimeo.networking.model.vod;
 
 import com.vimeo.networking.model.BaseResponseList;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * A list of {@link Season} items
  * Created by zetterstromk on 10/4/16.
  */
+@UseStag(FieldOption.NONE)
 public class SeasonList extends BaseResponseList<Season> {
 
     private static final long serialVersionUID = -2072805722241898821L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodItem.java
@@ -33,6 +33,8 @@ import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,6 +47,7 @@ import java.util.Date;
  * Created by rigbergh on 4/25/16.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VodItem implements Serializable {
 
     private static final String S_FILM = "film";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/vod/VodList.java
@@ -25,13 +25,14 @@
 package com.vimeo.networking.model.vod;
 
 import com.vimeo.networking.model.BaseResponseList;
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 /**
  * A list of {@link VodItem} objects
  * Created by rigbergh on 4/25/16.
  */
-@GsonAdapterKey
+@UseStag(FieldOption.NONE)
 public class VodList extends BaseResponseList<VodItem> {
 
     private static final long serialVersionUID = 2086096986453255372L;


### PR DESCRIPTION
#### Summary
The minimum required changes to migrate to Stag 2.0.0. Eliminating deprecated usage of `@GsonAdapterKey` was not done.