### PR TITLE
Adding add_moderators and moderate_videos interactions

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -72,6 +72,14 @@ public class InteractionCollection implements Serializable {
     protected Interaction mReport;
 
     @Nullable
+    @SerializedName("add_moderators")
+    protected Interaction mAddModerators;
+
+    @Nullable
+    @SerializedName("moderate_videos")
+    protected Interaction mModerateVideos;
+
+    @Nullable
     public Interaction getWatchLater() {
         return mWatchLater;
     }
@@ -116,6 +124,28 @@ public class InteractionCollection implements Serializable {
 
     public void setChannelMembership(@Nullable Interaction channelMembership) {
         mChannelMembership = channelMembership;
+    }
+
+    public void setReport(@Nullable Interaction report) {
+        mReport = report;
+    }
+
+    @Nullable
+    public Interaction getAddModerators() {
+        return mAddModerators;
+    }
+
+    public void setAddModerators(@Nullable Interaction addModerators) {
+        mAddModerators = addModerators;
+    }
+
+    @Nullable
+    public Interaction getModerateVideos() {
+        return mModerateVideos;
+    }
+
+    public void setModerateVideos(@Nullable Interaction moderateVideos) {
+        mModerateVideos = moderateVideos;
     }
 
     public void setLike(@Nullable Interaction like) {


### PR DESCRIPTION
#### Summary
Adding `add_moderators` and `moderate_videos` interactions.

Each of these interactions live on the `channel.metadata.interactions` object.

#### Implementation Summary
I added these interactions and added setters and getters for the fields.

#### How to Test
N/A
