### PR TITLE
CI-450: publish to JCenter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - rvm install 2.2
   - rvm use 2.2
   - bundle install
-  - FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane test
+  - FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane shipit
 notifications:
   slack:
     rooms:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,38 @@ platform :android do
     end
   end
 
+  desc "main entrypoint for CI"
+  lane :shipit do
+    if is_ci
+      # If the build was triggered by a Pull Request
+      if ENV['TRAVIS_PULL_REQUEST']
+        test
+      else
+        # This build was triggered by a branch update
+        branch = git_branch
+        # If the branch is master, this means new updates were merged into master
+        # Then publish the artifacts to bintray
+        if branch == 'origin/master'
+          publish_artifacts
+        end
+      end
+    end
+  end
+
+  desc "publish artifacts to bintray"
+  lane :publish_artifacts do
+
+    # Upload to bintray
+    gradle(
+      task: "vimeo-networking:bintrayUpload"
+    )
+
+    # Sync version files to a oss.sonatype.org staging repository to publish these files to Maven Central.
+    # https://bintray.com/docs/api/#_sync_version_artifacts_to_maven_central
+    sh "curl -X POST -d '{\"username\": \"#{ENV['SONATYPE_TOKEN_USER']}\", \"password\": \"#{ENV['SONATYPE_TOKEN_PASSWORD']}\"}' https://api.bintray.com/maven_central_sync/vimeo/maven/vimeo-networking/versions/#{get_version}"
+
+  end
+    
   desc "test"
   lane :test do
     
@@ -79,6 +111,13 @@ platform :android do
       danger(use_bundle_exec: false)
     end
 
+  end
+  
+  desc "get the version from gradle.properties"
+  private_lane :get_version do
+    str = IO.read('../gradle.properties')    
+    match = str.match(/version[ ]?=[ ]?'([0-9.]+)'/)
+    match.length == 2 ? match[1] : 0
   end
 
   # You can define as many lanes as you want

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,11 +1,45 @@
 fastlane documentation
 ================
 # Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
 ```
-sudo gem install fastlane
+xcode-select --install
 ```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+
 # Available Actions
 ## Android
+### android entrypoint
+```
+fastlane android entrypoint
+```
+main entrypoint for CI
+### android publish_artifacts
+```
+fastlane android publish_artifacts
+```
+publish artifacts to bintray
 ### android test
 ```
 fastlane android test
@@ -15,5 +49,5 @@ test
 ----
 
 This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
-More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@
 
 org.gradle.parallel=true
 org.gradle.daemon=true
+version='1.1.0'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 }
 
 group = 'com.vimeo.networking'
-version = '1.1.0'
 
 buildConfig {
     appName = project.name
@@ -91,10 +90,15 @@ allprojects {
         def bintrayProject = project.plugins.hasPlugin('com.jfrog.bintray')
         if (bintrayProject) {
             bintray {
-                Properties properties = new Properties()
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                user = properties.getProperty('bintray.user')
-                key = properties.getProperty('bintray.apikey')
+                // CI Publish - next 2 lines
+                user = System.getenv('BINTRAY_USER')
+                // api key
+                key = System.getenv('BINTRAY_API_KEY')
+                // Local publish - uncomment the next 4 lines
+                // Properties properties = new Properties()
+                // properties.load(project.rootProject.file('local.properties').newDataInputStream())
+                // user = properties.getProperty('bintray.user')
+                // key = properties.getProperty('bintray.apikey')
                 publications = ['mavenJava']
                 dryRun = false // Whether to run this as dry-run, without deploying
                 pkg {


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CI-450](https://vimean.atlassian.net/browse/CI-450)

Moved version to build.properties for readability

Changed Travis entrypoint to the `entrypoint` Fastlane lane.

Added `publish_artifacts` lane