### PR TITLE
Update Gradle dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ For a more in depth look at the usage, refer to the [example Android app](exampl
 ### Gradle
 Specify the dependency in your `build.gradle` file (make sure `jcenter()` is included as a repository)
 ```groovy
-compile 'com.vimeo.networking:vimeo-networking:1.1.0'
+implementation("com.vimeo.networking:vimeo-networking:1.1.2", {
+    exclude group: "com.intellij", module: "annotations"
+})
 ```
 
 ### JitPack


### PR DESCRIPTION
Update Gradle dependency example to 1.1.2 and fix workaround issue #285

#### Issue
- https://github.com/vimeo/vimeo-networking-java/issues/285

#### Summary
Update Gradle dependency example to 1.1.2 and fix workaround issue #285

#### How to Test
-
