### PR TITLE
Make VimeoClient non-final

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -75,7 +75,7 @@ import retrofit2.Retrofit;
  * @see <a href="https://developer.vimeo.com/api">The Vimeo API Docs</a>
  */
 @SuppressWarnings("unused")
-final public class VimeoClient {
+public class VimeoClient {
 
     private static volatile boolean sContinuePinCodeAuthorizationRefreshCycle;
 


### PR DESCRIPTION
#### Implementation Summary
`VimeoClient` in many cases should be injectable into a class so that a mock can be used instead for Unit Testing.  Having to mock networking code is a common case.  This PR makes the `VimeoClient` class non-final so that it can more easily mocked during testing.  

- Mockito does have support for mocking final classes but it's an incubating feature that we're told will change its syntax, so probably best not rely on it.
- PowerMock could also be used, but that is know to be a bit of a code-smell in many cases.  Again, not a good thing to force across a large set of tests.

Ideally `VimeoClient` may even be turned into interface vs a class, but that's a much bigger refactoring.

#### How to Test
N/A
