### PR TITLE
ADF-202 Extract Retrofit setup code to new classes

### DIFF
--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 
 compileJava {
@@ -10,6 +11,7 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 buildscript {
+    ext.kotlin_version = '1.1.3-2'
     repositories {
         maven {
             url 'https://plugins.gradle.org/m2/'
@@ -18,6 +20,7 @@ buildscript {
     dependencies {
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.6'
         classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -32,6 +35,7 @@ tasks.withType(Javadoc).all { enabled = true }
 
 dependencies {
     testCompile 'junit:junit:4.12'
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.intellij:annotations:12.0@jar'
 

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -11,7 +11,6 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 buildscript {
-    ext.kotlin_version = '1.1.3-2'
     repositories {
         maven {
             url 'https://plugins.gradle.org/m2/'
@@ -20,7 +19,6 @@ buildscript {
     dependencies {
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.6'
         classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -357,6 +357,11 @@ public class Configuration {
             return this;
         }
 
+        public Builder setScope(String scope) {
+            this.mScope = scope;
+            return this;
+        }
+
         public Builder setAccountStore(AccountStore accountStore) {
             this.mAccountStore = accountStore;
             return this;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -96,7 +96,7 @@ class RetrofitSetup {
      * OkHttp setup.
      */
     @NotNull
-    private OkHttpClient createOkHttpClient() {
+    OkHttpClient createOkHttpClient() {
         final RetrofitClientBuilder retrofitClientBuilder = new RetrofitClientBuilder();
         if (mCache != null) {
             retrofitClientBuilder.setCache(mCache);

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -117,7 +117,7 @@ class RetrofitSetup {
     /**
      * Try and pin certificates to prevent man-in-the-middle attacks (if pinning is enabled)
      */
-    private void setupCertPinning(RetrofitClientBuilder retrofitClientBuilder) {
+    private void setupCertPinning(@NotNull RetrofitClientBuilder retrofitClientBuilder) {
         if (mConfiguration.mCertPinningEnabled) {
             try {
                 retrofitClientBuilder.pinCertificates();

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking;
+
+import com.google.gson.Gson;
+import com.vimeo.networking.interceptors.AcceptHeaderInterceptor;
+import com.vimeo.networking.interceptors.CacheControlInterceptor;
+import com.vimeo.networking.interceptors.UserAgentInterceptor;
+import com.vimeo.networking.logging.ClientLogger;
+import com.vimeo.networking.logging.LoggingInterceptor;
+import com.vimeo.networking.utils.VimeoNetworkUtil;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+/**
+ * Retrofit setup code.  Used to create an instance of {@link Retrofit} to make API requests.
+ * Created by brentwatson on 8/7/17.
+ */
+class RetrofitSetup {
+
+    /**
+     * Configuration object used to pass timeout, interceptors, etc for Retrofit setup.
+     */
+    @NotNull
+    private final Configuration mConfiguration;
+
+    /**
+     * OkHttp {@link Cache} implementation used to cache API request/response values.
+     */
+    @Nullable
+    private final Cache mCache;
+
+    /**
+     * {@link Gson} object used to marshal / unmarshal JSON responses.
+     */
+    @NotNull
+    private final Gson mGson;
+
+    /**
+     * Value appended to {@code User-Agent} header to identify which version of this library is used.
+     */
+    @NotNull
+    private final String mLibraryUserAgentComponent;
+
+    RetrofitSetup(@NotNull Configuration configuration, @Nullable Cache cache) {
+        mConfiguration = configuration;
+        mCache = cache;
+        mGson = VimeoNetworkUtil.getGson();
+        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
+    }
+
+    /**
+     * @return a functional instance of {@link Retrofit} that can be used to make requests to the
+     * Vimeo API endpoints, with appropriate interceptors, timeouts, and cache configured.
+     */
+    @NotNull
+    @SuppressWarnings("WeakerAccess")
+    public Retrofit createRetrofit() {
+        return new Retrofit.Builder().baseUrl(mConfiguration.mBaseURLString)
+                .client(createOkHttpClient())
+                .addConverterFactory(GsonConverterFactory.create(mGson))
+                .build();
+    }
+
+    /**
+     * OkHttp setup.
+     */
+    @NotNull
+    private OkHttpClient createOkHttpClient() {
+        final RetrofitClientBuilder retrofitClientBuilder = new RetrofitClientBuilder();
+        if (mCache != null) {
+            retrofitClientBuilder.setCache(mCache);
+        }
+        retrofitClientBuilder.addNetworkInterceptor(new CacheControlInterceptor())
+                .setReadTimeout(mConfiguration.mTimeout, TimeUnit.SECONDS)
+                .setConnectionTimeout(mConfiguration.mTimeout, TimeUnit.SECONDS)
+                .addInterceptor(new LoggingInterceptor())
+                .addInterceptor(new UserAgentInterceptor(createUserAgent()))
+                .addInterceptor(new AcceptHeaderInterceptor())
+                .addNetworkInterceptors(mConfiguration.mNetworkInterceptors)
+                .addInterceptors(mConfiguration.mInterceptors);
+
+        setupCertPinning(retrofitClientBuilder);
+        return retrofitClientBuilder.build();
+    }
+
+    /**
+     * Try and pin certificates to prevent man-in-the-middle attacks (if pinning is enabled)
+     */
+    private void setupCertPinning(RetrofitClientBuilder retrofitClientBuilder) {
+        if (mConfiguration.mCertPinningEnabled) {
+            try {
+                retrofitClientBuilder.pinCertificates();
+            } catch (final Exception e) {
+                ClientLogger.e("Exception when pinning certificate: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * @return value used for {@code User-Agent} HTTP header value.
+     */
+    @NotNull
+    String createUserAgent() {
+        final String userProvidedAgent = mConfiguration.getUserAgentString();
+
+        if (userProvidedAgent != null && !userProvidedAgent.isEmpty()) {
+            return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
+        } else {
+            return mLibraryUserAgentComponent;
+        }
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -32,7 +32,7 @@ public final class Vimeo {
 
     public static final String VIMEO_BASE_URL_STRING = "https://api.vimeo.com/";
 
-    static final String API_VERSION = "3.3.3";
+    public static final String API_VERSION = "3.3.3";
 
     // Global Constants
     public static final int NOT_FOUND = -1;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/AcceptHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/AcceptHeaderInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.interceptors;
+
+import com.vimeo.networking.Vimeo;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Add custom {@code Accept} header to all requests.
+ * Created by brentwatson on 8/7/17.
+ */
+public class AcceptHeaderInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request())
+                .newBuilder()
+                .header(Vimeo.HEADER_ACCEPT, getAcceptHeader())
+                .build();
+    }
+
+    private String getAcceptHeader() {
+        return "application/vnd.vimeo.*+json; version=" + Vimeo.API_VERSION;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/AcceptHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/AcceptHeaderInterceptor.java
@@ -39,10 +39,8 @@ public class AcceptHeaderInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        return chain.proceed(chain.request())
-                .newBuilder()
-                .header(Vimeo.HEADER_ACCEPT, getAcceptHeader())
-                .build();
+        return chain.proceed(
+                chain.request().newBuilder().header(Vimeo.HEADER_ACCEPT, getAcceptHeader()).build());
     }
 
     private String getAcceptHeader() {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.interceptors;
+
+import com.vimeo.networking.Vimeo;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Rewrite the server's cache-control header because our server sets all {@code Cache-Control} headers
+ * to {@code no-store}
+ * Created by brentwatson on 8/7/17.
+ */
+public class CacheControlInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request())
+                .newBuilder()
+                .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
+                .build();
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
@@ -40,9 +40,9 @@ public class CacheControlInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        return chain.proceed(chain.request())
-                .newBuilder()
-                .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
-                .build();
+        return chain.proceed(chain.request()
+                                     .newBuilder()
+                                     .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
+                                     .build());
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/UserAgentInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/UserAgentInterceptor.java
@@ -48,9 +48,7 @@ public class UserAgentInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        return chain.proceed(chain.request())
-                .newBuilder()
-                .header(Vimeo.HEADER_USER_AGENT, mUserAgent)
-                .build();
+        return chain.proceed(
+                chain.request().newBuilder().header(Vimeo.HEADER_USER_AGENT, mUserAgent).build());
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/UserAgentInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/UserAgentInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.interceptors;
+
+import com.vimeo.networking.Vimeo;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Add custom {@code User-Agent} header to all requests.
+ * Created by brentwatson on 8/7/17.
+ */
+public class UserAgentInterceptor implements Interceptor {
+
+    @NotNull
+    private final String mUserAgent;
+
+    public UserAgentInterceptor(@NotNull String userAgent) {
+        mUserAgent = userAgent;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request())
+                .newBuilder()
+                .header(Vimeo.HEADER_USER_AGENT, mUserAgent)
+                .build();
+    }
+}

--- a/vimeo-networking/src/test/java/com/vimeo/networking/RetrofitSetupTest.kt
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/RetrofitSetupTest.kt
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking
+
+import com.vimeo.networking.Configuration.Builder
+import com.vimeo.networking.logging.ClientLogger
+import okhttp3.*
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [RetrofitSetup].
+ * Created by brentwatson on 8/8/17.
+ */
+class RetrofitSetupTest {
+
+    @Before
+    fun setUp() {
+        ClientLogger.setLogLevel(Vimeo.LogLevel.ERROR)
+    }
+
+    /**
+     * Test that the headers we added using `Interceptor`s are what we expect.
+     */
+    @Test
+    fun testInjectedHeaders() {
+        // These values will get set by the interceptor below:
+        var acceptHeader = "(unset)"
+        var userAgentHeader = "(unset)"
+
+        val configuration = Builder("")
+                .setBaseUrl("http://unittesting")
+                .setClientIdAndSecret("unit", "testing")
+                .setScope("unittesting")
+                .setUserAgentString("unit-testing-user-agent") // <-- This value will be asserted
+                .enableCertPinning(false)
+                .addInterceptor { chain ->
+                    // Intercept request and return some static data
+                    val mockResponse = ResponseBody.create(MediaType.parse("application/json"), "{'unit': 'testing'}")
+
+                    // Store HTTP header values that we will assert.
+                    val request = chain.request().apply {
+                        acceptHeader = header(Vimeo.HEADER_ACCEPT)
+                        userAgentHeader = header(Vimeo.HEADER_USER_AGENT)
+                    }
+
+                    // Return static response (avoiding actual network request in unit testing)
+                    Response.Builder().request(request)
+                            .protocol(Protocol.HTTP_1_1)
+                            .code(200)
+                            .body(mockResponse)
+                            .build()
+                }
+                .build()
+
+        with(RetrofitSetup(configuration, null).createOkHttpClient()) {
+            val request = Request.Builder().url("http://unit.test").build()
+            newCall(request).execute()
+        }
+
+        assertTrue("ACCEPT header does not start as expected: [$acceptHeader]",
+                acceptHeader.startsWith("application/vnd.vimeo.*+json;"))
+        assertTrue("USER-AGENT header does not contain 'unit-testing-user-agent': [$userAgentHeader]",
+                userAgentHeader.contains("unit-testing-user-agent"))
+        assertTrue("USER-AGENT header does not contain 'VimeoNetworking': [$userAgentHeader]",
+                userAgentHeader.contains("VimeoNetworking"))
+    }
+}


### PR DESCRIPTION
#### Ticket
[ADF-202](https://vimean.atlassian.net/browse/ADF-202)

#### Ticket Summary
`VimeoClient` is responsible for too much.  This change moves the setting up of Retrofit to a new `RetrofitSetup` class, and pulls various Interceptors into their own classes in a new `interceptors` package.

#### Implementation Summary
- New `RetrofitSetup` class used to configure Retrofit.
- new `interceptors` package holding extracted Interceptors.

#### How to Test
Make sure you can login and navigate app.  Use Charles proxy to ensure custom headers are being sent as before.