### PR TITLE
ADF-3 Search suggestion models

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/BaseSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/BaseSuggestion.java
@@ -1,0 +1,31 @@
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * A base class for search suggestions. Each suggest must contain a <code>text</code>
+ * string.
+ * <p>
+ * Created by zetterstromk on 2/21/17.
+ */
+@UseStag(FieldOption.SERIALIZED_NAME)
+abstract class BaseSuggestion implements Serializable {
+
+    @NotNull
+    @SerializedName("text")
+    String mText;
+
+    /**
+     * Returns the title associated with this suggestion.
+     */
+    @NotNull
+    public String getText() {
+        return mText;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
@@ -67,7 +67,7 @@ public final class OndemandSuggestion extends BaseSuggestion implements Serializ
     }
 
     @UseStag(FieldOption.SERIALIZED_NAME)
-    public static class OndemandSuggestionMetadata implements Serializable {
+    public final static class OndemandSuggestionMetadata implements Serializable {
 
         private static final long serialVersionUID = 7538947801290601850L;
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
@@ -67,7 +67,7 @@ public class OndemandSuggestion extends BaseSuggestion implements Serializable {
     }
 
     @UseStag(FieldOption.SERIALIZED_NAME)
-    static class OndemandSuggestionMetadata implements Serializable {
+    public static class OndemandSuggestionMetadata implements Serializable {
 
         private static final long serialVersionUID = 7538947801290601850L;
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
  * Created by zetterstromk on 2/21/17.
  */
 @UseStag(FieldOption.SERIALIZED_NAME)
-public class OndemandSuggestion extends BaseSuggestion implements Serializable {
+public final class OndemandSuggestion extends BaseSuggestion implements Serializable {
 
     private static final long serialVersionUID = -1176546228110567452L;
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
@@ -1,0 +1,83 @@
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.PictureCollection;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Search suggestions for ondemand titles
+ * <p>
+ * Created by zetterstromk on 2/21/17.
+ */
+@UseStag(FieldOption.SERIALIZED_NAME)
+public class OndemandSuggestion extends BaseSuggestion implements Serializable {
+
+    private static final long serialVersionUID = -1176546228110567452L;
+
+    @Nullable
+    @SerializedName("meta")
+    OndemandSuggestionMetadata mMetadata;
+
+    /**
+     * Return the {@link PictureCollection} associated with this VOD.
+     */
+    @Nullable
+    public PictureCollection getPictures() {
+        return mMetadata != null ? mMetadata.mPoster : null;
+    }
+
+    /**
+     * Returns the url representative of this VOD.
+     */
+    @Nullable
+    public String getOnDemandUrl() {
+        return mMetadata != null ? mMetadata.mTargetUrl : null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        OndemandSuggestion that = (OndemandSuggestion) o;
+
+        if (!mText.equals(that.mText)) { return false; }
+        return mMetadata != null ? mMetadata.equals(that.mMetadata) : that.mMetadata == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mText.hashCode();
+        result = 31 * result + (mMetadata != null ? mMetadata.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "OndemandSuggestion{" +
+               "mText='" + mText + '\'' +
+               ", mMetadata=" + mMetadata +
+               '}';
+    }
+
+    @UseStag(FieldOption.SERIALIZED_NAME)
+    static class OndemandSuggestionMetadata implements Serializable {
+
+        private static final long serialVersionUID = 7538947801290601850L;
+
+        @Nullable
+        @SerializedName("target_url")
+        String mTargetUrl;
+
+        @Nullable
+        @SerializedName("poster")
+        PictureCollection mPoster;
+
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SuggestionResponse.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SuggestionResponse.java
@@ -1,0 +1,68 @@
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+/**
+ * A response sent from the API for search/autocomplete suggestions.
+ * <p>
+ * Created by zetterstromk on 2/21/17.
+ */
+@UseStag(FieldOption.SERIALIZED_NAME)
+public class SuggestionResponse implements Serializable {
+
+    private static final long serialVersionUID = -3474410244242185856L;
+
+    @Nullable
+    @SerializedName("ondemand_title")
+    ArrayList<OndemandSuggestion> mOndemandSuggestions;
+
+    @Nullable
+    @SerializedName("video")
+    ArrayList<VideoSuggestion> mVideoSuggestions;
+
+    @Nullable
+    public ArrayList<OndemandSuggestion> getOndemandSuggestionList() {
+        return mOndemandSuggestions;
+    }
+
+    @Nullable
+    public ArrayList<VideoSuggestion> getVideoSuggestions() {
+        return mVideoSuggestions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        SuggestionResponse that = (SuggestionResponse) o;
+
+        if (mOndemandSuggestions != null ? !mOndemandSuggestions.equals(that.mOndemandSuggestions) : that.mOndemandSuggestions != null) {
+            return false;
+        }
+        return mVideoSuggestions != null ? mVideoSuggestions.equals(that.mVideoSuggestions) : that.mVideoSuggestions == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mOndemandSuggestions != null ? mOndemandSuggestions.hashCode() : 0;
+        result = 31 * result + (mVideoSuggestions != null ? mVideoSuggestions.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "SuggestionResponse{" +
+               "mOndemandSuggestions=" + mOndemandSuggestions +
+               ", mVideoSuggestions=" + mVideoSuggestions +
+               '}';
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
@@ -59,7 +59,7 @@ public final class VideoSuggestion extends BaseSuggestion implements Serializabl
     }
 
     @UseStag(FieldOption.SERIALIZED_NAME)
-    public static class VideoSuggestionMetadata implements Serializable {
+    public final static class VideoSuggestionMetadata implements Serializable {
 
         private static final long serialVersionUID = -5853739822133424630L;
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
@@ -1,0 +1,69 @@
+package com.vimeo.networking.model.search;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Search suggestions for videos. These suggestions can be ranked according to
+ * their score - the higher the score the more relevant the suggestion.
+ * <p>
+ * Created by zetterstromk on 2/21/17.
+ */
+@UseStag(FieldOption.SERIALIZED_NAME)
+public class VideoSuggestion extends BaseSuggestion implements Serializable {
+
+    private static final long serialVersionUID = -6047771941064977527L;
+
+    @Nullable
+    @SerializedName("meta")
+    VideoSuggestionMetadata mMetadata;
+
+    /**
+     * Returns the score associated with this suggestion. The higher the score
+     * the more relevant the suggestion.
+     */
+    public int getScore() {
+        return mMetadata != null ? mMetadata.mScore : 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        VideoSuggestion that = (VideoSuggestion) o;
+
+        if (!mText.equals(that.mText)) { return false; }
+        return mMetadata != null ? mMetadata.equals(that.mMetadata) : that.mMetadata == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mText.hashCode();
+        result = 31 * result + (mMetadata != null ? mMetadata.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "VideoSuggestion{" +
+               "mText='" + mText + '\'' +
+               ", mMetadata=" + mMetadata +
+               '}';
+    }
+
+    @UseStag(FieldOption.SERIALIZED_NAME)
+    static class VideoSuggestionMetadata implements Serializable {
+
+        private static final long serialVersionUID = -5853739822133424630L;
+
+        @SerializedName("score")
+        int mScore;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
  * Created by zetterstromk on 2/21/17.
  */
 @UseStag(FieldOption.SERIALIZED_NAME)
-public class VideoSuggestion extends BaseSuggestion implements Serializable {
+public final class VideoSuggestion extends BaseSuggestion implements Serializable {
 
     private static final long serialVersionUID = -6047771941064977527L;
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
@@ -59,7 +59,7 @@ public class VideoSuggestion extends BaseSuggestion implements Serializable {
     }
 
     @UseStag(FieldOption.SERIALIZED_NAME)
-    static class VideoSuggestionMetadata implements Serializable {
+    public static class VideoSuggestionMetadata implements Serializable {
 
         private static final long serialVersionUID = -5853739822133424630L;
 


### PR DESCRIPTION
#### Ticket
[ADF-3](https://vimean.atlassian.net/browse/ADF-3)

#### Ticket Summary
We need to create some models to represent the response from `https://api.vimeo.com/suggest`

#### Implementation Summary
I created the necessary models, using a base class to contains the `text` field, since all suggestions will always have this. I also added in `toString`, `equals`, and `hashCode` methods.

#### How to Test
Using Postman or another rest client, hit `https://api.vimeo.com/suggest?query=cats&video_count=5&ondemand_title_count=5` and compare the response with the models created.
