### PR TITLE
Adding new receipt errors

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -103,6 +103,10 @@ public enum ErrorCode {
     APP_DOES_NOT_HAVE_DELETE_CAPABILITY,
     @SerializedName("2700")
     INVALID_INPUT_NON_JSON_CONTENT_TYPE,
+    @SerializedName("2507")
+    PRODUCT_NOT_FOUND,
+    @SerializedName("3115")
+    INVALID_INPUT_RECEIPT_VALIDATION_UNSUCCESSFUL,
     @SerializedName("4000")
     OPERATION_TIMED_OUT,
     @SerializedName("5000")


### PR DESCRIPTION
#### Summary
New errors need to be included in the `ErrorCode` enum based on recent API changes. They are:
- `2507 - PRODUCT_NOT_FOUND`: Couldn't find a product matching the SKU.
- `3115 - INVALID_INPUT_RECEIPT_VALIDATION_UNSUCCESSFUL`: Receipt validation failed.

#### How to Test
- No testing
