### PR TITLE
Fix for invalid characters in user agent

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Cache;
+import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -134,10 +135,25 @@ class RetrofitSetup {
     String createUserAgent() {
         final String userProvidedAgent = mConfiguration.getUserAgentString();
 
-        if (userProvidedAgent != null && !userProvidedAgent.isEmpty()) {
+        if (userProvidedAgent != null && !userProvidedAgent.isEmpty() && isValidUserAgent(userProvidedAgent)) {
             return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
         } else {
             return mLibraryUserAgentComponent;
+        }
+    }
+
+    /**
+     * Determines if the provided {@code userAgent} is valid and can be sent in an HTTP request.
+     *
+     * @param userAgent the user agent to check.
+     * @return true if the user agent is valid, false if it contains invalid characters.
+     */
+    private boolean isValidUserAgent(@NotNull final String userAgent) {
+        try {
+            new Headers.Builder().set("User-Agent", userAgent);
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
         }
     }
 }

--- a/vimeo-networking/src/test/java/com/vimeo/networking/RetrofitSetupTest.kt
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/RetrofitSetupTest.kt
@@ -27,6 +27,7 @@ package com.vimeo.networking
 import com.vimeo.networking.Configuration.Builder
 import com.vimeo.networking.logging.ClientLogger
 import okhttp3.*
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -40,6 +41,32 @@ class RetrofitSetupTest {
     @Before
     fun setUp() {
         ClientLogger.setLogLevel(Vimeo.LogLevel.ERROR)
+    }
+
+    @Test
+    fun `user agent is successfully created with valid characters`() {
+        val retrofitSetup = RetrofitSetup(
+                Configuration.Builder("test")
+                        .setBaseUrl("http://unittesting")
+                        .setUserAgentString("test/test")
+                        .build(),
+                null
+        )
+
+        assertEquals("test/test VimeoNetworking/${BuildConfig.VERSION} (Java)", retrofitSetup.createUserAgent())
+    }
+
+    @Test
+    fun `user agent is created without provided characters if invalid`() {
+        val retrofitSetup = RetrofitSetup(
+                Configuration.Builder("test")
+                        .setBaseUrl("http://unittesting")
+                        .setUserAgentString("test/™")
+                        .build(),
+                null
+        )
+
+        assertEquals("VimeoNetworking/${BuildConfig.VERSION} (Java)", retrofitSetup.createUserAgent())
     }
 
     /**


### PR DESCRIPTION
#### Issue
- https://github.com/vimeo/vimeo-networking-java/issues/273

#### Summary
If the consumer passed invalid characters to the user agent, the library would crash. We can avoid this by checking if the characters are invalid, and if they are, then just ignoring them. Using Okhttp's `Headers.Builder.set()` we can verify that characters pass its validity check. Unit tests verify the behavior.

#### How to Test
Run the unit tests.