### PR TITLE
VA-2203 Notification connection for type counts

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Connection.java
@@ -57,12 +57,6 @@ public class Connection implements Serializable {
     @GsonAdapterKey("viewable_total")
     public int viewableTotal;
 
-    @GsonAdapterKey("new_total")
-    int newTotal;
-
-    @GsonAdapterKey("unread_total")
-    int unreadTotal;
-
     @Nullable
     @GsonAdapterKey("name")
     public String name;
@@ -95,14 +89,6 @@ public class Connection implements Serializable {
 
     public int getViewableTotal() {
         return viewableTotal;
-    }
-
-    public int getNewTotal() {
-        return newTotal;
-    }
-
-    public int getUnreadTotal() {
-        return unreadTotal;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -22,6 +22,7 @@
 
 package com.vimeo.networking.model;
 
+import com.vimeo.networking.model.notifications.NotificationConnection;
 import com.vimeo.stag.GsonAdapterKey;
 
 import org.jetbrains.annotations.Nullable;
@@ -131,5 +132,5 @@ public class ConnectionCollection implements Serializable {
     public Connection watchedVideos;
     @Nullable
     @GsonAdapterKey("notifications")
-    public Connection notifications;
+    public NotificationConnection notifications;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Notification.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Notification.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.networking.model.Comment;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConnection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConnection.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.model.notifications;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.Connection;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A specialized {@link Connection} returned for notification connections
+ * <p>
+ * Created by zetterstromk on 2/22/17.
+ */
+@UseStag(FieldOption.SERIALIZED_NAME)
+public class NotificationConnection extends Connection {
+
+    private static final long serialVersionUID = 4908222195478449252L;
+
+    @SerializedName("new_total")
+    protected int newTotal;
+
+    @SerializedName("unread_total")
+    protected int unreadTotal;
+
+    @Nullable
+    @SerializedName("type_count")
+    protected NotificationTypeCount mTypeCount;
+
+    public int getNewTotal() {
+        return newTotal;
+    }
+
+    public int getUnreadTotal() {
+        return unreadTotal;
+    }
+
+    @Nullable
+    public NotificationTypeCount getTypeCount() {
+        return mTypeCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        NotificationConnection that = (NotificationConnection) o;
+
+        if (newTotal != that.newTotal) { return false; }
+        if (unreadTotal != that.unreadTotal) { return false; }
+        if (total != that.total) { return false; }
+        if (mTypeCount != null ? !mTypeCount.equals(that.mTypeCount) : that.mTypeCount != null) { return false; }
+        return uri != null ? uri.equals(that.uri) : that.uri == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = newTotal;
+        result = 31 * result + unreadTotal;
+        result = 31 * result + (mTypeCount != null ? mTypeCount.hashCode() : 0);
+        result = 31 * result + (uri != null ? uri.hashCode() : 0);
+        result = 31 * result + total;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationConnection{" +
+               "newTotal=" + newTotal +
+               ", unreadTotal=" + unreadTotal +
+               ", mTypeCount=" + mTypeCount +
+               ", uri='" + uri + '\'' +
+               ", total=" + total +
+               '}';
+    }
+
+    @UseStag(FieldOption.SERIALIZED_NAME)
+    public static final class NotificationTypeCount implements Serializable {
+
+        private static final long serialVersionUID = 6893381498380227512L;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_COMMENT)
+        protected int mCommentTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_CREDIT)
+        protected int mCreditTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_LIKE)
+        protected int mLikeTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_SHARE)
+        protected int mShareTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_VIDEO_AVAILABLE)
+        protected int mVideoAvailableTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_MENTION)
+        protected int mMentionTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_REPLY)
+        protected int mReplyTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_STORAGE_WARNING)
+        protected int mStorageWarningTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_FOLLOW)
+        protected int mFollowTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_ACCOUNT_EXPIRATION_WARNING)
+        protected int mAccountExpirationWarningTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_VOD_PURCHASE)
+        protected int mVodPurchaseTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_VOD_PREORDER_AVAILABLE)
+        protected int mVodPreorderAvailableTotal;
+
+        @SerializedName(NotificationConstants.NOTIFICATION_VOD_RENTAL_EXPIRATION_WARNING)
+        protected int mVodRentailExpirationWarningTotal;
+
+        public int getCommentTotal() {
+            return mCommentTotal;
+        }
+
+        public int getCreditTotal() {
+            return mCreditTotal;
+        }
+
+        public int getLikeTotal() {
+            return mLikeTotal;
+        }
+
+        public int getShareTotal() {
+            return mShareTotal;
+        }
+
+        public int getVideoAvailableTotal() {
+            return mVideoAvailableTotal;
+        }
+
+        public int getMentionTotal() {
+            return mMentionTotal;
+        }
+
+        public int getReplyTotal() {
+            return mReplyTotal;
+        }
+
+        public int getStorageWarningTotal() {
+            return mStorageWarningTotal;
+        }
+
+        public int getFollowTotal() {
+            return mFollowTotal;
+        }
+
+        public int getAccountExpirationWarningTotal() {
+            return mAccountExpirationWarningTotal;
+        }
+
+        public int getVodPurchaseTotal() {
+            return mVodPurchaseTotal;
+        }
+
+        public int getVodPreorderAvailableTotal() {
+            return mVodPreorderAvailableTotal;
+        }
+
+        public int getVodRentailExpirationWarningTotal() {
+            return mVodRentailExpirationWarningTotal;
+        }
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConnection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConnection.java
@@ -42,21 +42,21 @@ public class NotificationConnection extends Connection {
     private static final long serialVersionUID = 4908222195478449252L;
 
     @SerializedName("new_total")
-    protected int newTotal;
+    protected int mNewTotal;
 
     @SerializedName("unread_total")
-    protected int unreadTotal;
+    protected int mUnreadTotal;
 
     @Nullable
     @SerializedName("type_count")
     protected NotificationTypeCount mTypeCount;
 
     public int getNewTotal() {
-        return newTotal;
+        return mNewTotal;
     }
 
     public int getUnreadTotal() {
-        return unreadTotal;
+        return mUnreadTotal;
     }
 
     @Nullable
@@ -71,8 +71,8 @@ public class NotificationConnection extends Connection {
 
         NotificationConnection that = (NotificationConnection) o;
 
-        if (newTotal != that.newTotal) { return false; }
-        if (unreadTotal != that.unreadTotal) { return false; }
+        if (mNewTotal != that.mNewTotal) { return false; }
+        if (mUnreadTotal != that.mUnreadTotal) { return false; }
         if (total != that.total) { return false; }
         if (mTypeCount != null ? !mTypeCount.equals(that.mTypeCount) : that.mTypeCount != null) { return false; }
         return uri != null ? uri.equals(that.uri) : that.uri == null;
@@ -81,8 +81,8 @@ public class NotificationConnection extends Connection {
 
     @Override
     public int hashCode() {
-        int result = newTotal;
-        result = 31 * result + unreadTotal;
+        int result = mNewTotal;
+        result = 31 * result + mUnreadTotal;
         result = 31 * result + (mTypeCount != null ? mTypeCount.hashCode() : 0);
         result = 31 * result + (uri != null ? uri.hashCode() : 0);
         result = 31 * result + total;
@@ -92,8 +92,8 @@ public class NotificationConnection extends Connection {
     @Override
     public String toString() {
         return "NotificationConnection{" +
-               "newTotal=" + newTotal +
-               ", unreadTotal=" + unreadTotal +
+               "newTotal=" + mNewTotal +
+               ", unreadTotal=" + mUnreadTotal +
                ", mTypeCount=" + mTypeCount +
                ", uri='" + uri + '\'' +
                ", total=" + total +

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConstants.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationConstants.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 /**
@@ -12,6 +34,13 @@ public final class NotificationConstants {
     public static final String NOTIFICATION_REPLY = "reply";
     public static final String NOTIFICATION_FOLLOW = "follow";
     public static final String NOTIFICATION_VIDEO_AVAILABLE = "video_available";
+    public static final String NOTIFICATION_SHARE = "share";
+    public static final String NOTIFICATION_MENTION = "mention";
+    public static final String NOTIFICATION_STORAGE_WARNING = "storage_warning";
+    public static final String NOTIFICATION_ACCOUNT_EXPIRATION_WARNING = "account_expiration_warning";
+    public static final String NOTIFICATION_VOD_PURCHASE = "vod_purchase";
+    public static final String NOTIFICATION_VOD_PREORDER_AVAILABLE = "vod_preorder_available";
+    public static final String NOTIFICATION_VOD_RENTAL_EXPIRATION_WARNING = "vod_rental_expiration_warning";
 
     private NotificationConstants() {
     }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationList.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationList.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.networking.model.BaseResponseList;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/NotificationType.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 import org.jetbrains.annotations.NotNull;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/SubscriptionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/SubscriptionCollection.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.stag.GsonAdapterKey;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Subscriptions.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/notifications/Subscriptions.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.notifications;
 
 import com.vimeo.stag.GsonAdapterKey;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/BaseSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/BaseSuggestion.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.search;
 
 import com.google.gson.annotations.SerializedName;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/OndemandSuggestion.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.search;
 
 import com.google.gson.annotations.SerializedName;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SuggestionResponse.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/SuggestionResponse.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.search;
 
 import com.google.gson.annotations.SerializedName;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/search/VideoSuggestion.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.vimeo.networking.model.search;
 
 import com.google.gson.annotations.SerializedName;


### PR DESCRIPTION
#### Ticket
[VA-2203](https://vimean.atlassian.net/browse/VA-2203)

#### Ticket Summary
We need to add a new object onto the notification connection for type counts.

Also, somehow my copyright profile got messed up and wasn't adding copyrights, so I went back and added them to files I recently added.

#### Implementation Summary
I decided that since the new fields only applied to the notification `Connection`, that it'd be better to remove the fields from `Connection` and make a specialized `NotificationConnection` object. This has all the great fields of `Connection` with the additional properties sent specific to the `notification` connection.
