### PR TITLE
ADF-299 annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ For a more in depth look at the usage, refer to the [example Android app](exampl
 ### Gradle
 Specify the dependency in your `build.gradle` file (make sure `jcenter()` is included as a repository)
 ```groovy
-implementation("com.vimeo.networking:vimeo-networking:1.1.2", {
-    exclude group: "com.intellij", module: "annotations"
-})
+implementation "com.vimeo.networking:vimeo-networking:1.1.8"
 ```
 
 ### JitPack

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For a more in depth look at the usage, refer to the [example Android app](exampl
 ### Gradle
 Specify the dependency in your `build.gradle` file (make sure `jcenter()` is included as a repository)
 ```groovy
-implementation "com.vimeo.networking:vimeo-networking:1.1.8"
+implementation "com.vimeo.networking:vimeo-networking:1.1.3"
 ```
 
 ### JitPack

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -33,9 +33,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation(project(':vimeo-networking')) {
-        exclude group: 'com.intellij', module: 'annotations'
-    }
+    implementation(project(':vimeo-networking'))
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -33,7 +33,9 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation project(':vimeo-networking')
+    implementation(project(':vimeo-networking')) {
+        exclude group: 'com.intellij', module: 'annotations'
+    }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation(project(':vimeo-networking'))
+    implementation project(':vimeo-networking')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -33,9 +33,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation(project(':vimeo-networking')) {
-        exclude group: 'com.intellij', module: 'annotations'
-    }
+    implementation project(':vimeo-networking')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.intellij:annotations:12.0@jar'
+    compile 'org.jetbrains:annotations:16.0.2@jar'
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'org.jetbrains:annotations:16.0.2@jar'
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,15 +36,20 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.intellij:annotations:12.0@jar'
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 
+    compile 'org.jetbrains:annotations:16.0.2@jar'
+
     def stagVersion = '2.5.1'
-    compile "com.vimeo.stag:stag-library:$stagVersion"
-    apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
+    compile ("com.vimeo.stag:stag-library:$stagVersion"){
+        exclude group: 'com.intellij', module: 'annotations'
+    }
+    apt ("com.vimeo.stag:stag-library-compiler:$stagVersion"){
+        exclude group: 'com.intellij', module: 'annotations'
+    }
 }
 
 group = 'com.vimeo.networking'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -47,9 +47,7 @@ dependencies {
     compile ("com.vimeo.stag:stag-library:$stagVersion"){
         exclude group: 'com.intellij', module: 'annotations'
     }
-    apt ("com.vimeo.stag:stag-library-compiler:$stagVersion"){
-        exclude group: 'com.intellij', module: 'annotations'
-    }
+    apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }
 
 group = 'com.vimeo.networking'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'org.jetbrains:annotations:16.0.2@jar'
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'org.jetbrains:annotations:16.0.2@jar'
+    compile 'com.intellij:annotations:12.0@jar'
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"


### PR DESCRIPTION
#### Issue
https://github.com/vimeo/vimeo-networking-java/issues/285
https://vimean.atlassian.net/browse/ADF-299

https://github.com/vimeo/vimeo-networking-java/issues/289
https://vimean.atlassian.net/browse/ADF-297

#### Summary
Build conflicts were occurring related to `com.intellij:annotations`. This dependency was updated in the build script to the new version `org.jetbrains:annotations:16.0.2` and stag's annotations were excluded (since it also pulled in the older version of the lib). Exclusions were removed from the sample since they are no longer needed after the changes made to the build script.

#### How to Test
- Create a test project as described in this issue:
https://github.com/vimeo/vimeo-networking-java/issues/285
- Confirm that it fails to build when pointing at the public version of networking.
- Use jitpack and point at the latest commit on this branch:
`implementation 'com.github.vimeo:vimeo-networking-java:7488ad96ac'`
- Confirm that it builds correctly

- Create a test project as described in this issue:
https://github.com/vimeo/vimeo-networking-java/issues/289
- Confirm that it fails to build when pointing at the public version of networking.
- Use jitpack and point at the latest commit on this branch:
`implementation 'com.github.vimeo:vimeo-networking-java:7488ad96ac'`
- Confirm that it builds correctly