### PR TITLE
Rename Kotlin gradle var name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,14 @@
 
 buildscript {
     ext.supportLibraryVersion = '26.0.1'
-    ext.kotlinVersion = '1.1.4'
+    ext.kotlin_version = '1.1.4'
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -36,5 +36,5 @@ dependencies {
         exclude group: 'com.intellij', module: 'annotations'
     }
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -33,7 +33,7 @@ tasks.withType(Javadoc).all { enabled = true }
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.intellij:annotations:12.0@jar'
 


### PR DESCRIPTION
#### Ticket Summary
`vimeo-networking/build.gradle` is not picking up new variable rename.  Var seems to be coming from root (App) module instead.  Renaming the var caused full app to stop compiling.  Reverting back to `kotlin_version`.