### PR TITLE
[FEATURE] ADF-126 Drakov support

### DIFF
--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 
-    def stagVersion = '2.1.1'
+    def stagVersion = '2.1.2'
     compile "com.vimeo.stag:stag-library:$stagVersion"
     apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -102,11 +102,9 @@ public final class VimeoClient {
      */
     private VimeoAccount mVimeoAccount;
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Configuration
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Configuration
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Configuration">
     @Nullable
     private static VimeoClient sSharedInstance;
@@ -204,6 +202,7 @@ public final class VimeoClient {
         }
     }
 
+    @NotNull
     public Retrofit getRetrofit() {
         return mRetrofit;
     }
@@ -255,11 +254,9 @@ public final class VimeoClient {
     }
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Authentication
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Authentication
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Authentication">
 
     /**
@@ -694,6 +691,7 @@ public final class VimeoClient {
      */
     private static class PinCodeAccountCallback extends AccountCallback {
 
+        @NotNull
         private final Timer mTimer;
 
         public PinCodeAccountCallback(@NotNull VimeoClient client, @NotNull AuthCallback callback,
@@ -704,9 +702,7 @@ public final class VimeoClient {
 
         private void cancelPolling() {
             VimeoClient.sContinuePinCodeAuthorizationRefreshCycle = false;
-            if (mTimer != null) {
-                mTimer.cancel();
-            }
+            mTimer.cancel();
         }
 
         @Override
@@ -854,11 +850,9 @@ public final class VimeoClient {
     }
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Editing (Video, User)
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Editing (Video, User)
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Editing (Video, User)">
     @Nullable
     public Call<Object> editVideo(String uri, String title, String description, @Nullable String password,
@@ -1035,11 +1029,9 @@ public final class VimeoClient {
     }
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Pictures
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Pictures
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Pictures">
 
     /**
@@ -1100,11 +1092,9 @@ public final class VimeoClient {
 
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Video actions (Like, Watch Later, Commenting)
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Video actions (Like, Watch Later, Commenting)
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Video actions (Like, Watch Later, Commenting)">
     public Call<Object> updateFollow(boolean follow, String uri, ModelCallback callback) {
         return updateFollow(follow, uri, callback, true);
@@ -1237,11 +1227,9 @@ public final class VimeoClient {
     }
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Gets, posts, puts, deletes
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Gets, posts, puts, deletes
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Gets, posts, puts, deletes">
     public void deleteVideo(String uri, Map<String, String> options, ModelCallback callback) {
         deleteContent(uri, options, callback, true);
@@ -1609,11 +1597,9 @@ public final class VimeoClient {
 
     // </editor-fold>
 
-    /**
-     * -----------------------------------------------------------------------------------------------------
-     * Header values
-     * -----------------------------------------------------------------------------------------------------
-     */
+    // -----------------------------------------------------------------------------------------------------
+    // Header values
+    // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Header values">
     public String getUserAgent() {
         return mConfiguration.mUserAgentString;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -152,7 +152,7 @@ public final class VimeoClient {
      * @param path    the path for which to change the base URL.
      * @param baseUrl the new base URL to use, may be null.
      */
-    public void setBaseUrlForRequest(@NotNull String path, @Nullable String baseUrl) {
+    public void setBaseUrlForRequest(@NotNull String path, @Nullable HttpUrl baseUrl) {
         mBaseUrlInterceptor.setBaseUrlForRequest(path, baseUrl);
     }
 
@@ -773,7 +773,7 @@ public final class VimeoClient {
         private final String mScope;
 
         PinCodePollingTimerTask(@NotNull PinCodeInfo pinCodeInfo, @NotNull Timer timer, int expiresInSeconds,
-                                @NotNull AuthCallback authCallback, @NotNull VimeoClient client,
+                                @NotNull AuthCallback authCallback, @Nullable VimeoClient client,
                                 @NotNull String scope) {
             mTimer = timer;
             mPinCodeInfo = pinCodeInfo;
@@ -860,7 +860,7 @@ public final class VimeoClient {
                 VimeoClient.sContinuePinCodeAuthorizationRefreshCycle = true;
                 mPinCodeAuthorizationTimer.scheduleAtFixedRate(
                         new PinCodePollingTimerTask(pinCodeInfo, mPinCodeAuthorizationTimer,
-                                                    pinCodeInfo.getExpiresIn(), authCallback, getInstance(),
+                                                    pinCodeInfo.getExpiresIn(), authCallback, sSharedInstance,
                                                     SCOPE), 0,
                         SECONDS_TO_MILLISECONDS * pinCodeInfo.getInterval());
             }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -144,16 +144,44 @@ public final class VimeoClient {
     }
 
     /**
-     * Sets a new base URL to be used for requests
-     * by the VimeoClient for specific paths. If a null
-     * base URL is provided, the default base URL will be
-     * used by the client.
+     * Sets a new base URL to be used for requests by the
+     * VimeoClient for specific paths. Only the included
+     * paths will have there base URL changed. If you
+     * have called {@link #excludePathsForBaseUrl(HttpUrl, String...)}
+     * before this, you must also call {@link #resetBaseUrl()}
+     * before calling this method. Any call to this method will
+     * override the previously used base URL.
      *
-     * @param path    the path for which to change the base URL.
-     * @param baseUrl the new base URL to use, may be null.
+     * @param baseUrl    the base URL.
+     * @param inclusions the paths to include. If this is empty,
+     *                   then no paths will be changed.
      */
-    public void setBaseUrlForRequest(@NotNull String path, @Nullable HttpUrl baseUrl) {
-        mBaseUrlInterceptor.setBaseUrlForRequest(path, baseUrl);
+    public void includePathsForBaseUrl(@NotNull HttpUrl baseUrl, @NotNull String... inclusions) {
+        mBaseUrlInterceptor.includePathsForBaseUrl(baseUrl, inclusions);
+    }
+
+    /**
+     * Sets a new base URL to be used for all requests
+     * by VimeoClient except the excluded paths. Excluded
+     * paths will be the only ones to not have their base
+     * changed. If you have called {@link #includePathsForBaseUrl(HttpUrl, String...)}
+     * before this, you must also call {@link #resetBaseUrl()}
+     * before calling this method. Any call to this method will
+     * override the previously used base URL.
+     *
+     * @param baseUrl    the base URL.
+     * @param exclusions the paths to exclude. If this is empty,
+     *                   then all paths will be changed.
+     */
+    public void excludePathsForBaseUrl(@NotNull HttpUrl baseUrl, @NotNull String... exclusions) {
+        mBaseUrlInterceptor.excludePathsForBaseUrl(baseUrl, exclusions);
+    }
+
+    /**
+     * Resets the base URL used by the VimeoClient.
+     */
+    public void resetBaseUrl() {
+        mBaseUrlInterceptor.resetBaseUrl();
     }
 
     @NotNull

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/BaseUrlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/BaseUrlInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking.utils;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * An interceptor that modifies the base URL for
+ * various requests. The base URL can be modified
+ * on a per request basis.
+ */
+public final class BaseUrlInterceptor implements Interceptor {
+
+    public BaseUrlInterceptor() {}
+
+    @NotNull
+    private final Map<String, String> mBaseUrlMap = new HashMap<>();
+
+    /**
+     * Sets the base URL used for requests
+     * on a specific path.
+     *
+     * @param path    the path to redirect to a different host.
+     * @param baseUrl the different host to use.
+     */
+    public void setBaseUrlForRequest(@NotNull String path, @Nullable String baseUrl) {
+        if (!path.startsWith("/")) {
+            path = '/' + path;
+        }
+
+        mBaseUrlMap.put(path, baseUrl);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        String baseUrl = mBaseUrlMap.get(request.url().encodedPath());
+        if (baseUrl != null) {
+            HttpUrl httpUrl = HttpUrl.parse(baseUrl);
+            HttpUrl newUrl = request.url().newBuilder()
+                    .host(httpUrl.host())
+                    .scheme(httpUrl.scheme())
+                    .username(httpUrl.username())
+                    .password(httpUrl.password())
+                    .port(httpUrl.port())
+                    .build();
+            request = request.newBuilder()
+                    .url(newUrl)
+                    .build();
+        }
+        return chain.proceed(request);
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/BaseUrlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/BaseUrlInterceptor.java
@@ -45,7 +45,7 @@ public final class BaseUrlInterceptor implements Interceptor {
     public BaseUrlInterceptor() {}
 
     @NotNull
-    private final Map<String, String> mBaseUrlMap = new HashMap<>();
+    private final Map<String, HttpUrl> mBaseUrlMap = new HashMap<>();
 
     /**
      * Sets the base URL used for requests
@@ -54,7 +54,7 @@ public final class BaseUrlInterceptor implements Interceptor {
      * @param path    the path to redirect to a different host.
      * @param baseUrl the different host to use.
      */
-    public void setBaseUrlForRequest(@NotNull String path, @Nullable String baseUrl) {
+    public void setBaseUrlForRequest(@NotNull String path, @Nullable HttpUrl baseUrl) {
         if (!path.startsWith("/")) {
             path = '/' + path;
         }
@@ -65,15 +65,14 @@ public final class BaseUrlInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        String baseUrl = mBaseUrlMap.get(request.url().encodedPath());
+        HttpUrl baseUrl = mBaseUrlMap.get(request.url().encodedPath());
         if (baseUrl != null) {
-            HttpUrl httpUrl = HttpUrl.parse(baseUrl);
             HttpUrl newUrl = request.url().newBuilder()
-                    .host(httpUrl.host())
-                    .scheme(httpUrl.scheme())
-                    .username(httpUrl.username())
-                    .password(httpUrl.password())
-                    .port(httpUrl.port())
+                    .host(baseUrl.host())
+                    .scheme(baseUrl.scheme())
+                    .username(baseUrl.username())
+                    .password(baseUrl.password())
+                    .port(baseUrl.port())
                     .build();
             request = request.newBuilder()
                     .url(newUrl)

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/Preconditions.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/Preconditions.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking.utils;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Used for checking preconditions.
+ * <p>
+ * Created by restainoa on 4/27/17.
+ */
+final class Preconditions {
+
+    private Preconditions() {}
+
+    /**
+     * Checks that the condition is true
+     * with an optional message that is
+     * displayed if it is not true.
+     *
+     * @param condition the condition.
+     * @param message   the message to show in
+     *                  case of failure.
+     */
+    static void checkIsTrue(boolean condition, @Nullable String message) {
+        if (!condition) {
+            throw new RuntimeException(message);
+        }
+    }
+
+}

--- a/vimeo-networking/src/test/java/com/vimeo/networking/utils/BaseUrlInterceptorTest.java
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/utils/BaseUrlInterceptorTest.java
@@ -1,0 +1,200 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.utils;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import okhttp3.Connection;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor.Chain;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Tests for {@link BaseUrlInterceptor}.
+ * <p>
+ * Created by restainoa on 4/27/17.
+ */
+public class BaseUrlInterceptorTest {
+
+    private BaseUrlInterceptor mBaseUrlInterceptor;
+
+    @Before
+    public void setUp() throws Exception {
+        mBaseUrlInterceptor = new BaseUrlInterceptor();
+    }
+
+    @NotNull
+    private static Chain createVerificationChain(@NotNull final HttpUrl originalUrl, @NotNull final HttpUrl proceedUrl) {
+        return new Chain() {
+            @Override
+            public Request request() {
+                return new Request.Builder().url(originalUrl).build();
+            }
+
+            @Override
+            public Response proceed(Request request) throws IOException {
+                Assert.assertEquals(proceedUrl.host(), request.url().host());
+                return null;
+            }
+
+            @Override
+            public Connection connection() {
+                return null;
+            }
+        };
+    }
+
+    @NotNull
+    private static HttpUrl createTestUrlForPath(@Nullable String path) {
+        StringBuilder url = new StringBuilder("http://test.vimeo.com");
+        if (path != null) {
+            url.append(path);
+        }
+        return HttpUrl.parse(url.toString());
+    }
+
+    @Test
+    public void test_includePathsForBaseUrl_PreSanitizedPaths_SuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl, "/me", "/you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+
+    @Test
+    public void test_includePathsForBaseUrl_UnsanitizedPaths_SuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl, "me", "you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+
+    @Test
+    public void test_includePathsForBaseUrl_EmptyPaths_UnsuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl);
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+
+    @Test
+    public void test_excludePathsForBaseUrl_PreSanitizedPaths_SuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl, "/me", "/you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), httpUrl));
+    }
+
+    @Test
+    public void test_excludePathsForBaseUrl_UnsanitizedPaths_SuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl, "me", "you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), httpUrl));
+    }
+
+    @Test
+    public void test_excludePathsForBaseUrl_EmptyPaths_UnsuccessfullyIntercepts() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl);
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), httpUrl));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_excludeThenIncludePathsForBaseUrl_NoReset_ThrowsException() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl);
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_includeThenExcludePathsForBaseUrl_NoReset_ThrowsException() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl);
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl);
+    }
+
+    @Test
+    public void test_excludeThenIncludePathsForBaseUrl_Reset_Includes() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl, "/me", "/you");
+        mBaseUrlInterceptor.resetBaseUrl();
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl, "/me", "/you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), httpUrl));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+
+    @Test
+    public void test_includeThenExcludePathsForBaseUrl_Reset_Exclues() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl, "/me", "/you");
+        mBaseUrlInterceptor.resetBaseUrl();
+        mBaseUrlInterceptor.excludePathsForBaseUrl(httpUrl, "/me", "/you");
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), httpUrl));
+    }
+
+    @Test
+    public void test_NoIncludeOrExclude_NoIntercept() throws Exception {
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+
+    @Test
+    public void test_resetBaseUrl_AfterInclude_NoIntercept() throws Exception {
+        HttpUrl httpUrl = HttpUrl.parse("http://localhost");
+        mBaseUrlInterceptor.includePathsForBaseUrl(httpUrl, "/me", "/you");
+        mBaseUrlInterceptor.resetBaseUrl();
+
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/me"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/you"), createTestUrlForPath(null)));
+        mBaseUrlInterceptor.intercept(createVerificationChain(createTestUrlForPath("/them"), createTestUrlForPath(null)));
+    }
+}


