### PR TITLE
VA-2204 Use custom Type Adapter over Stag for VideoFile log issue

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFile.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFile.java
@@ -23,7 +23,7 @@
 package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
-import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.UseStag;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,8 +35,11 @@ import java.util.Date;
  * <p/>
  * Created by alfredhanssen on 4/25/15.
  */
+// TODO: Remove the VideoFileDeserializer and use Stag instead, once API corrects log issue behind version 2/16/17 [KZ]
+// @UseStag(FieldOption.SERIALIZED_NAME)
 public class VideoFile implements Serializable {
 
+    @UseStag
     public enum MimeType {
         NONE("None"),
         @SerializedName("video/mp4")
@@ -60,6 +63,7 @@ public class VideoFile implements Serializable {
     }
 
     @Deprecated
+    @UseStag
     public enum VideoQuality {
         NONE("N/A"),
         @SerializedName("hls")
@@ -91,22 +95,22 @@ public class VideoFile implements Serializable {
     // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Fields common between all file types">
     @Nullable
-    @GsonAdapterKey("link_expiration_time")
+    @SerializedName("link_expiration_time")
     Date mLinkExpirationTime;
 
-    @GsonAdapterKey("link")
+    @SerializedName("link")
     String mLink;
 
     @Nullable
-    @GsonAdapterKey("log")
+    @SerializedName("log")
     String mLog;
 
     @Nullable
-    @GsonAdapterKey("token")
+    @SerializedName("token")
     String mToken;
 
     @Nullable
-    @GsonAdapterKey("license_link")
+    @SerializedName("license_link")
     String mLicenseLink;
 
     @Nullable
@@ -151,38 +155,38 @@ public class VideoFile implements Serializable {
     /** quality will be removed in the future when {@link Video#files} is removed */
     @Deprecated
     @Nullable
-    @GsonAdapterKey("quality")
+    @SerializedName("quality")
     VideoQuality mQuality;
 
     /** expires will be removed in the future when {@link Video#files} is removed */
     @Deprecated
     @Nullable
-    @GsonAdapterKey("expires")
+    @SerializedName("expires")
     Date mExpires;
 
     @Nullable
-    @GsonAdapterKey("type")
+    @SerializedName("type")
     MimeType mMimeType;
 
-    @GsonAdapterKey("fps")
+    @SerializedName("fps")
     double mFps;
 
-    @GsonAdapterKey("width")
+    @SerializedName("width")
     int mWidth;
 
-    @GsonAdapterKey("height")
+    @SerializedName("height")
     int mHeight;
 
-    @GsonAdapterKey("size")
+    @SerializedName("size")
     long mSize; // size of the file, in bytes
 
     /** The md5 provides us with a way to uniquely identify video files at {@link #getLink()} */
     @Nullable
-    @GsonAdapterKey("md5")
+    @SerializedName("md5")
     String mMd5;
 
     @Nullable
-    @GsonAdapterKey("created_time")
+    @SerializedName("created_time")
     Date mCreatedTime; // time indicating when this transcode was completed
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFileDeserializer.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideoFileDeserializer.java
@@ -1,0 +1,217 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.vimeo.networking.model.VideoFile.MimeType;
+import com.vimeo.networking.model.VideoFile.VideoQuality;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * A class to help with parsing a {@link VideoFile}. Depending on where the file is
+ * located, the <code>log</code> field may be an object or a {@link String}.
+ * Created by zetterstromk on 2/16/17.
+ */
+@Deprecated
+public final class VideoFileDeserializer {
+
+    private VideoFileDeserializer() {
+    }
+
+    /**
+     * Handles deserialization for the broken VideoFile class
+     */
+    @Deprecated
+    public static final class TypeAdapterFactory implements com.google.gson.TypeAdapterFactory {
+
+        public TypeAdapterFactory() {
+        }
+
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+            if (type.getRawType().equals(VideoFile.class)) {
+                return (TypeAdapter<T>) new VideoFileTypeAdapter(gson);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Handles deserialization for the broken VideoFile class.
+     * The log field was changed from an object to a String, but depending
+     * on API version, the String may not be sent. Since the API will
+     * only ever send Vimeo apps the log field, and we only use the newer
+     * String, we can ignore the log objects.
+     */
+    @Deprecated
+    private static final class VideoFileTypeAdapter extends TypeAdapter<com.vimeo.networking.model.VideoFile> {
+
+        private final TypeAdapter<MimeType> mMimeTypeTypeAdapter;
+        private final TypeAdapter<VideoQuality> mVideoQualityTypeAdapter;
+        private final TypeAdapter<Date> mDateTypeAdpter;
+
+        @SuppressWarnings("unchecked")
+        VideoFileTypeAdapter(@NotNull Gson gsonInternal) {
+            this.mMimeTypeTypeAdapter = gsonInternal.getAdapter(MimeType.class);
+            this.mVideoQualityTypeAdapter = gsonInternal.getAdapter(VideoQuality.class);
+            this.mDateTypeAdpter = gsonInternal.getAdapter(Date.class);
+        }
+
+        @Override
+        public void write(JsonWriter writer, VideoFile object) throws IOException {
+            writer.beginObject();
+            if (object == null) {
+                writer.endObject();
+                return;
+            }
+
+            if (object.mLinkExpirationTime != null) {
+                writer.name("link_expiration_time");
+                mDateTypeAdpter.write(writer, object.mLinkExpirationTime);
+            }
+
+            if (object.mLink != null) {
+                writer.name("link");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.mLink);
+            }
+
+            if (object.mLog != null) {
+                writer.name("log");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.mLog);
+            }
+
+            if (object.mToken != null) {
+                writer.name("token");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.mToken);
+            }
+
+            if (object.mLicenseLink != null) {
+                writer.name("license_link");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.mLicenseLink);
+            }
+
+            if (object.mQuality != null) {
+                writer.name("quality");
+                mVideoQualityTypeAdapter.write(writer, object.mQuality);
+            }
+
+            if (object.mExpires != null) {
+                writer.name("expires");
+                mDateTypeAdpter.write(writer, object.mExpires);
+            }
+
+            if (object.mMimeType != null) {
+                writer.name("type");
+                mMimeTypeTypeAdapter.write(writer, object.mMimeType);
+            }
+
+            writer.name("fps");
+            writer.value(object.mFps);
+
+            writer.name("width");
+            writer.value(object.mWidth);
+
+            writer.name("height");
+            writer.value(object.mHeight);
+
+            writer.name("size");
+            writer.value(object.mSize);
+
+            if (object.mMd5 != null) {
+                writer.name("md5");
+                com.google.gson.internal.bind.TypeAdapters.STRING.write(writer, object.mMd5);
+            }
+
+            if (object.mCreatedTime != null) {
+                writer.name("created_time");
+                mDateTypeAdpter.write(writer, object.mCreatedTime);
+            }
+
+            writer.endObject();
+        }
+
+        @Override
+        public VideoFile read(JsonReader reader) throws IOException {
+            if (reader.peek() == com.google.gson.stream.JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
+            if (reader.peek() != com.google.gson.stream.JsonToken.BEGIN_OBJECT) {
+                reader.skipValue();
+                return null;
+            }
+            reader.beginObject();
+
+            com.vimeo.networking.model.VideoFile object = new com.vimeo.networking.model.VideoFile();
+            while (reader.hasNext()) {
+                String name = reader.nextName();
+                com.google.gson.stream.JsonToken jsonToken = reader.peek();
+                if (jsonToken == com.google.gson.stream.JsonToken.NULL) {
+                    reader.skipValue();
+                    continue;
+                }
+                switch (name) {
+                    case "link_expiration_time":
+                        object.mLinkExpirationTime = mDateTypeAdpter.read(reader);
+                        break;
+                    case "link":
+                        object.mLink = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        break;
+                    case "log":
+                        if (jsonToken == JsonToken.STRING) {
+                            object.mLog = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        } else {
+                            reader.skipValue();
+                        }
+                        break;
+                    case "token":
+                        object.mToken = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        break;
+                    case "license_link":
+                        object.mLicenseLink = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        break;
+                    case "quality":
+                        object.mQuality = mVideoQualityTypeAdapter.read(reader);
+                        break;
+                    case "expires":
+                        object.mExpires = mDateTypeAdpter.read(reader);
+                        break;
+                    case "type":
+                        object.mMimeType = mMimeTypeTypeAdapter.read(reader);
+                        break;
+                    case "fps":
+                        object.mFps = reader.nextDouble();
+                        break;
+                    case "width":
+                        object.mWidth = reader.nextInt();
+                        break;
+                    case "height":
+                        object.mHeight = reader.nextInt();
+                        break;
+                    case "size":
+                        object.mSize = reader.nextLong();
+                        break;
+                    case "md5":
+                        object.mMd5 = com.google.gson.internal.bind.TypeAdapters.STRING.read(reader);
+                        break;
+                    case "created_time":
+                        object.mCreatedTime = mDateTypeAdpter.read(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+
+            reader.endObject();
+            return object;
+        }
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
@@ -27,6 +27,7 @@ package com.vimeo.networking.utils;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.vimeo.networking.model.VideoFileDeserializer;
 import com.vimeo.stag.generated.Stag;
 
 import java.io.UnsupportedEncodingException;
@@ -78,6 +79,7 @@ public class VimeoNetworkUtil {
         // Example date: "2015-05-21T14:24:03+00:00"
         return new GsonBuilder().registerTypeAdapterFactory(new Stag.Factory())
                 .registerTypeAdapterFactory(new PrivacyDeserializer.TypeAdapterFactory())
+                .registerTypeAdapterFactory(new VideoFileDeserializer.TypeAdapterFactory())
                 .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateSerializer())
                 .registerTypeAdapter(Date.class, ISO8601Wrapper.getDateDeserializer())
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);


### PR DESCRIPTION
#### Ticket
[VA-2204](https://vimean.atlassian.net/browse/VA-2204)

#### Ticket Summary
We have a crash in the Android app when trying to parse a non-field-filtered `Video` object. This is because we get the `files` array, which contain `VideoFile` objects. Within the files array, these objects contain a `log` property that is an object. We are looking for `log` to be a String. 

#### Implementation Summary
I filed an issue with the [API](https://github.vimeows.com/Vimeo-API/api/issues/935) to use Strings everywhere for the `log` fields.

In the meantime, I created a custom `TypeAdapter` and removed `VideoFile` from general Stag processing (the sub-enums still use Stag).

#### How to Test
Run with the Android app:
* In the notifications screen, when credited in a video, the list would not render, now it does
* When editing a video setting (title, description, or privacy), saving those changes would crash the app, now it does not
