### PR TITLE
Entity representation

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Category implements Serializable, Followable {
+public class Category implements Serializable, Followable, Entity {
 
     private static final long serialVersionUID = 441419347585215353L;
 
@@ -73,6 +73,19 @@ public class Category implements Serializable, Followable {
     @Nullable
     @SerializedName("metadata")
     protected Metadata mMetadata;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     @Nullable
     public String getUri() {
@@ -192,5 +205,11 @@ public class Category implements Serializable, Followable {
     @Override
     public int hashCode() {
         return this.mUri != null ? this.mUri.hashCode() : 0;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Category.java
@@ -209,7 +209,7 @@ public class Category implements Serializable, Followable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
@@ -35,7 +35,7 @@ import java.util.Date;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Channel implements Serializable, Followable {
+public class Channel implements Serializable, Followable, Entity {
 
     private static final long serialVersionUID = 3190410523525111858L;
 
@@ -71,6 +71,19 @@ public class Channel implements Serializable, Followable {
 
     @SerializedName("metadata")
     protected Metadata mMetadata;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    public void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     public void setUri(String uri) {
         mUri = uri;
@@ -191,5 +204,11 @@ public class Channel implements Serializable, Followable {
     @Override
     public int hashCode() {
         return this.mUri != null ? this.mUri.hashCode() : 0;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
@@ -81,7 +81,7 @@ public class Channel implements Serializable, Followable, Entity {
         return mResourceKey;
     }
 
-    public void setResourceKey(@Nullable String resourceKey) {
+    protected void setResourceKey(@Nullable String resourceKey) {
         mResourceKey = resourceKey;
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Channel.java
@@ -208,7 +208,7 @@ public class Channel implements Serializable, Followable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
@@ -26,6 +26,8 @@ import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.Vimeo;
 import com.vimeo.stag.UseStag;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -34,7 +36,7 @@ import java.util.Date;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Comment implements Serializable {
+public class Comment implements Serializable, Entity {
 
     private static final long serialVersionUID = -7716027694845877155L;
 
@@ -62,6 +64,19 @@ public class Comment implements Serializable {
 
     @SerializedName("metadata")
     protected Metadata mMetadata;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     public String getUri() {
         return mUri;
@@ -125,4 +140,9 @@ public class Comment implements Serializable {
         return this.mUri != null ? this.mUri.hashCode() : 0;
     }
 
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
+    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Comment.java
@@ -142,7 +142,7 @@ public class Comment implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
@@ -1,0 +1,20 @@
+package com.vimeo.networking.model;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents data that can be uniquely identified by an {@link Entity#identifier()}.
+ * <p>
+ * Implementors of this interface must provide a unique identifier.
+ */
+public interface Entity {
+
+    /**
+     * The identifier, as a {@link String}, that uniquely identifies this entity.
+     *
+     * @return a non null {@link String}.
+     */
+    @NotNull
+    String identifier();
+
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
@@ -1,6 +1,6 @@
 package com.vimeo.networking.model;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents data that can be uniquely identified by an {@link Entity#identifier()}.
@@ -12,9 +12,9 @@ public interface Entity {
     /**
      * The identifier, as a {@link String}, that uniquely identifies this entity.
      *
-     * @return a non null {@link String}.
+     * @return a {@link String}, or null if the entity does not have an identifier.
      */
-    @NotNull
+    @Nullable
     String identifier();
 
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Entity.java
@@ -3,7 +3,7 @@ package com.vimeo.networking.model;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents data that can be uniquely identified by an {@link Entity#identifier()}.
+ * Represents data that can be uniquely identified by an {@link Entity#getIdentifier()}.
  * <p>
  * Implementors of this interface must provide a unique identifier.
  */
@@ -15,6 +15,6 @@ public interface Entity {
      * @return a {@link String}, or null if the entity does not have an identifier.
      */
     @Nullable
-    String identifier();
+    String getIdentifier();
 
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
@@ -117,7 +117,7 @@ public class Group implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Group.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.UseStag;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -33,7 +35,7 @@ import java.util.Date;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Group implements Serializable {
+public class Group implements Serializable, Entity {
 
     private static final long serialVersionUID = -3604741570351063891L;
 
@@ -63,6 +65,19 @@ public class Group implements Serializable {
 
     @SerializedName("metadata")
     protected Metadata mMetadata;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     public String getUri() {
         return mUri;
@@ -98,5 +113,11 @@ public class Group implements Serializable {
 
     public Metadata getMetadata() {
         return mMetadata;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
@@ -81,7 +81,7 @@ public class Picture implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Picture.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.UseStag;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -32,7 +34,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Picture implements Serializable {
+public class Picture implements Serializable, Entity {
 
     private static final long serialVersionUID = 5278427992827202066L;
 
@@ -47,6 +49,19 @@ public class Picture implements Serializable {
 
     @SerializedName("link_with_play_button")
     protected String mLinkWithPlayButton;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     public int getWidth() {
         return mWidth;
@@ -64,4 +79,9 @@ public class Picture implements Serializable {
         return mLinkWithPlayButton;
     }
 
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
+    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
@@ -38,7 +38,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Recommendation implements Serializable {
+public class Recommendation implements Serializable, Entity {
 
     private static final long serialVersionUID = -1451431453348153582L;
 
@@ -122,6 +122,12 @@ public class Recommendation implements Serializable {
         } else {
             return RecommendationType.NONE;
         }
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
     // </editor-fold>
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Recommendation.java
@@ -126,7 +126,7 @@ public class Recommendation implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
     // </editor-fold>

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.UseStag;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -32,7 +34,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Tag implements Serializable {
+public class Tag implements Serializable, Entity {
 
     private static final long serialVersionUID = 3388947522077930006L;
 
@@ -50,6 +52,19 @@ public class Tag implements Serializable {
 
     @SerializedName("metadata")
     protected Metadata mMetadata;
+
+    @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
 
     public String getUri() {
         return mUri;
@@ -69,5 +84,11 @@ public class Tag implements Serializable {
 
     public Metadata getMetadata() {
         return mMetadata;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Tag.java
@@ -88,7 +88,7 @@ public class Tag implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
@@ -45,7 +45,7 @@ import java.util.Date;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 @UseStag(FieldOption.SERIALIZED_NAME)
-public class User implements Serializable, Followable {
+public class User implements Serializable, Followable, Entity {
 
     private static final long serialVersionUID = 4317573825273169510L;
     private static final String ACCOUNT_BASIC = "basic";
@@ -136,6 +136,10 @@ public class User implements Serializable, Followable {
     private Boolean mIsVideoCreator;
 
     @Nullable
+    @SerializedName("resource_key")
+    private String mResourceKey;
+
+    @Nullable
     public UserBadge getBadge() {
         return mBadge;
     }
@@ -182,6 +186,15 @@ public class User implements Serializable, Followable {
      * -----------------------------------------------------------------------------------------------------
      */
     // <editor-fold desc="Accessors/Helpers">
+    @Nullable
+    public String getResourceKey() {
+        return mResourceKey;
+    }
+
+    protected void setResourceKey(@Nullable String resourceKey) {
+        mResourceKey = resourceKey;
+    }
+
     public void setUri(String uri) {
         mUri = uri;
     }
@@ -532,5 +545,11 @@ public class User implements Serializable, Followable {
                ", mBadge=" + mBadge +
                ", mLiveQuota=" + mLiveQuota +
                '}';
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/User.java
@@ -549,7 +549,7 @@ public class User implements Serializable, Followable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 @UseStag
-public class Video implements Serializable {
+public class Video implements Serializable, Entity {
 
     private static final long serialVersionUID = -2289103918709562107L;
 
@@ -1025,6 +1025,12 @@ public class Video implements Serializable {
     @Override
     public int hashCode() {
         return this.mResourceKey != null ? this.mResourceKey.hashCode() : 0;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
     // </editor-fold>
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -1029,7 +1029,7 @@ public class Video implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
     // </editor-fold>

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/tvod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/tvod/Season.java
@@ -27,6 +27,7 @@ package com.vimeo.networking.model.tvod;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.model.Connection;
 import com.vimeo.networking.model.ConnectionCollection;
+import com.vimeo.networking.model.Entity;
 import com.vimeo.networking.model.Metadata;
 import com.vimeo.networking.model.User;
 import com.vimeo.stag.UseStag;
@@ -45,7 +46,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 @UseStag
-public class Season implements Serializable {
+public class Season implements Serializable, Entity {
 
     private static final String SEASON_TYPE_MAIN = "main";
     private static final String SEASON_TYPE_EXTRAS = "extras";
@@ -214,6 +215,12 @@ public class Season implements Serializable {
     @Override
     public int hashCode() {
         return mUri != null ? mUri.hashCode() : 0;
+    }
+
+    @Nullable
+    @Override
+    public String identifier() {
+        return mResourceKey;
     }
     // </editor-fold>
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/tvod/Season.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/tvod/Season.java
@@ -219,7 +219,7 @@ public class Season implements Serializable, Entity {
 
     @Nullable
     @Override
-    public String identifier() {
+    public String getIdentifier() {
         return mResourceKey;
     }
     // </editor-fold>


### PR DESCRIPTION
# Summary
Various unique entities are represented by the Vimeo API. Each of these entities has a unique identifier. Here I have created an interface for a common way to access this identifier property, and have added the appropriate fields to each entity that was missing them.

The affected models are
- Category
- Channel
- Clip (Video)
- Comment
- Group
- Picture
- Recommendation
- Tag
- User
- Season