### PR TITLE
Reuse VimeoClient for Initialization

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -86,17 +86,17 @@ public class VimeoClient {
     @NotNull
     private Configuration mConfiguration;
     @NotNull
-    private final VimeoService mVimeoService;
+    private VimeoService mVimeoService;
     @Nullable
-    private final Cache mCache;
+    private Cache mCache;
     @Nullable
     private String mCurrentCodeGrantState;
 
     @NotNull
-    private final Retrofit mRetrofit;
+    private Retrofit mRetrofit;
 
     @NotNull
-    private final String mUserAgent;
+    private String mUserAgent;
 
     @Nullable
     private Timer mPinCodeAuthorizationTimer;
@@ -138,13 +138,23 @@ public class VimeoClient {
 
     public static void initialize(@NotNull Configuration configuration) {
         if (sSharedInstance != null) {
-            sSharedInstance.mConfiguration = configuration;
+            sSharedInstance.mConfiguration.deleteAccount(sSharedInstance.mVimeoAccount);
+            sSharedInstance.setVimeoAccount(null);
+            sSharedInstance.setup(configuration);
         } else {
             sSharedInstance = new VimeoClient(configuration);
         }
     }
 
     private VimeoClient(@NotNull Configuration configuration) {
+        setup(configuration);
+    }
+
+    /**
+     * Setup Retrofit object, API service and cache object to make requests.
+     * This setup is done when a new {@link Configuration} object is initialized.
+     */
+    private void setup(final Configuration configuration) {
         mConfiguration = configuration;
         mConfiguration.mInterceptors.add(mBaseUrlInterceptor);
         mCache = mConfiguration.getCache();

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -84,7 +84,7 @@ public class VimeoClient {
     private static volatile boolean sContinuePinCodeAuthorizationRefreshCycle;
 
     @NotNull
-    private final Configuration mConfiguration;
+    private Configuration mConfiguration;
     @NotNull
     private final VimeoService mVimeoService;
     @Nullable
@@ -137,7 +137,11 @@ public class VimeoClient {
     }
 
     public static void initialize(@NotNull Configuration configuration) {
-        sSharedInstance = new VimeoClient(configuration);
+        if (sSharedInstance != null) {
+            sSharedInstance.mConfiguration = configuration;
+        } else {
+            sSharedInstance = new VimeoClient(configuration);
+        }
     }
 
     private VimeoClient(@NotNull Configuration configuration) {
@@ -246,6 +250,10 @@ public class VimeoClient {
     public void saveAccount(@Nullable VimeoAccount vimeoAccount, String email) {
         setVimeoAccount(vimeoAccount);
         mConfiguration.saveAccount(vimeoAccount, email);
+    }
+
+    public void setConfiguration(@NotNull Configuration configuration) {
+        mConfiguration = configuration;
     }
 
     @NotNull

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -139,7 +139,6 @@ public class VimeoClient {
     public static void initialize(@NotNull Configuration configuration) {
         if (sSharedInstance != null) {
             sSharedInstance.mConfiguration.deleteAccount(sSharedInstance.mVimeoAccount);
-            sSharedInstance.setVimeoAccount(null);
             sSharedInstance.setup(configuration);
         } else {
             sSharedInstance = new VimeoClient(configuration);
@@ -260,10 +259,6 @@ public class VimeoClient {
     public void saveAccount(@Nullable VimeoAccount vimeoAccount, String email) {
         setVimeoAccount(vimeoAccount);
         mConfiguration.saveAccount(vimeoAccount, email);
-    }
-
-    public void setConfiguration(@NotNull Configuration configuration) {
-        mConfiguration = configuration;
     }
 
     @NotNull


### PR DESCRIPTION
When calling `VimeoClient.initialize` with a configuration object, a new instance of `VimeoClient` is created every time. This PR uses an existing instance if there is one and sets the configuration object. If there isn't an existing VimeoClient object, then a new one is created with the configuration object. 