### PR TITLE
fixing annotations and updating tools and sdk on the sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 android:
   components:
     - tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-26.0.1
+    - android-26
     - extra-android-support
     - extra-android-m2repository
 before_cache:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ For a more in depth look at the usage, refer to the [example Android app](exampl
 ### Gradle
 Specify the dependency in your `build.gradle` file (make sure `jcenter()` is included as a repository)
 ```groovy
-implementation("com.vimeo.networking:vimeo-networking:1.1.2", {
-    exclude group: "com.intellij", module: "annotations"
-})
+implementation "com.vimeo.networking:vimeo-networking:1.1.3"
 ```
 
 ### Submodule

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "com.vimeo.example"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -28,10 +28,12 @@ tasks.withType(Javadoc).all { enabled = true }
 dependencies {
     testCompile 'junit:junit:4.12'
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.intellij:annotations:12.0@jar'
+    compile 'org.jetbrains:annotations:16.0.2@jar'
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.vimeo.stag:stag-library:1.0.0'
+    compile ('com.vimeo.stag:stag-library:1.0.0'){
+        exclude group: 'com.intellij', module: 'annotations'
+    }
     apt 'com.vimeo.stag:stag-library-compiler:1.0.0'
 }
 


### PR DESCRIPTION
#### Issue
https://github.com/vimeo/vimeo-networking-java/issues/285
https://vimean.atlassian.net/browse/ADF-299

https://github.com/vimeo/vimeo-networking-java/issues/289
https://vimean.atlassian.net/browse/ADF-297

#### Summary
Build conflicts were occurring related to `com.intellij:annotations`. This dependency was updated in the build script to the new version `org.jetbrains:annotations:16.0.2` and stag's annotations were excluded (since it also pulled in the older version of the lib). 

#### How to Test
- Create a test project as described in this issue:
https://github.com/vimeo/vimeo-networking-java/issues/285
- Confirm that it fails to build when pointing at the public version of networking.
- Use jitpack and point at the latest commit on this branch:
`implementation 'com.github.vimeo:vimeo-networking-java:7488ad96ac'`
- Confirm that it builds correctly

- Create a test project as described in this issue:
https://github.com/vimeo/vimeo-networking-java/issues/289
- Confirm that it fails to build when pointing at the public version of networking.
- Use jitpack and point at the latest commit on this branch:
`implementation 'com.github.vimeo:vimeo-networking-java:7488ad96ac'`
- Confirm that it builds correctly