### PR TITLE
Follow User Agent RFC Spec

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -146,7 +146,7 @@ public final class VimeoClient {
         String userProvidedAgent = mConfiguration.getUserAgentString();
 
         if (userProvidedAgent != null && !userProvidedAgent.isEmpty()) {
-            return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
+            return mLibraryUserAgentComponent + ' ' + userProvidedAgent;
         } else {
             return mLibraryUserAgentComponent;
         }


### PR DESCRIPTION
#### Summary
Based on the RFC spec for user agents, the primary identifier should be the first thing in the UA. The VimeoNetworking portion of the UA was being appended, which is not in accordance to the spec. This PR ensures that the implementation is up to spec.

Original PR: https://github.com/vimeo/vimeo-networking-java/pull/206
RFC Spec: https://tools.ietf.org/html/rfc7231#section-5.5.3