### PR TITLE
[BUG] VimeoError was not being properly deserialized

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/VimeoError.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/VimeoError.java
@@ -25,6 +25,8 @@ package com.vimeo.networking.model.error;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.networking.Vimeo;
 import com.vimeo.networking.utils.VimeoNetworkUtil;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,7 +43,7 @@ import retrofit2.Response;
  * Created by zetterstromk on 5/27/15.
  */
 @SuppressWarnings("unused")
-//@UseStag(FieldOption.SERIALIZED_NAME)
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class VimeoError extends RuntimeException {
 
     private static final long serialVersionUID = -5252307626841557962L;
@@ -144,17 +146,6 @@ public class VimeoError extends RuntimeException {
 
         final ErrorCode errorCode = VimeoNetworkUtil.getGson().fromJson(mRawErrorCode, ErrorCode.class);
         mErrorCode = errorCode != null ? errorCode : ErrorCode.DEFAULT;
-    }
-
-    /**
-     * Sets the enumerated error code and sets the raw error code based on the serialized value of the enum.
-     *
-     * @param errorCode the error code causing the error.
-     */
-    public void setErrorCode(@NotNull ErrorCode errorCode) {
-        mErrorCode = errorCode;
-        final String json = VimeoNetworkUtil.getGson().toJson(errorCode);
-        mRawErrorCode = json.replaceAll("^\"|\"$", "");
     }
 
     /**

--- a/vimeo-networking/src/test/java/com/vimeo/networking/model/error/VimeoErrorTest.kt
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/model/error/VimeoErrorTest.kt
@@ -1,9 +1,8 @@
 package com.vimeo.networking.model.error
 
+import com.google.gson.annotations.SerializedName
 import com.vimeo.networking.Utils
-import com.vimeo.networking.utils.VimeoNetworkUtil
 import org.assertj.core.api.Assertions.assertThat
-
 import org.junit.Test
 
 /**
@@ -15,14 +14,20 @@ class VimeoErrorTest {
 
     @Test
     fun verifyTypeAdapterWasNotGenerated() {
-        Utils.verifyNoTypeAdapterGeneration(VimeoError::class.java)
+        Utils.verifyTypeAdapterGeneration(VimeoError::class.java)
     }
+
+    /**
+     * Extract the [SerializedName] annotation from the [ErrorCode] enum value.
+     */
+    private fun ErrorCode.getAnnotation(): SerializedName? =
+        ErrorCode::class.java.getField(this.name).getAnnotation(SerializedName::class.java)
 
     @Test
     fun `error code is properly set`() {
         ErrorCode.values().forEach {
             val vimeoError = VimeoError()
-            vimeoError.errorCode = it
+            vimeoError.rawErrorCode = it.getAnnotation()?.value
             assertThat(vimeoError.errorCode).isEqualTo(it)
         }
     }
@@ -35,13 +40,4 @@ class VimeoErrorTest {
         }
     }
 
-    @Test
-    fun `raw error code is properly set`() {
-        ErrorCode.values().forEach {
-            val vimeoError = VimeoError()
-            vimeoError.errorCode = it
-            val errorCode = VimeoNetworkUtil.getGson().fromJson(vimeoError.rawErrorCode, ErrorCode::class.java)
-            assertThat(errorCode).isEqualTo(it)
-        }
-    }
 }


### PR DESCRIPTION
# Summary
The `VimeoError` class was not being properly deserialized from json because Gson was not calling the setter for `setRawErrorCode` and the `mErrorCode` field was never being set. The solution to this was to enable type adapter serialization for this class.

#### How to Test
- Run the unit tests.
