### PR TITLE
Revert VimeoClient Initialization

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -137,23 +137,10 @@ public class VimeoClient {
     }
 
     public static void initialize(@NotNull Configuration configuration) {
-        if (sSharedInstance != null) {
-            sSharedInstance.mConfiguration.deleteAccount(sSharedInstance.mVimeoAccount);
-            sSharedInstance.setup(configuration);
-        } else {
-            sSharedInstance = new VimeoClient(configuration);
-        }
+        sSharedInstance = new VimeoClient(configuration);
     }
 
     private VimeoClient(@NotNull Configuration configuration) {
-        setup(configuration);
-    }
-
-    /**
-     * Setup Retrofit object, API service and cache object to make requests.
-     * This setup is done when a new {@link Configuration} object is initialized.
-     */
-    private void setup(final Configuration configuration) {
         mConfiguration = configuration;
         mConfiguration.mInterceptors.add(mBaseUrlInterceptor);
         mCache = mConfiguration.getCache();


### PR DESCRIPTION
#### Summary
The PR #274 had changed `VimeoClient` to reuse the cached VimeoClient instance if it had been initialized. However, this change caused other issues. It requires further investigation on the best way to implement it. This PR reverts the changes `VimeoClient`.
