### PR TITLE
Add new chromecast receiver token

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
@@ -186,6 +186,10 @@ public class Privacy implements Serializable {
     public CommentValue mComments;
 
     @Nullable
+    @SerializedName("_bypass_token")
+    public String mBypassToken;
+
+    @Nullable
     public ViewValue getView() {
         return mView;
     }
@@ -206,5 +210,9 @@ public class Privacy implements Serializable {
     @Nullable
     public CommentValue getComments() {
         return mComments;
+    }
+
+    public String getBypassToken() {
+        return mBypassToken;
     }
 }


### PR DESCRIPTION
#### Summary
Add new optional token used when casting videos via ChromeCast

#### How to Test
For an app with the appropriate permissions the new field on `video.privacy` should be set.
