### PR TITLE
Api category localization

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -426,7 +426,6 @@ public class Configuration {
             return this;
         }
 
-
         /**
          * Takes a single locale and creates a single element list to add to Builder
          *

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -61,7 +61,7 @@ public class Configuration {
     protected String mScope;
 
     @NotNull
-    protected List<Locale> mLocales;
+    protected final List<Locale> mLocales;
 
     protected String mAccessToken;
 
@@ -341,8 +341,10 @@ public class Configuration {
         }
 
         /**
-         * If you used the basic Builder access token constructor but have the intent of
+         * This method is deprecated. Please use {@code Builder(String, String, String, AccountStore)}
+         * and provide the client id and secret there instead.
          */
+        @Deprecated
         public Builder setClientIdAndSecret(String clientId, String clientSecret) {
             this.mClientID = clientId;
             this.mClientSecret = clientSecret;
@@ -415,11 +417,11 @@ public class Configuration {
         }
 
         /**
-         * Sets a list of locales in the Builder
+         * Sets a list of locales in the Builder. Default language is English if nothing is set.
+         * Will replace any existing locales set in the Builder.
          *
-         * @param locales      The list of locales from the user
-         *
-         * @return             An instance of the current Builder
+         * @param locales The list of locales from the user
+         * @return An instance of the current Builder
          */
         public Builder setLocales(@NotNull List<Locale> locales) {
             mLocales = locales;
@@ -427,11 +429,11 @@ public class Configuration {
         }
 
         /**
-         * Takes a single locale and creates a single element list to add to Builder
+         * Takes a single locale and creates a single element list to add to Builder. Default
+         * language is English if nothing is set. Will replace any existing locales set in the Builder.
          *
-         * @param locale       A single locale
-         *
-         * @return             An instance of the current Builder
+         * @param locale A single locale
+         * @return An instance of the current Builder
          */
         public Builder setLocale(@NotNull Locale locale) {
             mLocales = new ArrayList<>();

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import okhttp3.Cache;
 import okhttp3.Interceptor;
@@ -58,6 +59,9 @@ public class Configuration {
     protected String mClientID;
     protected String mClientSecret;
     protected String mScope;
+
+    @NotNull
+    protected List<Locale> mLocales;
 
     protected String mAccessToken;
 
@@ -98,6 +102,10 @@ public class Configuration {
 
     public String getScope() {
         return mScope;
+    }
+
+    public List<Locale> getLocales() {
+        return mLocales;
     }
 
     public String getAccessToken() {
@@ -215,6 +223,7 @@ public class Configuration {
         this.mClientID = builder.mClientID;
         this.mClientSecret = builder.mClientSecret;
         this.mScope = builder.mScope;
+        this.mLocales = builder.mLocales;
 
         this.mAccessToken = builder.mAccessToken;
 
@@ -259,6 +268,11 @@ public class Configuration {
         private String mClientID;
         private String mClientSecret;
         private String mScope;
+
+        @NotNull
+        private List<Locale> mLocales = new ArrayList<Locale>(){{
+            add(Locale.ENGLISH);
+        }};
 
         private String mAccessToken;
 
@@ -392,6 +406,17 @@ public class Configuration {
 
         public Builder setLogLevel(LogLevel level) {
             this.mLogLevel = level;
+            return this;
+        }
+
+        public Builder setLocales(List<Locale> locales) {
+            this.mLocales = locales;
+            return this;
+        }
+
+        public Builder setLocale(Locale locale) {
+            this.mLocales = new ArrayList<>();
+            this.mLocales.add(locale);
             return this;
         }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -232,6 +232,9 @@ public class Configuration {
         if (!this.isValid()) {
             throw new AssertionError("Built invalid VimeoClientConfiguration");
         }
+        if (!this.isLocaleValid()) {
+            throw new AssertionError("Built invalid Configuration. Locale list is empty or contains null values");
+        }
 
         this.mCodeGrantRedirectURI = builder.mCodeGrantRedirectUri;
 
@@ -256,6 +259,10 @@ public class Configuration {
                 !this.mClientSecret.trim().isEmpty() &&
                 this.mScope != null && !this.mScope.trim().isEmpty()) ||
                 (this.mAccessToken != null && !this.mAccessToken.trim().isEmpty());
+    }
+
+    private boolean isLocaleValid() {
+        return !this.mLocales.isEmpty() && !this.mLocales.contains(null);
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -255,7 +255,7 @@ public class Configuration {
                 this.mClientSecret != null &&
                 !this.mClientSecret.trim().isEmpty() &&
                 this.mScope != null && !this.mScope.trim().isEmpty()) ||
-               (this.mAccessToken != null && !this.mAccessToken.trim().isEmpty());
+                (this.mAccessToken != null && !this.mAccessToken.trim().isEmpty());
     }
 
     /**
@@ -270,7 +270,7 @@ public class Configuration {
         private String mScope;
 
         @NotNull
-        private List<Locale> mLocales = new ArrayList<Locale>(){{
+        private List<Locale> mLocales = new ArrayList<Locale>() {{
             add(Locale.ENGLISH);
         }};
 
@@ -337,7 +337,9 @@ public class Configuration {
             this.mAccountStore = accountStore;
         }
 
-        /** If you used the basic Builder access token constructor but have the intent of */
+        /**
+         * If you used the basic Builder access token constructor but have the intent of
+         */
         public Builder setClientIdAndSecret(String clientId, String clientSecret) {
             this.mClientID = clientId;
             this.mClientSecret = clientSecret;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -421,7 +421,7 @@ public class Configuration {
          *
          * @return             An instance of the current Builder
          */
-        public Builder setLocales(List<Locale> locales) {
+        public Builder setLocales(@NotNull List<Locale> locales) {
             mLocales = locales;
             return this;
         }
@@ -433,7 +433,7 @@ public class Configuration {
          *
          * @return             An instance of the current Builder
          */
-        public Builder setLocale(Locale locale) {
+        public Builder setLocale(@NotNull Locale locale) {
             mLocales = new ArrayList<>();
             mLocales.add(locale);
             return this;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -104,10 +104,6 @@ public class Configuration {
         return mScope;
     }
 
-    public List<Locale> getLocales() {
-        return mLocales;
-    }
-
     public String getAccessToken() {
         return mAccessToken;
     }
@@ -418,14 +414,29 @@ public class Configuration {
             return this;
         }
 
+        /**
+         * Sets a list of locales in the Builder
+         *
+         * @param locales      The list of locales from the user
+         *
+         * @return             An instance of the current Builder
+         */
         public Builder setLocales(List<Locale> locales) {
-            this.mLocales = locales;
+            mLocales = locales;
             return this;
         }
 
+
+        /**
+         * Takes a single locale and creates a single element list to add to Builder
+         *
+         * @param locale       A single locale
+         *
+         * @return             An instance of the current Builder
+         */
         public Builder setLocale(Locale locale) {
-            this.mLocales = new ArrayList<>();
-            this.mLocales.add(locale);
+            mLocales = new ArrayList<>();
+            mLocales.add(locale);
             return this;
         }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -90,6 +90,7 @@ public final class Vimeo {
     public static final String HEADER_CACHE_CONTROL = "Cache-Control";
     public static final String HEADER_USER_AGENT = "User-Agent";
     public static final String HEADER_ACCEPT = "Accept";
+    public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
 
     // Header Values
     public static final String HEADER_CACHE_PUBLIC = "public";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -65,7 +65,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import okhttp3.Cache;
 import okhttp3.CacheControl;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -108,7 +108,7 @@ public class VimeoClient {
     private final BaseUrlInterceptor mBaseUrlInterceptor = new BaseUrlInterceptor();
 
     @NotNull
-    private final LanguageHeaderInterceptor mLanguageHeaderInterceptor = new LanguageHeaderInterceptor(getLocaleCodes());
+    private final LanguageHeaderInterceptor mLanguageHeaderInterceptor;
 
     /**
      * Currently authenticated account
@@ -148,6 +148,7 @@ public class VimeoClient {
 
     private VimeoClient(@NotNull Configuration configuration) {
         mConfiguration = configuration;
+        this.mLanguageHeaderInterceptor = new LanguageHeaderInterceptor(getLocaleCodes(mConfiguration));
         mConfiguration.mInterceptors.add(mBaseUrlInterceptor);
         mConfiguration.mInterceptors.add(mLanguageHeaderInterceptor);
         mCache = mConfiguration.getCache();
@@ -442,9 +443,9 @@ public class VimeoClient {
      *
      * blah blah
      */
-    public String getLocaleCodes() {
+    public String getLocaleCodes(Configuration configuration) {
 
-        List<Locale> localeList = mConfiguration.getLocales();
+        List<Locale> localeList = configuration.getLocales();
         StringBuilder codeBuilder = new StringBuilder();
 
         for (int i = 0; i < localeList.size(); i++) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -439,9 +439,12 @@ public class VimeoClient {
     }
 
     /**
-     * Localization header
+     * Creates a String of locales from the current configuration.
+     * In the format "xx,xx,xx" which is supported by the Vimeo API.
      *
-     * blah blah
+     * @param configuration             The Configuration of this session
+     *
+     * @return String of locales
      */
     public String getLocaleCodes(Configuration configuration) {
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -321,7 +321,7 @@ public class VimeoClient {
         final String state = queryMap.get(Vimeo.CODE_GRANT_STATE);
 
         if (code == null || code.isEmpty() || state == null || state.isEmpty() ||
-            !state.equals(mCurrentCodeGrantState)) {
+                !state.equals(mCurrentCodeGrantState)) {
             mCurrentCodeGrantState = null;
 
             callback.failure(new VimeoError("Code grant code/state is null or state has changed"));
@@ -335,7 +335,7 @@ public class VimeoClient {
 
         final Call<VimeoAccount> call =
                 mVimeoService.authenticateWithCodeGrant(getBasicAuthHeader(), redirectURI, code,
-                                                        Vimeo.CODE_GRANT_TYPE);
+                        Vimeo.CODE_GRANT_TYPE);
         call.enqueue(new AccountCallback(this, callback));
         return call;
     }
@@ -355,8 +355,8 @@ public class VimeoClient {
 
         final Call<VimeoAccount> call =
                 mVimeoService.authorizeWithClientCredentialsGrant(getBasicAuthHeader(),
-                                                                  Vimeo.CLIENT_CREDENTIALS_GRANT_TYPE,
-                                                                  mConfiguration.mScope);
+                        Vimeo.CLIENT_CREDENTIALS_GRANT_TYPE,
+                        mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, callback));
         return call;
     }
@@ -375,8 +375,8 @@ public class VimeoClient {
 
         final Call<VimeoAccount> call =
                 mVimeoService.authorizeWithClientCredentialsGrant(getBasicAuthHeader(),
-                                                                  Vimeo.CLIENT_CREDENTIALS_GRANT_TYPE,
-                                                                  mConfiguration.mScope);
+                        Vimeo.CLIENT_CREDENTIALS_GRANT_TYPE,
+                        mConfiguration.mScope);
 
         VimeoAccount vimeoAccount = null;
         try {
@@ -406,10 +406,10 @@ public class VimeoClient {
         }
 
         final Call<VimeoAccount> call = mVimeoService.exchangeOAuthOneToken(getBasicAuthHeader(),
-                                                                            Vimeo.OAUTH_ONE_GRANT_TYPE,
-                                                                            token,
-                                                                            tokenSecret,
-                                                                            mConfiguration.mScope);
+                Vimeo.OAUTH_ONE_GRANT_TYPE,
+                token,
+                tokenSecret,
+                mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, callback));
         return call;
     }
@@ -442,40 +442,39 @@ public class VimeoClient {
      * This method is used to create an account on Vimeo with the credentials {@code email} and
      * {@code password}. It is used to join with an email and password.
      *
-     * @param displayName                The display name for the account.
-     * @param email                      Account's email.
-     * @param password                   Account's password.
-     * @param marketingOptIn             Flag to opt in or out of email marketing emails.
-     * @param callback                   Callback to inform you of the result of login.
-     *
+     * @param displayName    The display name for the account.
+     * @param email          Account's email.
+     * @param password       Account's password.
+     * @param marketingOptIn Flag to opt in or out of email marketing emails.
+     * @param callback       Callback to inform you of the result of login.
      * @return A Call object.
      */
     @Nullable
     public Call<VimeoAccount> join(@Nullable final String displayName,
                                    @Nullable final String email,
                                    @Nullable final String password,
-                                             final boolean marketingOptIn,
+                                   final boolean marketingOptIn,
                                    @Nullable final AuthCallback callback) {
         if (callback == null) {
             throw new AssertionError("Callback cannot be null");
         }
 
         if (displayName == null || displayName.isEmpty() || email == null || email.isEmpty() ||
-            password == null || password.isEmpty()) {
+                password == null || password.isEmpty()) {
 
             final VimeoError error = new VimeoError("Name, email, and password must be set.");
 
             if (displayName == null || displayName.isEmpty()) {
                 error.addInvalidParameter(Vimeo.FIELD_NAME, ErrorCode.INVALID_INPUT_NO_NAME,
-                                          "An empty or null name was provided.");
+                        "An empty or null name was provided.");
             }
             if (email == null || email.isEmpty()) {
                 error.addInvalidParameter(Vimeo.FIELD_EMAIL, ErrorCode.INVALID_INPUT_NO_EMAIL,
-                                          "An empty or null email was provided.");
+                        "An empty or null email was provided.");
             }
             if (password == null || password.isEmpty()) {
                 error.addInvalidParameter(Vimeo.FIELD_PASSWORD, ErrorCode.INVALID_INPUT_NO_PASSWORD,
-                                          "An empty or null password was provided.");
+                        "An empty or null password was provided.");
             }
             callback.failure(error);
 
@@ -497,22 +496,21 @@ public class VimeoClient {
     /**
      * This method is used to create an account on Vimeo with Facebook.
      *
-     * @param facebookToken              Facebook token.
-     * @param email                      Account's email.
-     * @param marketingOptIn             Flag to opt in or out of email marketing emails.
-     * @param callback                   Callback to inform you of the result of login.
-     *
+     * @param facebookToken  Facebook token.
+     * @param email          Account's email.
+     * @param marketingOptIn Flag to opt in or out of email marketing emails.
+     * @param callback       Callback to inform you of the result of login.
      * @return A Call object.
      */
     @Nullable
     public Call<VimeoAccount> joinWithFacebookToken(@NotNull final String facebookToken,
                                                     @NotNull final String email,
-                                                             final boolean marketingOptIn,
+                                                    final boolean marketingOptIn,
                                                     @NotNull final AuthCallback callback) {
         if (facebookToken.isEmpty()) {
             final VimeoError error = new VimeoError("Facebook authentication error.");
             error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                      "An empty or null Facebook access token was provided.");
+                    "An empty or null Facebook access token was provided.");
             callback.failure(error);
             return null;
         }
@@ -530,21 +528,21 @@ public class VimeoClient {
     /**
      * Register the user using a Google authentication token.
      *
-     * @param googleToken               {@code id_token} value received by Google after authenticating.
-     * @param email                     User email address.
-     * @param marketingOptIn            Flag to opt in or out of marketing emails.
-     * @param callback                  This callback will be executed after the request succeeds or fails.
+     * @param googleToken    {@code id_token} value received by Google after authenticating.
+     * @param email          User email address.
+     * @param marketingOptIn Flag to opt in or out of marketing emails.
+     * @param callback       This callback will be executed after the request succeeds or fails.
      * @return a retrofit {@link Call} object, which <b>has already been enqueued</b>.
      */
     @Nullable
     public Call<VimeoAccount> joinWithGoogleToken(@NotNull final String googleToken,
                                                   @NotNull final String email,
-                                                           final boolean marketingOptIn,
+                                                  final boolean marketingOptIn,
                                                   @NotNull final AuthCallback callback) {
         if (googleToken.isEmpty()) {
             final VimeoError error = new VimeoError("Google authentication error.");
             error.addInvalidParameter(Vimeo.FIELD_TOKEN, ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                      "An empty or null Google access token was provided.");
+                    "An empty or null Google access token was provided.");
             callback.failure(error);
             return null;
         }
@@ -570,13 +568,13 @@ public class VimeoClient {
 
             if (email == null || email.isEmpty()) {
                 error.addInvalidParameter(Vimeo.FIELD_USERNAME,
-                                          ErrorCode.INVALID_INPUT_NO_EMAIL,
-                                          "An empty or null email was provided.");
+                        ErrorCode.INVALID_INPUT_NO_EMAIL,
+                        "An empty or null email was provided.");
             }
             if (password == null || password.isEmpty()) {
                 error.addInvalidParameter(Vimeo.FIELD_PASSWORD,
-                                          ErrorCode.INVALID_INPUT_NO_PASSWORD,
-                                          "An empty or null password was provided.");
+                        ErrorCode.INVALID_INPUT_NO_PASSWORD,
+                        "An empty or null password was provided.");
             }
             callback.failure(error);
 
@@ -584,10 +582,10 @@ public class VimeoClient {
         }
 
         final Call<VimeoAccount> call = mVimeoService.logIn(getBasicAuthHeader(),
-                                                            email,
-                                                            password,
-                                                            Vimeo.PASSWORD_GRANT_TYPE,
-                                                            mConfiguration.mScope);
+                email,
+                password,
+                Vimeo.PASSWORD_GRANT_TYPE,
+                mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, email, callback));
         return call;
     }
@@ -608,10 +606,10 @@ public class VimeoClient {
 
         final Call<VimeoAccount> call =
                 mVimeoService.logIn(getBasicAuthHeader(),
-                                    email,
-                                    password,
-                                    Vimeo.PASSWORD_GRANT_TYPE,
-                                    mConfiguration.mScope);
+                        email,
+                        password,
+                        Vimeo.PASSWORD_GRANT_TYPE,
+                        mConfiguration.mScope);
 
         VimeoAccount vimeoAccount = null;
         try {
@@ -635,15 +633,15 @@ public class VimeoClient {
         if (facebookToken.isEmpty()) {
             final VimeoError error = new VimeoError("Facebook authentication error.");
             error.addInvalidParameter(Vimeo.FIELD_TOKEN,
-                                      ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                      "An empty or null Facebook access token was provided.");
+                    ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                    "An empty or null Facebook access token was provided.");
             return null;
         }
 
         final Call<VimeoAccount> call = mVimeoService.logInWithFacebook(getBasicAuthHeader(),
-                                                                        Vimeo.FACEBOOK_GRANT_TYPE,
-                                                                        facebookToken,
-                                                                        mConfiguration.mScope);
+                Vimeo.FACEBOOK_GRANT_TYPE,
+                facebookToken,
+                mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, email, callback));
         return call;
     }
@@ -663,16 +661,16 @@ public class VimeoClient {
         if (googleToken.isEmpty()) {
             final VimeoError error = new VimeoError("Google authentication error.");
             error.addInvalidParameter(Vimeo.FIELD_TOKEN,
-                                      ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
-                                      "An empty or null Google access token was provided.");
+                    ErrorCode.UNABLE_TO_LOGIN_NO_TOKEN,
+                    "An empty or null Google access token was provided.");
             callback.failure(error);
             return null;
         }
 
         final Call<VimeoAccount> call = mVimeoService.logInWithGoogle(getBasicAuthHeader(),
-                                                                      Vimeo.GOOGLE_GRANT_TYPE,
-                                                                      googleToken,
-                                                                      mConfiguration.mScope);
+                Vimeo.GOOGLE_GRANT_TYPE,
+                googleToken,
+                mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, email, callback));
         return call;
     }
@@ -687,11 +685,11 @@ public class VimeoClient {
         // If you've provided an access token to the configuration builder, we're assuming that you wouldn't
         // want to be able to log out of it, because this would invalidate the constant you've provided us.
         if (mConfiguration.mAccessToken != null && mVimeoAccount != null &&
-            mConfiguration.mAccessToken.equals(mVimeoAccount.getAccessToken())) {
+                mConfiguration.mAccessToken.equals(mVimeoAccount.getAccessToken())) {
             if (callback != null) {
                 callback.failure(new VimeoError(
                         "Don't log out of the account provided through the configuration builder. Need to ensure " +
-                        "that the access token generated in the dev console isn't accidentally invalidated."));
+                                "that the access token generated in the dev console isn't accidentally invalidated."));
             }
             return null;
         }
@@ -854,7 +852,7 @@ public class VimeoClient {
             final VimeoClient vimeoClient = mVimeoClient.get();
             final long now = System.nanoTime();
             if (!VimeoClient.sContinuePinCodeAuthorizationRefreshCycle || now >= mExpiresInNano ||
-                authCallback == null || vimeoClient == null) {
+                    authCallback == null || vimeoClient == null) {
                 if (VimeoClient.sContinuePinCodeAuthorizationRefreshCycle) {
                     //noinspection AssignmentToStaticFieldFromInstanceMethod
                     VimeoClient.sContinuePinCodeAuthorizationRefreshCycle = false;
@@ -869,10 +867,10 @@ public class VimeoClient {
             } else {
                 final Call<VimeoAccount> call =
                         vimeoClient.mVimeoService.logInWithPinCode(vimeoClient.getBasicAuthHeader(),
-                                                                   Vimeo.DEVICE_GRANT_TYPE,
-                                                                   mPinCodeInfo.getUserCode(),
-                                                                   mPinCodeInfo.getDeviceCode(),
-                                                                   mScope);
+                                Vimeo.DEVICE_GRANT_TYPE,
+                                mPinCodeInfo.getUserCode(),
+                                mPinCodeInfo.getDeviceCode(),
+                                mScope);
                 call.enqueue(new PinCodeAccountCallback(vimeoClient, authCallback, mTimer));
             }
         }
@@ -908,17 +906,17 @@ public class VimeoClient {
 
         final String SCOPE = mConfiguration.mScope;
         final Call<PinCodeInfo> call = mVimeoService.getPinCodeInfo(getBasicAuthHeader(),
-                                                                    Vimeo.DEVICE_GRANT_TYPE,
-                                                                    SCOPE);
+                Vimeo.DEVICE_GRANT_TYPE,
+                SCOPE);
 
         call.enqueue(new VimeoCallback<PinCodeInfo>() {
             @Override
             public void success(PinCodeInfo pinCodeInfo) {
                 if (pinCodeInfo.getUserCode() == null ||
-                    pinCodeInfo.getDeviceCode() == null ||
-                    pinCodeInfo.getActivateLink() == null ||
-                    pinCodeInfo.getExpiresIn() <= 0 ||
-                    pinCodeInfo.getInterval() <= 0) {
+                        pinCodeInfo.getDeviceCode() == null ||
+                        pinCodeInfo.getActivateLink() == null ||
+                        pinCodeInfo.getExpiresIn() <= 0 ||
+                        pinCodeInfo.getInterval() <= 0) {
                     pinCodeCallback.failure(new VimeoError("Invalid data returned from server for pin code"));
                     return;
                 }
@@ -928,9 +926,9 @@ public class VimeoClient {
                 //noinspection AssignmentToStaticFieldFromInstanceMethod
                 VimeoClient.sContinuePinCodeAuthorizationRefreshCycle = true;
                 final TimerTask task = new PinCodePollingTimerTask(pinCodeInfo,
-                                                                   mPinCodeAuthorizationTimer,
-                                                                   pinCodeInfo.getExpiresIn(),
-                                                                   SCOPE, sSharedInstance, authCallback
+                        mPinCodeAuthorizationTimer,
+                        pinCodeInfo.getExpiresIn(),
+                        SCOPE, sSharedInstance, authCallback
                 );
                 final long period = SECONDS_TO_MILLISECONDS * pinCodeInfo.getInterval();
                 mPinCodeAuthorizationTimer.scheduleAtFixedRate(task, 0, period);
@@ -1408,9 +1406,15 @@ public class VimeoClient {
      * @param filter   the field filter to apply to the request
      * @param callback the callback to be invoked when the request finishes
      */
+    @SuppressWarnings("WeakerAccess")
     public void getCurrentUser(@Nullable String filter, @NotNull VimeoCallback<User> callback) {
-        getContent(Vimeo.ENDPOINT_ME, CacheControl.FORCE_NETWORK, GetRequestCaller.USER, null,
-                null, filter, callback);
+        getContent(Vimeo.ENDPOINT_ME,
+                CacheControl.FORCE_NETWORK,
+                GetRequestCaller.USER,
+                null,
+                null,
+                filter,
+                callback);
     }
 
     /**
@@ -1442,10 +1446,10 @@ public class VimeoClient {
         final String cacheHeaderValue = createCacheControlString(cacheControl);
         final Map<String, String> queryMap = createQueryMap(query, refinementMap, fieldFilter);
         final Call<DataType_T> call = caller.call(getAuthHeader(),
-                                                  uri,
-                                                  queryMap,
-                                                  cacheHeaderValue,
-                                                  mVimeoService);
+                uri,
+                queryMap,
+                cacheHeaderValue,
+                mVimeoService);
         call.enqueue(callback);
         return call;
     }
@@ -1478,10 +1482,10 @@ public class VimeoClient {
         final String cacheHeaderValue = createCacheControlString(cacheControl);
         final Map<String, String> queryMap = createQueryMap(query, refinementMap, fieldFilter);
         final Call<DataType_T> call = caller.call(getAuthHeader(),
-                                                  uri,
-                                                  queryMap,
-                                                  cacheHeaderValue,
-                                                  mVimeoService);
+                uri,
+                queryMap,
+                cacheHeaderValue,
+                mVimeoService);
         try {
             return call.execute();
         } catch (final IOException ioe) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -456,11 +456,6 @@ public class VimeoClient {
         }
 
         return codeBuilder.toString();
-
-//        List<String> codeList = localeList.stream()
-//                .map(Locale::getLanguage)
-//                .collect(Collectors.toList());
-//        return String.join(",", codeList);
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -148,7 +148,7 @@ public class VimeoClient {
 
     private VimeoClient(@NotNull Configuration configuration) {
         mConfiguration = configuration;
-        this.mLanguageHeaderInterceptor = new LanguageHeaderInterceptor(getLocaleCodes(mConfiguration));
+        mLanguageHeaderInterceptor = new LanguageHeaderInterceptor(mConfiguration.mLocales);
         mConfiguration.mInterceptors.add(mBaseUrlInterceptor);
         mConfiguration.mInterceptors.add(mLanguageHeaderInterceptor);
         mCache = mConfiguration.getCache();
@@ -436,29 +436,6 @@ public class VimeoClient {
                 mVimeoService.ssoTokenExchange(getBasicAuthHeader(), token, mConfiguration.mScope);
         call.enqueue(new AccountCallback(this, callback));
         return call;
-    }
-
-    /**
-     * Creates a String of locales from the current configuration.
-     * In the format "xx,xx,xx" which is supported by the Vimeo API.
-     *
-     * @param configuration             The Configuration of this session
-     *
-     * @return String of locales
-     */
-    public String getLocaleCodes(Configuration configuration) {
-
-        List<Locale> localeList = configuration.getLocales();
-        StringBuilder codeBuilder = new StringBuilder();
-
-        for (int i = 0; i < localeList.size(); i++) {
-            if (i > 0) {
-                codeBuilder.append(",");
-            }
-            codeBuilder.append(localeList.get(i).getLanguage());
-        }
-
-        return codeBuilder.toString();
     }
 
     /**
@@ -1413,7 +1390,7 @@ public class VimeoClient {
      * @return {@link Call} that can be used to cancel network requests.
      */
     public Call<Product> getProduct(String uri, VimeoCallback<Product> callback) {
-        return getContent(uri, CacheControl.FORCE_NETWORK, GetRequestCaller.PRODUCT, null,null, null, callback);
+        return getContent(uri, CacheControl.FORCE_NETWORK, GetRequestCaller.PRODUCT, null, null, null, callback);
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
@@ -1,0 +1,38 @@
+package com.vimeo.networking.interceptors;
+
+import com.vimeo.networking.Vimeo;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Add custom {@code Accept-Language} header to all requests.
+ * Created by harishveeramani on 6/13/18.
+ */
+
+public class LanguageHeaderInterceptor implements Interceptor {
+    String validLocales;
+
+    public LanguageHeaderInterceptor(String validLocales) {
+        this.validLocales = validLocales;
+    }
+
+    @Override
+    public Response intercept(Interceptor.Chain chain) throws IOException {
+        return chain.proceed(
+                chain.request().newBuilder().header(
+                        Vimeo.HEADER_ACCEPT_LANGUAGE,
+                        getAcceptLanguageHeader()
+                ).build()
+        );
+    }
+
+    private String getAcceptLanguageHeader() {
+         return validLocales;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
@@ -3,9 +3,6 @@ package com.vimeo.networking.interceptors;
 import com.vimeo.networking.Vimeo;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 
 import okhttp3.Interceptor;
 import okhttp3.Response;
@@ -33,6 +30,6 @@ public class LanguageHeaderInterceptor implements Interceptor {
     }
 
     private String getAcceptLanguageHeader() {
-         return validLocales;
+        return validLocales;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
@@ -1,6 +1,5 @@
 package com.vimeo.networking.interceptors;
 
-import com.vimeo.networking.Configuration;
 import com.vimeo.networking.Vimeo;
 
 import org.jetbrains.annotations.NotNull;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
@@ -18,6 +18,8 @@ import okhttp3.Response;
  */
 public class LanguageHeaderInterceptor implements Interceptor {
     private static final String HEADER_SEPARATOR = ",";
+
+    @NotNull
     private String mValidLocales;
 
     public LanguageHeaderInterceptor(@NotNull List<Locale> locales) {
@@ -34,7 +36,8 @@ public class LanguageHeaderInterceptor implements Interceptor {
         );
     }
 
-    private String parseLocales(List<Locale> locales) {
+    @NotNull
+    private String parseLocales(@NotNull List<Locale> locales) {
         final StringBuilder codeBuilder = new StringBuilder();
 
         for (int i = 0; i < locales.size(); i++) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/LanguageHeaderInterceptor.java
@@ -1,8 +1,13 @@
 package com.vimeo.networking.interceptors;
 
+import com.vimeo.networking.Configuration;
 import com.vimeo.networking.Vimeo;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
 
 import okhttp3.Interceptor;
 import okhttp3.Response;
@@ -11,12 +16,12 @@ import okhttp3.Response;
  * Add custom {@code Accept-Language} header to all requests.
  * Created by harishveeramani on 6/13/18.
  */
-
 public class LanguageHeaderInterceptor implements Interceptor {
-    String validLocales;
+    private static final String HEADER_SEPARATOR = ",";
+    private String mValidLocales;
 
-    public LanguageHeaderInterceptor(String validLocales) {
-        this.validLocales = validLocales;
+    public LanguageHeaderInterceptor(@NotNull List<Locale> locales) {
+        mValidLocales = parseLocales(locales);
     }
 
     @Override
@@ -24,12 +29,21 @@ public class LanguageHeaderInterceptor implements Interceptor {
         return chain.proceed(
                 chain.request().newBuilder().header(
                         Vimeo.HEADER_ACCEPT_LANGUAGE,
-                        getAcceptLanguageHeader()
+                        mValidLocales
                 ).build()
         );
     }
 
-    private String getAcceptLanguageHeader() {
-        return validLocales;
+    private String parseLocales(List<Locale> locales) {
+        final StringBuilder codeBuilder = new StringBuilder();
+
+        for (int i = 0; i < locales.size(); i++) {
+            if (i > 0) {
+                codeBuilder.append(HEADER_SEPARATOR);
+            }
+            codeBuilder.append(locales.get(i).getLanguage());
+        }
+
+        return codeBuilder.toString();
     }
 }


### PR DESCRIPTION
#### Issue
When requests are made, particularly with categories, we are supposed to be able to get a localized version back. On categories, this means a few titles will be in a different language. We need to tell the API that we want a different localization for a request.

#### Summary
Created a LanguageHeaderInterceptor to automatically add the `Accept-Language` header to HTTP requests made to the API. Done by passing in the user's locales to the Configuration Builder and then passing on the language codes to the interceptor. On devices that support multiple locales, a string of all the locales will be passed on and the API will select the first support locale. Defaults to English if none of the locales are supported.

#### How to Test
- Go to Explore tab and check the current language of the category titles.
- Close Vimeo app and change device language
- Open Vimeo app and go back to Explore tab and verify category titles have changed to new language.