### PR TITLE
Backwards compatibility

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/PictureCollection.java
@@ -65,18 +65,18 @@ public class PictureCollection implements Serializable {
     }
 
     @Nullable
-    @SerializedName("uri")
+    @SerializedName(value = "uri", alternate = "m_uri")
     protected String mUri;
 
-    @SerializedName("active")
+    @SerializedName(value = "active", alternate = "m_is_active")
     protected boolean mIsActive;
 
     @Nullable
-    @SerializedName("type")
+    @SerializedName(value = "type", alternate = "m_type")
     protected String mType;
 
     @Nullable
-    @SerializedName("sizes")
+    @SerializedName(value = "sizes", alternate = "m_pictures")
     protected ArrayList<Picture> mPictures;
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Preferences.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Preferences.java
@@ -42,7 +42,7 @@ public class Preferences implements Serializable {
     private static final long serialVersionUID = -251634859829805204L;
 
     @Nullable
-    @SerializedName("videos")
+    @SerializedName(value = "videos", alternate = "m_videos")
     protected VideosPreference mVideos;
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Spatial.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Spatial.java
@@ -36,11 +36,11 @@ public class Spatial implements Serializable {
     }
 
     @NotNull
-    @SerializedName("projection")
+    @SerializedName(value = "projection", alternate = "m_projection")
     protected String mProjection;
 
     @NotNull
-    @SerializedName("stereo_format")
+    @SerializedName(value = "stereo_format", alternate = "m_stereo_format")
     protected String mStereoFormat;
 
     @NotNull

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/UserBadge.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/UserBadge.java
@@ -65,16 +65,16 @@ public class UserBadge implements Serializable {
         SUPPORT
     }
 
-    @SerializedName("type")
+    @SerializedName(value = "type", alternate = "m_badge_type")
     protected String mBadgeType;
 
-    @SerializedName("text")
+    @SerializedName(value = "text", alternate = "m_text")
     protected String mText;
 
-    @SerializedName("alt_text")
+    @SerializedName(value = "alt_text", alternate = "m_alternate_text")
     protected String mAlternateText;
 
-    @SerializedName("url")
+    @SerializedName(value = "url", alternate = "m_url")
     protected String mUrl;
 
     public String getText() {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -204,7 +204,7 @@ public class Video implements Serializable {
     public ArrayList<VideoFile> mDownload;
 
     @Nullable
-    @SerializedName("badge")
+    @SerializedName(value = "badge", alternate = "m_video_badge")
     public VideoBadge mVideoBadge;
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/VideosPreference.java
@@ -40,11 +40,11 @@ public class VideosPreference implements Serializable {
     private static final long serialVersionUID = 1956447486226253433L;
 
     @Nullable
-    @SerializedName("privacy")
+    @SerializedName(value = "privacy", alternate = "m_privacy")
     protected Privacy mPrivacy;
 
     @Nullable
-    @SerializedName("password")
+    @SerializedName(value = "password", alternate = "m_password")
     protected String mPassword;
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Drm.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Drm.java
@@ -47,11 +47,11 @@ public class Drm implements Serializable {
     private static final long serialVersionUID = 3048847922257143776L;
 
     @Nullable
-    @SerializedName("widevine")
+    @SerializedName(value = "widevine", alternate = "m_widevine")
     public VideoFile mWidevine;
 
     @Nullable
-    @SerializedName("playready")
+    @SerializedName(value = "playready", alternate = "m_play_ready")
     public VideoFile mPlayReady;
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
@@ -74,31 +74,31 @@ public class Play implements Serializable {
     }
 
     @Nullable
-    @SerializedName(value = "embed", alternate = {"m_embed"})
+    @SerializedName(value = "embed", alternate = "m_embed")
     protected Embed mEmbed;
 
     @Nullable
-    @SerializedName(value = "hls", alternate = {"m_hls"})
+    @SerializedName(value = "hls", alternate = "m_hls")
     protected VideoFile mHls;
 
     @Nullable
-    @SerializedName(value = "dash", alternate = {"m_dash"})
+    @SerializedName(value = "dash", alternate = "m_dash")
     protected VideoFile mDash;
 
     @Nullable
-    @SerializedName(value = "progressive", alternate = {"m_progressive"})
+    @SerializedName(value = "progressive", alternate = "m_progressive")
     protected ArrayList<VideoFile> mProgressive;
 
     @Nullable
-    @SerializedName(value = "progress", alternate = {"m_progress"})
+    @SerializedName(value = "progress", alternate = "m_progress")
     protected PlayProgress mProgress;
 
     @Nullable
-    @SerializedName(value = "status", alternate = {"m_status"})
+    @SerializedName(value = "status", alternate = "m_status")
     protected Status mStatus;
 
     @Nullable
-    @SerializedName(value = "drm", alternate = {"m_drm"})
+    @SerializedName(value = "drm", alternate = "m_drm")
     protected Drm mDrm;
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
@@ -74,31 +74,31 @@ public class Play implements Serializable {
     }
 
     @Nullable
-    @SerializedName("embed")
+    @SerializedName(value = "embed", alternate = {"m_embed"})
     protected Embed mEmbed;
 
     @Nullable
-    @SerializedName("hls")
+    @SerializedName(value = "hls", alternate = {"m_hls"})
     protected VideoFile mHls;
 
     @Nullable
-    @SerializedName("dash")
+    @SerializedName(value = "dash", alternate = {"m_dash"})
     protected VideoFile mDash;
 
     @Nullable
-    @SerializedName("progressive")
+    @SerializedName(value = "progressive", alternate = {"m_progressive"})
     protected ArrayList<VideoFile> mProgressive;
 
     @Nullable
-    @SerializedName("progress")
+    @SerializedName(value = "progress", alternate = {"m_progress"})
     protected PlayProgress mProgress;
 
     @Nullable
-    @SerializedName("status")
+    @SerializedName(value = "status", alternate = {"m_status"})
     protected Status mStatus;
 
     @Nullable
-    @SerializedName("drm")
+    @SerializedName(value = "drm", alternate = {"m_drm"})
     protected Drm mDrm;
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/PlayProgress.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/PlayProgress.java
@@ -43,7 +43,7 @@ public class PlayProgress implements Serializable {
     private static final long serialVersionUID = -3745271302058282379L;
 
     @Nullable
-    @SerializedName("seconds")
+    @SerializedName(value = "seconds", alternate = "m_seconds")
     protected Float mSeconds;
 
     /**


### PR DESCRIPTION
#### Summary
Due to a problem where we didn't use the stag serializer in some code, the field names were all broken because of the `@GsonAdapterKey` annotation. Since we have now replaced that annotation with the `@SerializedName` annotation which is picked up by gson regardless of whether the stag plugin is used, we need to add backwards compatibility for the broken cached json. The only classes that were affected were those that are referenced by `Video` and `VideoFile`.

#### Implementation Summary
By using the alternate name scheme, we can add these optional names as json keys to pick up what was broken. When these classes are serialized again, the `value` is used and the `alternate` values are ignored.
