### PR TITLE
Android Gradle Plugin 3.0 Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 android:
   components:
     - tools
-    - build-tools-26.0.1
+    - build-tools-26.0.2
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     ext.supportLibraryVersion = '26.1.0'
     ext.kotlin_version = '1.1.51'
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -15,8 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven { url 'https://maven.google.com' }
     }
     apply plugin: "com.jfrog.bintray"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.supportLibraryVersion = '26.0.1'
-    ext.kotlin_version = '1.1.4-3'
+    ext.supportLibraryVersion = '26.1.0'
+    ext.kotlin_version = '1.1.51'
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/example-java-android/build.gradle
+++ b/example-java-android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.vimeo.example"
@@ -21,8 +21,8 @@ android {
 
 dependencies {
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:design:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:design:$supportLibraryVersion"
 
     compile project(':vimeo-networking')
 }

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '26.0.2'
+
     defaultConfig {
         applicationId 'com.vimeo.android.networking.example.kotlin'
         minSdkVersion 16
@@ -29,12 +30,12 @@ android {
 
 dependencies {
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:design:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:design:$supportLibraryVersion"
 
-    compile(project(':vimeo-networking')) {
+    implementation(project(':vimeo-networking')) {
         exclude group: 'com.intellij', module: 'annotations'
     }
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 21 09:07:02 EST 2016
+#Wed Oct 25 17:31:14 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
#### Summary
- Updating Android Gradle Plugin to version 3.0
- Updating Gradle version to 4.1
- Updating Android Build Tools version to 26.0.2
- Updating Android Support library in samples to version 26.1.0
- Updating Kotlin version in samples to 1.1.51