### PR TITLE
ADF-154 consistent user agent

### DIFF
--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -6,6 +6,9 @@ compileJava {
     targetCompatibility = 1.7
 }
 
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
+
 buildscript {
     repositories {
         maven {
@@ -14,10 +17,12 @@ buildscript {
     }
     dependencies {
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.6'
+        classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
     }
 }
 
 apply plugin: 'net.ltgt.apt'
+apply plugin: 'de.fuerstenau.buildconfig'
 
 repositories {
     jcenter()
@@ -39,6 +44,14 @@ dependencies {
 
 group = 'com.vimeo.networking'
 version = '1.1.0'
+
+buildConfig {
+    appName = project.name
+    version = project.version
+
+    clsName = 'BuildConfig'
+    packageName = project.group
+}
 
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -133,7 +133,7 @@ public final class VimeoClient {
         mCache = mConfiguration.getCache();
         mRetrofit = createRetrofit();
         mVimeoService = mRetrofit.create(VimeoService.class);
-        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION;
+        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
         ClientLogger.setLogProvider(mConfiguration.mLogProvider);
         ClientLogger.setLogLevel(mConfiguration.mLogLevel);
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -97,6 +97,9 @@ public final class VimeoClient {
     private final Gson mGson;
     private Timer mPinCodeAuthorizationTimer;
 
+    @NotNull
+    private final String mLibraryUserAgentComponent;
+
     /**
      * Currently authenticated account
      */
@@ -130,11 +133,23 @@ public final class VimeoClient {
         mCache = mConfiguration.getCache();
         mRetrofit = createRetrofit();
         mVimeoService = mRetrofit.create(VimeoService.class);
+        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION;
         ClientLogger.setLogProvider(mConfiguration.mLogProvider);
         ClientLogger.setLogLevel(mConfiguration.mLogLevel);
 
         VimeoAccount vimeoAccount = mConfiguration.loadAccount();
         setVimeoAccount(vimeoAccount);
+    }
+
+    @NotNull
+    private String createUserAgent() {
+        String userProvidedAgent = mConfiguration.getUserAgentString();
+
+        if (userProvidedAgent != null && !userProvidedAgent.isEmpty()) {
+            return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
+        } else {
+            return mLibraryUserAgentComponent;
+        }
     }
 
     private Retrofit createRetrofit() {
@@ -168,7 +183,7 @@ public final class VimeoClient {
 
                         // Customize the request to add the user agent and accept header to all of them
                         Request request = original.newBuilder()
-                                .header(Vimeo.HEADER_USER_AGENT, mConfiguration.mUserAgentString)
+                                .header(Vimeo.HEADER_USER_AGENT, createUserAgent())
                                 .header(Vimeo.HEADER_ACCEPT, getAcceptHeader())
                                 .method(original.method(), original.body())
                                 .build();
@@ -1616,7 +1631,7 @@ public final class VimeoClient {
      */
     // <editor-fold desc="Header values">
     public String getUserAgent() {
-        return mConfiguration.mUserAgentString;
+        return createUserAgent();
     }
 
     public String getAcceptHeader() {


### PR DESCRIPTION
#### Ticket
[ADF-154](https://vimean.atlassian.net/browse/ADF-154)

#### Ticket Summary
In order to begin publicly supporting beta versions of the networking API, the networking library needs to begin identifying itself as the source of requests using the user agent string.

See https://github.vimeows.com/Vimeo-API/api/issues/1141#issuecomment-143397

#### Implementation Summary
The format of the user agent is as follows:
```
[Optional consumer supplied UA] VimeoNetworking/version (Java)
```

The version is retrieved at runtime from a generated `BuildConfig` class.

#### How to Test
Make a request with the VimeoClient and ensure that the user agent has at least `VimeoNetworking/1.1.0 (Java)` in it.
