### PR TITLE
VA-2686 Adding support for reporting interaction

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
@@ -29,7 +29,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * This model object represents an Interaction.
@@ -89,6 +91,10 @@ public class Interaction implements Serializable {
     @SerializedName("expires_time")
     protected Date mExpiration;
 
+    @Nullable
+    @SerializedName("reason")
+    protected ArrayList<String> mReportingReasons;
+
     public boolean isAdded() {
         return mAdded;
     }
@@ -115,5 +121,15 @@ public class Interaction implements Serializable {
 
     public void setIsAdded(boolean added) {
         mAdded = added;
+    }
+
+    /**
+     * @return a {@code List<String>} containing the allowable reasons that can be sent to the API
+     * when POSTing a report of a terms of service violation. This method will return null in the event
+     * that it is not a "report" {@link Interaction}
+     */
+    @Nullable
+    public List<String> getReportingReasons() {
+        return mReportingReasons;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -68,8 +68,20 @@ public class InteractionCollection implements Serializable {
     protected Interaction mChannelMembership;
 
     @Nullable
+    @SerializedName("report")
+    protected Interaction mReport;
+
+    @Nullable
     public Interaction getWatchLater() {
         return mWatchLater;
+    }
+
+    /**
+     * @return the uri for sending a terms of service violation report for the parent object
+     */
+    @Nullable
+    public Interaction getReport() {
+        return mReport;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -77,7 +77,7 @@ public class InteractionCollection implements Serializable {
     }
 
     /**
-     * @return the uri for sending a terms of service violation report for the parent object
+     * @return the {@link Interaction} for sending a terms of service violation report for the parent object
      */
     @Nullable
     public Interaction getReport() {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -465,6 +465,24 @@ public class Video implements Serializable {
     // </editor-fold>
 
     // -----------------------------------------------------------------------------------------------------
+    // Report
+    // -----------------------------------------------------------------------------------------------------
+    // <editor-fold desc="Report">
+    /**
+     * @return an {@link Interaction} containing the necessary data for reporting a video to the API
+     * for a terms of service violation. This method will return null in the event that reporting is
+     * unavailable for this {@code Video}
+     */
+    @Nullable
+    public Interaction getReportInteraction() {
+        if (mMetadata != null && mMetadata.mInteractions != null && mMetadata.mInteractions.getReport() != null) {
+            return mMetadata.mInteractions.getReport();
+        }
+        return null;
+    }
+    // </editor-fold>
+
+    // -----------------------------------------------------------------------------------------------------
     // Likes
     // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Like">


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VA-2686](https://vimean.atlassian.net/browse/VA-2686)

#### Ticket Summary
The API team recently added support for a report interaction in the Video response:
https://github.vimeows.com/Vimeo-API/blueprint/commit/e609bff2b914ce5b9175dce6b416b82ddbacd0aa
This ticket is about adding the necessary items to the models of the networking library.

#### Implementation Summary
I added models and helper methods for getting report related interactions data.

#### How to Test
Confirm that reporting still works in VA-2686-Interaction-Support app branch and that tests in VideoReportingReasonsPresenterTest still pass.
