### PR TITLE
Adding the channel membership interaction

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -64,6 +64,10 @@ public class InteractionCollection implements Serializable {
     protected Interaction mSubscribe;
 
     @Nullable
+    @SerializedName("channel")
+    protected Interaction mChannelMembership;
+
+    @Nullable
     public Interaction getWatchLater() {
         return mWatchLater;
     }
@@ -91,6 +95,15 @@ public class InteractionCollection implements Serializable {
     @Nullable
     public Interaction getSubscribe() {
         return mSubscribe;
+    }
+
+    @Nullable
+    public Interaction getChannelMembership() {
+        return mChannelMembership;
+    }
+
+    public void setChannelMembership(@Nullable Interaction channelMembership) {
+        mChannelMembership = channelMembership;
     }
 
     public void setLike(@Nullable Interaction like) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -455,6 +455,17 @@ public class Video implements Serializable {
     }
     // </editor-fold>
 
+    // <editor-fold desc="Channel">
+    @Nullable
+    public Interaction getChannelMembershipInteraction() {
+        if (mMetadata != null && mMetadata.getInteractions() != null && mMetadata.getInteractions().getChannelMembership() != null) {
+            return mMetadata.getInteractions().getChannelMembership();
+        }
+
+        return null;
+    }
+    // </editor-fold>
+
     // -----------------------------------------------------------------------------------------------------
     // Likes
     // -----------------------------------------------------------------------------------------------------

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -458,11 +458,9 @@ public class Video implements Serializable {
     // <editor-fold desc="Channel">
     @Nullable
     public Interaction getChannelMembershipInteraction() {
-        if (mMetadata != null && mMetadata.getInteractions() != null && mMetadata.getInteractions().getChannelMembership() != null) {
-            return mMetadata.getInteractions().getChannelMembership();
-        }
+        final InteractionCollection interactionCollection = mMetadata != null ? mMetadata.getInteractions() : null;
 
-        return null;
+        return interactionCollection != null ? interactionCollection.getChannelMembership() : null;
     }
     // </editor-fold>
 


### PR DESCRIPTION
#### Summary
There is an interaction on the Video object that provides contextual information about the interaction between a Video and a Channel when a video is embedded in a channel stream. It allows the consumer to delete the video from the channel by using a DELETE on the URI of the interaction.

#### Implementation Summary
I added the `channel` interaction and called it the "channel membership" interaction.

#### How to Test
No testing necessary.
