### PR TITLE
ADF-4 autocomplete methods

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
@@ -262,7 +262,7 @@ public final class Search {
             return null;
         }
 
-        Map<String, String> queryMap = new HashMap<>();
+        Map<String, String> queryMap = new HashMap<>(3);
         queryMap.put(Vimeo.PARAMETER_GET_QUERY, query);
 
         if (videoSuggestionCount > 0) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Search.java
@@ -25,7 +25,9 @@
 package com.vimeo.networking;
 
 import com.vimeo.networking.callbacks.ModelCallback;
+import com.vimeo.networking.model.error.VimeoError;
 import com.vimeo.networking.model.search.SearchResponse;
+import com.vimeo.networking.model.search.SuggestionResponse;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -229,6 +231,49 @@ public final class Search {
                 VimeoClient.getInstance().createQueryMap(query, refinementMap, fieldFilter);
         // VimeoClient is the end-all interactor with the retrofit service
         return VimeoClient.getInstance().search(queryMap, callback);
+    }
+
+    private static final String PARAM_VIDEO_SUGGESTION = "video_count";
+    private static final String PARAM_VOD_SUGGESTION = "ondemand_title_count";
+
+    /**
+     * API access to search suggestions.
+     *
+     * @param query                the text query to base suggestions off of. For best performance, the query should be
+     *                             3 characters or more, however, it works with as little as 1 character. If an empty
+     *                             string is provided, this method will immediately notify the callback of a failure
+     *                             and return null.
+     * @param videoSuggestionCount the number of video suggestions to receive. This determines the maximum number of
+     *                             items in the {@link SuggestionResponse#getVideoSuggestions()} list. This will
+     *                             be ignored if a value less than or equal to 0 is provided.
+     * @param vodSuggestionCount   the number of ondemand suggestions to receive. This determines the maximum number of
+     *                             items in the {@link SuggestionResponse#getOndemandSuggestionList()} list. This will
+     *                             be ignored if a value less than or equal to 0 is provided.
+     * @param callback             the callback to be invoked upon completion of this request
+     * @return a {@link Call} that can be used to cancel this request
+     */
+    @Nullable
+    public static Call<SuggestionResponse> suggest(@NotNull String query, int videoSuggestionCount,
+                                                   int vodSuggestionCount,
+                                                   @NotNull ModelCallback<SuggestionResponse> callback) {
+
+        if (query.isEmpty()) {
+            callback.failure(new VimeoError("Query cannot be empty!"));
+            return null;
+        }
+
+        Map<String, String> queryMap = new HashMap<>();
+        queryMap.put(Vimeo.PARAMETER_GET_QUERY, query);
+
+        if (videoSuggestionCount > 0) {
+            queryMap.put(PARAM_VIDEO_SUGGESTION, String.valueOf(videoSuggestionCount));
+        }
+
+        if (vodSuggestionCount > 0) {
+            queryMap.put(PARAM_VOD_SUGGESTION, String.valueOf(vodSuggestionCount));
+        }
+
+        return VimeoClient.getInstance().suggest(queryMap, callback);
     }
 
     public static class QueryParameterProvider {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -41,6 +41,7 @@ import com.vimeo.networking.model.error.ErrorCode;
 import com.vimeo.networking.model.error.VimeoError;
 import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.search.SearchResponse;
+import com.vimeo.networking.model.search.SuggestionResponse;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
 
 import org.jetbrains.annotations.NotNull;
@@ -1290,6 +1291,24 @@ public final class VimeoClient {
         call.enqueue(callback);
         return call;
     }
+
+    /**
+     * A package private search suggestions method. See {@link Search#suggest(String, int, int, ModelCallback)} for
+     * public usage of the suggestion API.
+     *
+     * @param queryMap the query parameters
+     * @param callback the callback to be invokedn when the call finishes
+     * @return the {@link Call} object provided by Retrofit
+     */
+    @Nullable
+    Call<SuggestionResponse> suggest(@NotNull Map<String, String> queryMap,
+                                     @NotNull ModelCallback<SuggestionResponse> callback) {
+        Call<SuggestionResponse> call = mVimeoService.suggest(getAuthHeader(), queryMap);
+        call.enqueue(callback);
+
+        return call;
+    }
+
 
     /**
      * Fetches the currently authenticated user from the API

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1283,7 +1283,7 @@ public final class VimeoClient {
      * @param callback the callback to be invoked when the call finishes
      * @return the Call object provided by the Retrofit service
      */
-    @Nullable
+    @NotNull
     Call<SearchResponse> search(@NotNull Map<String, String> queryMap,
                                 @NotNull ModelCallback<SearchResponse> callback) {
 
@@ -1300,7 +1300,7 @@ public final class VimeoClient {
      * @param callback the callback to be invokedn when the call finishes
      * @return the {@link Call} object provided by Retrofit
      */
-    @Nullable
+    @NotNull
     Call<SuggestionResponse> suggest(@NotNull Map<String, String> queryMap,
                                      @NotNull ModelCallback<SuggestionResponse> callback) {
         Call<SuggestionResponse> call = mVimeoService.suggest(getAuthHeader(), queryMap);

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -30,6 +30,7 @@ import com.vimeo.networking.model.Video;
 import com.vimeo.networking.model.VimeoAccount;
 import com.vimeo.networking.model.notifications.SubscriptionCollection;
 import com.vimeo.networking.model.search.SearchResponse;
+import com.vimeo.networking.model.search.SuggestionResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -214,4 +215,8 @@ public interface VimeoService {
     Call<SearchResponse> search(@Header("Authorization") String authHeader,
                                 @QueryMap Map<String, String> queryParams);
     // </editor-fold>
+
+    @GET("suggest")
+    Call<SuggestionResponse> suggest(@Header("Authorization") String authHeader,
+                                     @QueryMap Map<String, String> queryParams);
 }

--- a/vimeo-networking/src/test/java/com/vimeo/networking/SearchTest.java
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/SearchTest.java
@@ -1,0 +1,36 @@
+package com.vimeo.networking;
+
+import com.vimeo.networking.callbacks.ModelCallback;
+import com.vimeo.networking.model.error.VimeoError;
+import com.vimeo.networking.model.search.SuggestionResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import retrofit2.Call;
+
+/**
+ * Tests for the Search class
+ * <p>
+ * Created by zetterstromk on 2/22/17.
+ */
+public class SearchTest {
+
+    @Test
+    public void testSuggest_emptyQuery() throws Exception {
+        ModelCallback<SuggestionResponse> callback = new ModelCallback<SuggestionResponse>(SuggestionResponse.class) {
+            @Override
+            public void success(SuggestionResponse suggestionResponse) {
+
+            }
+
+            @Override
+            public void failure(VimeoError error) {
+
+            }
+        };
+        Call<SuggestionResponse> call = Search.suggest("", 0, 0, callback);
+
+        Assert.assertNull(call);
+    }
+}


### PR DESCRIPTION
#### Ticket
[ADF-4](https://vimean.atlassian.net/browse/ADF-4)

#### Ticket Summary
Before we can integrate autocomplete into the Android app, we need to add the necessary groundwork in the networking layer. This ticket is about creating the API call.

#### Implementation Summary
- [x] This relies upon #181 (Search suggestion models)

I created a simple retrofit service interface and wired it up to a `Search` method, `suggest`. This method takes a query, counts for the number of results to receive per type, and a callback. 

I also created a simple test to validate that null is returned when the query is empty.

#### How to Test
You can run the `SearchTest` if you'd like, but there is nothing to test aside from that, yet.
