### PR TITLE
Showing the latest released version as a badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ vimeo-networking is a Java networking library used for interacting with the Vime
 | master | [![Build Status](https://travis-ci.org/vimeo/vimeo-networking-java.svg?branch=master)](https://travis-ci.org/vimeo/vimeo-networking-java) |
 | v2.0.0 | [![Build Status](https://travis-ci.org/vimeo/vimeo-networking-java.svg?branch=v2.0.0)](https://travis-ci.org/vimeo/vimeo-networking-java) |
 
+| Latest Version |
+|----------------|
+| [![Download](https://api.bintray.com/packages/vimeo/maven/vimeo-networking/images/download.svg)](https://bintray.com/vimeo/maven/vimeo-networking/_latestVersion) |
 
 ## Contents
 * [Prerequisites](#prerequisites)


### PR DESCRIPTION
#### Summary
Since our default branch is v2.0.0 and we have so many changes ahead of our latest public release, it would be helpful to be able to see at a glance that the latest version of the library is in fact 1.1.0. We can do this by adding a badge to the readme as I have done here.