### PR TITLE
Adding error code for upload quota cap exceeded

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -281,6 +281,8 @@ public enum ErrorCode {
     INVALID_INPUT_EMPTY_USER_URI,
     @SerializedName("4003")
     UPLOAD_TICKET_CREATION_ERROR,
+    @SerializedName("3428")
+    UPLOAD_QUOTA_SIZE_EXCEEDED_CAP,
     @SerializedName("4101")
     UPLOAD_QUOTA_SIZE_EXCEEDED,
     @SerializedName("4102")


### PR DESCRIPTION
#### Summary
The API has added a new error code which we'd like to support.

The new error code is for total quota breach for basic users (currently 5gb)

#### How to Test
Make a request to create an upload ticket providing the size of a video that will exceed a basic users total limit. If weekly limit (currently 500mb) is also exceeded by the video, that error will be returned instead.
