### PR TITLE
Add Comment Privacy editing for a video

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -72,6 +72,7 @@ public final class Vimeo {
     public static final String PARAMETER_USERS_BIO = "bio";
 
     public static final String PARAMETER_VIDEO_VIEW = "view";
+    public static final String PARAMETER_VIDEO_COMMENTS = "comments";
     public static final String PARAMETER_VIDEO_NAME = "name";
     public static final String PARAMETER_VIDEO_DESCRIPTION = "description";
     public static final String PARAMETER_VIDEO_PRIVACY = "privacy";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -937,6 +936,7 @@ public class VimeoClient {
             parameters.put(Vimeo.PARAMETER_VIDEO_DESCRIPTION, description);
         }
         if (privacySettings != null && !privacySettings.isEmpty()) {
+            final Map<String, String> privacyMap = new HashMap<>();
             final PrivacyValue viewPrivacyValue = privacySettings.get(PrivacyType.VIEW);
             if (viewPrivacyValue != null) {
                 if (viewPrivacyValue == Privacy.PrivacyValue.PASSWORD) {
@@ -946,16 +946,13 @@ public class VimeoClient {
                     }
                     parameters.put(Vimeo.PARAMETER_VIDEO_PASSWORD, password);
                 }
-                parameters.put(Vimeo.PARAMETER_VIDEO_PRIVACY,
-                               Collections.singletonMap(Vimeo.PARAMETER_VIDEO_VIEW,
-                                                        viewPrivacyValue.getText()));
+                privacyMap.put(Vimeo.PARAMETER_VIDEO_VIEW, viewPrivacyValue.getText());
             }
             final PrivacyValue commentPrivacyValue = privacySettings.get(PrivacyType.COMMENTS);
             if (commentPrivacyValue != null) {
-                parameters.put(Vimeo.PARAMETER_VIDEO_PRIVACY,
-                               Collections.singletonMap(Vimeo.PARAMETER_VIDEO_COMMENTS,
-                                                        commentPrivacyValue.getText()));
+                privacyMap.put(Vimeo.PARAMETER_VIDEO_COMMENTS, commentPrivacyValue.getText());
             }
+            parameters.put(Vimeo.PARAMETER_VIDEO_PRIVACY, privacyMap);
         }
         final Call<Video> call = mVimeoService.editVideo(getAuthHeader(), uri, parameters);
         call.enqueue(callback);

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/PrivacyType.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/PrivacyType.java
@@ -1,0 +1,13 @@
+package com.vimeo.networking.model;
+
+/**
+ * The different types of capabilities for a video whose privacy values can be changed.
+ *
+ * Created by Mohit Sarveiya on 3/15/18.
+ */
+public enum PrivacyType {
+    VIEW,
+    COMMENTS,
+    DOWNLOAD,
+    EMBED
+}


### PR DESCRIPTION
#### Summary
- Updated `editVideo` method to accept a map of privacy values for view, comment, download, etc.
- Updated `editVideo` method to add privacy settings for view and comment if there are any.
- Added an enum to specify the type of privacy the client is editing.

#### How to Test
Make a request to `editVideo` with a map of privacy type and values.

Ex:

```
final Map<PrivacyType, PrivacyValue> privacySettings = new HashMap<>();
privacySettings.put(PrivacyType.VIEW, PrivacyValue.ANYBODY);
privacySettings.put(PrivacyType.COMMENTS, PrivacyValue.ANYBODY);

vimeoClient.editVideo(title, description, password, privacySettings, null, {
     ...
})
```

Verify this request completes successfully. 