### PR TITLE
Fixing typo that broke commenting

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -73,7 +73,7 @@ public final class Vimeo {
     public static final String PARAMETER_VIDEO_PRIVACY = "privacy";
     public static final String PARAMETER_VIDEO_PASSWORD = "password";
 
-    public static final String PARAMETER_COMMENT_TEXT_BODY = "mText";
+    public static final String PARAMETER_COMMENT_TEXT_BODY = "text";
 
     public static final String PARAMETER_ACTIVE = "active";
 


### PR DESCRIPTION
#### Ticket
[VA-2299](https://vimean.atlassian.net/browse/VA-2299)

#### Ticket Summary
Commenting was broken due to a mistakenly renamed constant that was changed during conversion to hungarian notation.

#### Implementation Summary
The constant was changed back to its correct name (I also searched high and low for other "mXYZ" named constants and did not find any others).

#### How to Test
Try to make a comment post and it should now work as expected.