### PR TITLE
Google auth endpoints

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -44,6 +44,7 @@ public final class Vimeo {
     public static final String CODE_GRANT_TYPE = "authorization_code";
     public static final String DEVICE_GRANT_TYPE = "device_grant";
     public static final String FACEBOOK_GRANT_TYPE = "facebook";
+    public static final String GOOGLE_GRANT_TYPE = "google";
     public static final String PASSWORD_GRANT_TYPE = "password";
     public static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     public static final String OAUTH_ONE_GRANT_TYPE = "vimeo_oauth1";
@@ -61,6 +62,7 @@ public final class Vimeo {
     public static final String PARAMETER_STATE = "state";
     public static final String PARAMETER_SCOPE = "scope";
     public static final String PARAMETER_TOKEN = "token";
+    public static final String PARAMETER_ID_TOKEN = "id_token";
     public static final String PARAMETER_CLIENT_ID = "client_id";
 
     public static final String PARAMETER_USERS_NAME = "name";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -466,18 +466,12 @@ final public class VimeoClient {
     }
 
     @Nullable
-    public Call<VimeoAccount> joinWithFacebookToken(String facebookToken, String email, AuthCallback callback) {
-        if (callback == null) {
-            throw new AssertionError("Callback cannot be null");
-        }
-
-        if (facebookToken == null || facebookToken.isEmpty()) {
+    public Call<VimeoAccount> joinWithFacebookToken(@NotNull final String facebookToken, @NotNull final String email,
+                                                    @NotNull final AuthCallback callback) {
+        if (facebookToken.isEmpty()) {
             final VimeoError error = new VimeoError("Facebook authentication error.");
-
-            if (facebookToken == null || facebookToken.isEmpty()) {
-                error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                          "An empty or null Facebook access token was provided.");
-            }
+            error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                                      "An empty or null Facebook access token was provided.");
             callback.failure(error);
             return null;
         }
@@ -492,26 +486,20 @@ final public class VimeoClient {
     }
 
     /**
-     * Register the user using Google authentication token.
+     * Register the user using a Google authentication token.
      *
      * @param googleToken {@code id_token} value received by Google after authenticating.
-     * @param email User email address.
-     * @param callback This callback will be executed after the request succeeds or fails.
+     * @param email       User email address.
+     * @param callback    This callback will be executed after the request succeeds or fails.
      * @return a retrofit {@link Call} object, which <b>has already been enqueued</b>.
      */
     @Nullable
-    public Call<VimeoAccount> joinWithGoogleToken(String googleToken, String email, AuthCallback callback) {
-        if (callback == null) {
-            throw new AssertionError("Callback cannot be null");
-        }
-
-        if (googleToken == null || googleToken.isEmpty()) {
+    public Call<VimeoAccount> joinWithGoogleToken(@NotNull final String googleToken, @NotNull final String email,
+                                                  @NotNull final AuthCallback callback) {
+        if (googleToken.isEmpty()) {
             final VimeoError error = new VimeoError("Google authentication error.");
-
-            if (googleToken == null || googleToken.isEmpty()) {
-                error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                          "An empty or null Google access token was provided.");
-            }
+            error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                                      "An empty or null Google access token was provided.");
             callback.failure(error);
             return null;
         }
@@ -595,20 +583,13 @@ final public class VimeoClient {
     }
 
     @Nullable
-    public Call<VimeoAccount> loginWithFacebookToken(String facebookToken, String email, AuthCallback callback) {
-        if (callback == null) {
-            throw new AssertionError("Callback cannot be null");
-        }
-
-        if (facebookToken == null || facebookToken.isEmpty()) {
+    public Call<VimeoAccount> loginWithFacebookToken(@NotNull final String facebookToken, @NotNull final String email,
+                                                     @NotNull final AuthCallback callback) {
+        if (facebookToken.isEmpty()) {
             final VimeoError error = new VimeoError("Facebook authentication error.");
-
-            if (facebookToken == null || facebookToken.isEmpty()) {
-                error.addInvalidParameter(Vimeo.FIELD_TOKEN,
-                                          ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                          "An empty or null Facebook access token was provided.");
-            }
-            callback.failure(error);
+            error.addInvalidParameter(Vimeo.FIELD_TOKEN,
+                                      ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                                      "An empty or null Facebook access token was provided.");
             return null;
         }
 
@@ -624,24 +605,18 @@ final public class VimeoClient {
      * Allow a user to login to their account using a Google authentication token.
      *
      * @param googleToken {@code id_token} value received by Google after authenticating.
-     * @param email User email address.
-     * @param callback This callback will be executed after the request succeeds or fails.
+     * @param email       User email address.
+     * @param callback    This callback will be executed after the request succeeds or fails.
      * @return a retrofit {@link Call} object, which <b>has already been enqueued</b>.
      */
     @Nullable
-    public Call<VimeoAccount> loginWithGoogleToken(String googleToken, String email, AuthCallback callback) {
-        if (callback == null) {
-            throw new AssertionError("Callback cannot be null");
-        }
-
-        if (googleToken == null || googleToken.isEmpty()) {
+    public Call<VimeoAccount> loginWithGoogleToken(@NotNull final String googleToken, @NotNull final String email,
+                                                   @NotNull final AuthCallback callback) {
+        if (googleToken.isEmpty()) {
             final VimeoError error = new VimeoError("Google authentication error.");
-
-            if (googleToken == null || googleToken.isEmpty()) {
-                error.addInvalidParameter(Vimeo.FIELD_TOKEN,
-                                          ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                          "An empty or null Google access token was provided.");
-            }
+            error.addInvalidParameter(Vimeo.FIELD_TOKEN,
+                                      ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                                      "An empty or null Google access token was provided.");
             callback.failure(error);
             return null;
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -109,6 +109,14 @@ public interface VimeoService {
                                          @Field("grant_type") String grantType, @Field("token") String token,
                                          @Field("scope") String scope);
 
+    @FormUrlEncoded
+    @POST("oauth/authorize/google")
+    Call<VimeoAccount> logInWithGoogle(@Header("Authorization") String authHeader,
+                                       @Field("grant_type") String grantType,
+                                       @Field("id_token") String idToken,
+                                       @Field("scope") String scope);
+
+
     @Headers("Cache-Control: no-cache, no-store")
     @DELETE("tokens")
     Call<Object> logOut(@Header("Authorization") String authHeader);


### PR DESCRIPTION
#### Summary
Added endpoints for authenticating a user using a Google `id_token` auth token.

#### Implementation Summary
The new Google auth endpoints match the existing Facebook auth endpoints almost exactly other than passing `id_token` instead of `token` param.

Note: these endpoints will only work with the vimeo app not external users of the API.

#### How to Test
Verify that a user can:
- Login with a Google auth token
- Join with a Google auth token

#### Internal Ticket
[VA-2451](https://vimean.atlassian.net/browse/VA-2451)
