### PR TITLE
Don’t use Stag for serialization of Privacy object

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
@@ -23,7 +23,7 @@
 package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +32,8 @@ import java.io.Serializable;
 /**
  * Created by hanssena on 4/23/15.
  */
+// TODO: Figure out how to enable UseStag on this class without breaking deserialization due to the API giving us back integers for add and download 2/1/17 [AR]
+// @UseStag(FieldOption.SERIALIZED_NAME)
 public class Privacy implements Serializable {
 
     private static final long serialVersionUID = -1679908652622815871L;
@@ -44,6 +46,7 @@ public class Privacy implements Serializable {
     private static final String PRIVACY_DISABLE = "disable";
     private static final String PRIVACY_UNLISTED = "unlisted";
 
+    @UseStag
     public enum PrivacyValue {
         @SerializedName(PRIVACY_NOBODY)
         NOBODY(PRIVACY_NOBODY),
@@ -85,21 +88,21 @@ public class Privacy implements Serializable {
     }
 
     @Nullable
-    @GsonAdapterKey("view")
+    @SerializedName("view")
     public PrivacyValue view;
 
     @Nullable
-    @GsonAdapterKey("embed")
+    @SerializedName("embed")
     public String embed;
 
-    @GsonAdapterKey("download")
-    protected int download;
+    @SerializedName("download")
+    public boolean download;
 
-    @GsonAdapterKey("add")
-    protected int add;
+    @SerializedName("add")
+    public boolean add;
 
     @Nullable
-    @GsonAdapterKey("comments")
+    @SerializedName("comments")
     public PrivacyValue comments;
 
     @Nullable
@@ -113,11 +116,11 @@ public class Privacy implements Serializable {
     }
 
     public boolean isDownload() {
-        return download == 1;
+        return download;
     }
 
     public boolean isAdd() {
-        return add == 1;
+        return add;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/PrivacyDeserializer.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/PrivacyDeserializer.java
@@ -1,0 +1,150 @@
+package com.vimeo.networking.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.vimeo.networking.model.Privacy;
+import com.vimeo.networking.model.Privacy.PrivacyValue;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+/**
+ * (De)serializer for the Privacy class, since
+ * we need custom handling for two fields in it
+ * (download and add).
+ * <p>
+ * Created by restainoa on 2/1/17.
+ */
+@Deprecated
+final class PrivacyDeserializer {
+
+    private PrivacyDeserializer() {
+    }
+
+    /**
+     * Handles deserialization for the broken Privacy class
+     */
+    @Deprecated
+    static final class TypeAdapterFactory implements com.google.gson.TypeAdapterFactory {
+
+        TypeAdapterFactory() {
+        }
+
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+            if (type.getRawType().equals(Privacy.class)) {
+                return (TypeAdapter<T>) new PrivacyTypeAdapter(gson);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Handles deserialization for the broken Privacy class.
+     * add and download fields are currently sent to us as
+     * integers even though we need booleans. This class helps
+     * us deserialize them correctly.
+     */
+    @Deprecated
+    private static final class PrivacyTypeAdapter extends TypeAdapter<com.vimeo.networking.model.Privacy> {
+
+        private final TypeAdapter<PrivacyValue> mPrivacyValueTypeAdapter;
+
+        @SuppressWarnings("unchecked")
+        PrivacyTypeAdapter(@NotNull Gson gsonInternal) {
+            this.mPrivacyValueTypeAdapter = gsonInternal.getAdapter(PrivacyValue.class);
+        }
+
+        @Override
+        public void write(JsonWriter writer, Privacy object) throws IOException {
+            writer.beginObject();
+            if (object == null) {
+                writer.endObject();
+                return;
+            }
+
+            if (object.view != null) {
+                writer.name("view");
+                mPrivacyValueTypeAdapter.write(writer, object.view);
+            }
+
+            if (object.embed != null) {
+                writer.name("embed");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.embed);
+            }
+
+            writer.name("download");
+            writer.value(object.download);
+
+            writer.name("add");
+            writer.value(object.add);
+
+            if (object.comments != null) {
+                writer.name("comments");
+                mPrivacyValueTypeAdapter.write(writer, object.comments);
+            }
+
+            writer.endObject();
+        }
+
+        @Override
+        public Privacy read(JsonReader reader) throws IOException {
+            if (reader.peek() == com.google.gson.stream.JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
+            if (reader.peek() != com.google.gson.stream.JsonToken.BEGIN_OBJECT) {
+                reader.skipValue();
+                return null;
+            }
+            reader.beginObject();
+
+            com.vimeo.networking.model.Privacy object = new com.vimeo.networking.model.Privacy();
+            while (reader.hasNext()) {
+                String name = reader.nextName();
+                com.google.gson.stream.JsonToken jsonToken = reader.peek();
+                if (jsonToken == com.google.gson.stream.JsonToken.NULL) {
+                    reader.skipValue();
+                    continue;
+                }
+                switch (name) {
+                    case "view":
+                        object.view = mPrivacyValueTypeAdapter.read(reader);
+                        break;
+                    case "embed":
+                        object.embed = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        break;
+                    case "download":
+                        if (jsonToken == JsonToken.NUMBER) {
+                            object.download = reader.nextInt() == 1;
+                        } else {
+                            object.download = reader.nextBoolean();
+                        }
+                        break;
+                    case "add":
+                        if (jsonToken == JsonToken.NUMBER) {
+                            object.add = reader.nextInt() == 1;
+                        } else {
+                            object.add = reader.nextBoolean();
+                        }
+                        break;
+                    case "comments":
+                        object.comments = mPrivacyValueTypeAdapter.read(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+
+            reader.endObject();
+            return object;
+        }
+    }
+
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
@@ -57,6 +57,7 @@ public class VimeoNetworkUtil {
      * Static helper method that automatically applies the VimeoClient Gson preferences
      * </p>
      * This includes formatting for dates as well as a LOWER_CASE_WITH_UNDERSCORES field naming policy
+     *
      * @return Gson object that can be passed into a {@link GsonConverterFactory} create() method
      */
     public static Gson getGson() {
@@ -76,6 +77,7 @@ public class VimeoNetworkUtil {
     public static GsonBuilder getGsonBuilder() {
         // Example date: "2015-05-21T14:24:03+00:00"
         return new GsonBuilder().registerTypeAdapterFactory(new Stag.Factory())
+                .registerTypeAdapterFactory(new PrivacyDeserializer.TypeAdapterFactory())
                 .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateSerializer())
                 .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateDeserializer())
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);
@@ -84,6 +86,7 @@ public class VimeoNetworkUtil {
     /**
      * Returns a simple query map from a provided uri. The simple map enforces there is exactly one value for
      * every name (multiple values for the same name are regularly allowed in a set of parameters)
+     *
      * @param uri a uri, optionally with a query
      * @return a query map with a one to one mapping of names to values or empty {@link HashMap}
      * if no parameters are found on the uri
@@ -112,6 +115,7 @@ public class VimeoNetworkUtil {
     /**
      * Return a builder of the given cache control because for some reason this doesn't exist already.
      * Useful for adding more attributes to an already defined {@link CacheControl}
+     *
      * @param cacheControl The CacheControl to convert to a builder
      * @return A builder with the same attributes as the CacheControl passed in
      */


### PR DESCRIPTION
#### Summary
Don’t use Stag for serialization of Privacy object

#### Implementation Summary
Due to the `Privacy.add` and `Privacy.download` fields being sent from the server as integers, we need to deserialize these as integers and not as booleans. Gson and Stag don't support integer to boolean conversion, so we need to create a custom adapter that does it for us.
