### PR TITLE
Adding total_cap_exceeded status

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -32,7 +32,7 @@ public final class Vimeo {
 
     public static final String VIMEO_BASE_URL_STRING = "https://api.vimeo.com/";
 
-    public static final String API_VERSION = "3.4";
+    public static final String API_VERSION = "3.4.1";
 
     // Global Constants
     public static final int NOT_FOUND = -1;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -90,6 +90,7 @@ public class Video implements Serializable {
     private static final String STATUS_UPLOADING_ERROR = "uploading_error";
     private static final String STATUS_TRANSCODING_ERROR = "transcoding_error";
     private static final String STATUS_QUOTA_EXCEEDED = "quota_exceeded";
+    private static final String STATUS_TOTAL_CAP_EXCEEDED = "total_cap_exceeded";
 
     @UseStag
     public enum Status {
@@ -110,7 +111,9 @@ public class Video implements Serializable {
         @SerializedName(STATUS_TRANSCODING_ERROR)
         TRANSCODING_ERROR(STATUS_TRANSCODING_ERROR),
         @SerializedName(STATUS_QUOTA_EXCEEDED)
-        QUOTA_EXCEEDED(STATUS_QUOTA_EXCEEDED);
+        QUOTA_EXCEEDED(STATUS_QUOTA_EXCEEDED),
+        @SerializedName(STATUS_TOTAL_CAP_EXCEEDED)
+        TOTAL_CAP_EXCEEDED(STATUS_TOTAL_CAP_EXCEEDED);
 
         private final String mString;
 


### PR DESCRIPTION
# Summary
A new status was added to the `clip.status` field in version 3.4.1 of the API. The status is `total_cap_exceeded` and complements the `quota_exceeded` status, which was originally used to represent weekly and total limits being exceeded. In order to be more clear, this status was added to differentiate between weekly and total. Now each status has a different use case:
- `total_cap_exceeded`: used when the video exceeds the user's total storage cap (common for basic users who have a 5GB total limit.
- `quota_exceeded`: used when the video exceeds the user's weekly storage cap.