### PR DESCRIPTION
#### Ticket
[ADF-126](https://vimean.atlassian.net/browse/ADF-126)

#### Ticket Summary
We would like to start using Drakov (https://github.com/Aconex/drakov) to support mocking API calls. We would like to support changing the host on a per request basis.

#### Implementation Summary
There were a few approaches to implementing this support. 

The first would have been to add a URL parameter to every request method in `VimeoService` and to propagate that change outward. This seemed like an extremely disruptive change to make for something that is not going to be used frequently. Additionally, adding it as a parameter on service calls would affect client code negatively, making it more complicated.

A second would be to recreate the retrofit client whenever we needed to change the base URL. This approach was not friendly for consumers that would be changing the base URL a lot and would have created some very confusing logic in the client in order to support this feature on a per request basis.

The solution chosen was to use a custom interceptor to change the base URL and set that on the OkHttpClient used by the Retrofit instance. See here for discussion on this being the correct approach for dynamically changing the base URL (https://github.com/square/retrofit/issues/1404#issuecomment-207408548, https://gist.github.com/swankjesse/8571a8207a5815cca1fb) The interceptor holds a map of endpoints that should be redirected to a different base URL, and access to this interceptor is regulated by the `VimeoClient`. This allows for a good balance of adaptability and low side affects. It has almost no impact on the client code, and allows different API calls to be changed. As an example, the code to change the base URL for all requests to the list of staff picks videos and the request to the staff picks channel itself is as follows:

```java
HttpUrl newBaseUrl = HttpUrl.parse("https://api.vimeo-staging.com/");
VimeoClient.getInstance().includePathsForBaseUrl(newBaseUrl, "/channels/927", "/channels/927/videos");
```

This method `includePathsForBaseUrl` can be called from anywhere, and after it is called, every call to the supplied path will be changed to the new host. Currently, the URI paths supplied must match exactly, which is why two calls for both the channel URI and the URI for the videos in that channel must be made. A potential solution to this problem would be allowing a more lenient matching mechanism. I wanted this to be specific as possible though, and if we decide to make it more lenient then it should be able to be easily changed.

#### How to Test
Drop the above lines of code anywhere in the client app and observe that the base URL is changed in the requests.
