### PR TITLE
Fixing Caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@
 
 buildscript {
     ext.supportLibraryVersion = '26.1.0'
-    ext.kotlin_version = '1.2.20'
+    ext.kotlin_version = '1.2.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/example-java-android/src/main/java/com/vimeo/android/networking/example/TestApp.java
+++ b/example-java-android/src/main/java/com/vimeo/android/networking/example/TestApp.java
@@ -45,6 +45,10 @@ public class TestApp extends Application {
             configBuilder.enableCertPinning(false);
             configBuilder.setLogLevel(LogLevel.VERBOSE);
         }
+        configBuilder
+                .setCacheDirectory(this.getCacheDir())
+                .setUserAgentString(getUserAgentString(this))
+                .setDebugLogger(new NetworkingLogger());
         VimeoClient.initialize(configBuilder.build());
         // </editor-fold>
     }
@@ -64,8 +68,7 @@ public class TestApp extends Application {
         TestAccountStore testAccountStore = new TestAccountStore(this.getApplicationContext());
         Configuration.Builder configBuilder =
                 new Configuration.Builder(clientId, clientSecret, SCOPE, testAccountStore);
-        configBuilder.setCacheDirectory(this.getCacheDir())
-                .setUserAgentString(getUserAgentString(this)).setDebugLogger(new NetworkingLogger())
+        configBuilder
                 // Used for oauth flow
                 .setCodeGrantRedirectUri(codeGrantRedirectUri);
 

--- a/example-kotlin-android/src/main/kotlin/com/vimeo/android/networking/example/kotlin/TestApp.kt
+++ b/example-kotlin-android/src/main/kotlin/com/vimeo/android/networking/example/kotlin/TestApp.kt
@@ -36,6 +36,10 @@ class TestApp : Application() {
             configBuilder.enableCertPinning(false)
             configBuilder.setLogLevel(LogLevel.VERBOSE)
         }
+        configBuilder
+                .setCacheDirectory(this.cacheDir)
+                .setUserAgentString(getUserAgentString(this))
+                .setDebugLogger(NetworkingLogger())
         VimeoClient.initialize(configBuilder.build())
         // </editor-fold>
     }
@@ -56,8 +60,7 @@ class TestApp : Application() {
             val codeGrantRedirectUri = getString(R.string.deeplink_redirect_scheme) + "://" + getString(R.string.deeplink_redirect_host)
             val testAccountStore = TestAccountStore(this.applicationContext)
             val configBuilder = Configuration.Builder(clientId, clientSecret, SCOPE)
-            configBuilder.setCacheDirectory(this.cacheDir)
-                    .setUserAgentString(getUserAgentString(this)).setDebugLogger(NetworkingLogger())
+            configBuilder
                     .setCodeGrantRedirectUri(codeGrantRedirectUri)
 
             return configBuilder

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
@@ -40,9 +40,9 @@ public class CacheControlInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        return chain.proceed(chain.request()
-                                     .newBuilder()
-                                     .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
-                                     .build());
+        return chain.proceed(chain.request())
+                .newBuilder()
+                .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
+                .build();
     }
 }


### PR DESCRIPTION
#### Issue
It has come to our attention that caching has been broken for some time in the app. The cause of this was a change to the way the `CacheControlInterceptor` was constructed. Originally, the chain of events was:
1. `val response = chain.proceed(chain.request())`
2. `return response.newBuilder().header(correct cache headers).build()`

[This was changed last August to a different chain, which caused the headers to not be rewritten](https://github.com/vimeo/vimeo-networking-java/commit/3d4c8e7fcdb0fea7537f322459722300f1b84f89#diff-eb316d561736430dbe7d37edb608149aL43):
1. `val request = chain.request().newBuilder().header(new cache headers).build()`
2. `return chain.proceed(request)`

This resulted in the headers being overridden on the request, but not on the response. Since our problem is that the server always sends a response to not cache the headers, overwriting the request does nothing.

#### Summary
- I have changed the chaining logic in `CacheControlInterceptor` to the original logic which rewrites the headers on the response, rather than the request. This is identical to the way that is suggested in the OkHttp samples (https://github.com/square/okhttp/blob/parent-3.9.1/samples/guide/src/main/java/okhttp3/recipes/RewriteResponseCacheControl.java)
- I updated the gradle plugin and the kotlin version
- I moved some configuration calls in the sample apps so that they apply to either the access token or client secret approach.

#### How to Test
Run the sample app and make a network request and then a cache request and observe that caching works as expected.
