### PR TITLE
Creating typed PUT method that returns User

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1593,9 +1593,11 @@ public class VimeoClient {
      * Certain endpoints will return the current user in the response when you perform a PUT on them. Use this method to
      * interact with them.
      *
-     * @param uri      the URI to connect to.
-     * @param options  the options that can be sent with the request.
-     * @param callback the callback that will be invoked.
+     * @param uri          the URI to connect to.
+     * @param cacheControl allows the consumer to force a request from cache or network.
+     * @param options      the options that can be sent with the request.
+     * @param body         The body of the PUT request
+     * @param callback     the callback that will be invoked.
      * @return a call with the request, or null if the parameters passed are invalid.
      */
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1589,6 +1589,33 @@ public class VimeoClient {
         return call;
     }
 
+    /**
+     * Certain endpoints will return the current user in the response when you perform a PUT on them. Use this method to
+     * interact with them.
+     *
+     * @param uri      the URI to connect to.
+     * @param options  the options that can be sent with the request.
+     * @param callback the callback that will be invoked.
+     * @return a call with the request, or null if the parameters passed are invalid.
+     */
+    @Nullable
+    public Call<User> putContentWithUserResponse(@Nullable String uri,
+                                                 @Nullable Map<String, String> options,
+                                                 @NotNull VimeoCallback<User> callback) {
+        if (uri == null || uri.isEmpty()) {
+            callback.failure(new VimeoError("uri cannot be empty!"));
+            return null;
+        }
+
+        if (options == null) {
+            options = new HashMap<>();
+        }
+
+        final Call<User> call = mVimeoService.putContentWithUserResponse(getAuthHeader(), uri, options);
+        call.enqueue(callback);
+        return call;
+    }
+
     @Nullable
     public Call putContent(@Nullable String uri,
                            @Nullable Map<String, String> options,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -367,6 +367,11 @@ public interface VimeoService {
     Call<Products> getProducts(@Header("Authorization") String authHeader);
     // </editor-fold>
 
+    @PUT
+    Call<User> putContentWithUserResponse(@Header("Authorization") String authHeader,
+                                          @Url String uri,
+                                          @QueryMap Map<String, String> options);
+
     /**
      * ---------------------------------------------------------------------------------------------------
      * Generic Region


### PR DESCRIPTION
#### Summary
Certain `PUT` calls can return a `User` in the success callback. Since our `PUT` doesn't return a proper type, it requires us to make a second request for the `User`. We can eliminate one network request by properly returning the `User` when appropriate.

#### How to Test
Make a `PUT` request to an endpoint that returns a `User` in its response.