### PR TITLE
Only run Danger when a Github token exists

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -66,7 +66,7 @@ platform :android do
     rescue => error
     end
     
-    if is_ci
+    if is_ci && ENV['DANGER_GITHUB_API_TOKEN']
       danger(use_bundle_exec: false)
     end
 


### PR DESCRIPTION
External PRs break Travis because env vars aren't available to them.