### PR TITLE
VA-3460 Adding GCS Support

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -158,6 +158,10 @@ public class ConnectionCollection implements Serializable {
     protected Connection mRecommendedUsers;
 
     @Nullable
+    @SerializedName("upload_attempt")
+    private Connection mUploadAttempt;
+
+    @Nullable
     @SerializedName("watched_videos")
     protected Connection mWatchedVideos;
 
@@ -182,7 +186,8 @@ public class ConnectionCollection implements Serializable {
     private Interaction mLiveStats;
 
     /**
-     * @return the {@link Interaction} for getting the {@link com.vimeo.networking.model.live.LiveStats} for a live {@link Video}
+     * @return the {@link Interaction} for getting the {@link com.vimeo.networking.model.live.LiveStats}
+     * for a live {@link Video}
      */
     @Nullable
     public Interaction getLiveStats() {
@@ -352,6 +357,11 @@ public class ConnectionCollection implements Serializable {
     @Nullable
     public Connection getFolders() {
         return mFolders;
+    }
+
+    @Nullable
+    public Connection getUploadAttempt() {
+        return mUploadAttempt;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -380,4 +380,8 @@ public class ConnectionCollection implements Serializable {
     void setLiveStats(@Nullable Interaction liveStats) {
         mLiveStats = liveStats;
     }
+
+    void setUploadAttempt(@Nullable Connection uploadAttempt) {
+        mUploadAttempt = uploadAttempt;
+    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
@@ -23,17 +23,20 @@
 package com.vimeo.networking.upload;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.networking.model.Metadata;
 import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * The data representation of the Gcs object that is used for uploading files.
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-@UseStag
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class Gcs implements Serializable{
 
     private static final long serialVersionUID = -4272338075095674506L;
@@ -50,6 +53,19 @@ public class Gcs implements Serializable{
     @SerializedName("upload_link")
     private String mUploadLink;
 
+    @Nullable
+    @SerializedName("metadata")
+    public Metadata mMetadata;
+
+
+    @Nullable
+    public Metadata getMetadata() {
+        return mMetadata;
+    }
+
+    public void setMetadata(@Nullable final Metadata metadata) {
+        mMetadata = metadata;
+    }
 
     /**
      * @return The starting byte used for uploading if available
@@ -92,5 +108,31 @@ public class Gcs implements Serializable{
      */
     public void setUploadLink(@Nullable String uploadLink) {
         mUploadLink = uploadLink;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        Gcs gcs = (Gcs) o;
+        return Objects.equals(mStartingByte, gcs.mStartingByte) &&
+               Objects.equals(mEndingByte, gcs.mEndingByte) &&
+               Objects.equals(mUploadLink, gcs.mUploadLink);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(mStartingByte, mEndingByte, mUploadLink);
+    }
+
+    @Override
+    public String toString() {
+        return "Gcs{" +
+               "mStartingByte=" + mStartingByte +
+               ", mEndingByte=" + mEndingByte +
+               ", mUploadLink='" + mUploadLink + '\'' +
+               ", mMetadata=" + mMetadata +
+               '}';
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
@@ -49,4 +49,48 @@ public class Gcs implements Serializable{
     @Nullable
     @SerializedName("upload_link")
     private String mUploadLink;
+
+
+    /**
+     * @return The starting byte used for uploading if available
+     */
+    @Nullable
+    public Long getStartingByte() {
+        return mStartingByte;
+    }
+
+    /**
+     * Set the starting byte used for uploading
+     */
+    public void setStartingByte(@Nullable Long startingByte) {
+        mStartingByte = startingByte;
+    }
+    /**
+     * @return The ending byte used for uploading if available
+     */
+    @Nullable
+    public Long getEndingByte() {
+        return mEndingByte;
+    }
+
+    /**
+     * Set the ending byte used for uploading
+     */
+    public void setEndingByte(@Nullable Long endingByte) {
+        mEndingByte = endingByte;
+    }
+    /**
+     * @return The upload link used for uploading if available
+     */
+    @Nullable
+    public String getUploadLink() {
+        return mUploadLink;
+    }
+
+    /**
+     * Set the upload link used for uploading
+     */
+    public void setUploadLink(@Nullable String uploadLink) {
+        mUploadLink = uploadLink;
+    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
@@ -55,7 +55,7 @@ public class Gcs implements Serializable{
 
     @Nullable
     @SerializedName("metadata")
-    public Metadata mMetadata;
+    private Metadata mMetadata;
 
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
@@ -30,12 +30,11 @@ import com.vimeo.stag.UseStag.FieldOption;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * The data representation of the Gcs object that is used for uploading files.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"unused"})
 @UseStag(FieldOption.SERIALIZED_NAME)
 public class Gcs implements Serializable{
 
@@ -111,28 +110,31 @@ public class Gcs implements Serializable{
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
-        Gcs gcs = (Gcs) o;
-        return Objects.equals(mStartingByte, gcs.mStartingByte) &&
-               Objects.equals(mEndingByte, gcs.mEndingByte) &&
-               Objects.equals(mUploadLink, gcs.mUploadLink);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(mStartingByte, mEndingByte, mUploadLink);
-    }
-
-    @Override
     public String toString() {
         return "Gcs{" +
                "mStartingByte=" + mStartingByte +
                ", mEndingByte=" + mEndingByte +
                ", mUploadLink='" + mUploadLink + '\'' +
-               ", mMetadata=" + mMetadata +
                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || !getClass().equals(o.getClass())) { return false; }
+
+        final Gcs gcs = (Gcs) o;
+
+        return (mStartingByte != null ? mStartingByte.equals(gcs.mStartingByte) : gcs.mStartingByte == null) &&
+               (mEndingByte != null ? mEndingByte.equals(gcs.mEndingByte) : gcs.mEndingByte == null) &&
+               (mUploadLink != null ? mUploadLink.equals(gcs.mUploadLink) : gcs.mUploadLink == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mStartingByte != null ? mStartingByte.hashCode() : 0;
+        result = 31 * result + (mEndingByte != null ? mEndingByte.hashCode() : 0);
+        result = 31 * result + (mUploadLink != null ? mUploadLink.hashCode() : 0);
+        return result;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Gcs.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.upload;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * The data representation of the Gcs object that is used for uploading files.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+@UseStag
+public class Gcs implements Serializable{
+
+    private static final long serialVersionUID = -4272338075095674506L;
+
+    @Nullable
+    @SerializedName("start_byte")
+    private Long mStartingByte;
+
+    @Nullable
+    @SerializedName("end_byte")
+    private Long mEndingByte;
+
+    @Nullable
+    @SerializedName("upload_link")
+    private String mUploadLink;
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
@@ -6,6 +6,7 @@ import com.vimeo.stag.UseStag;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 /**
  * The representation of the upload object.
@@ -39,7 +40,7 @@ public class Upload implements Serializable {
 
     @Nullable
     @SerializedName("gcs")
-    private Gcs mGcs;
+    private ArrayList<Gcs> mGcs;
 
     @Nullable
     @SerializedName("form")
@@ -141,14 +142,14 @@ public class Upload implements Serializable {
      * @return The Gcs object used for uploading if available
      */
     @Nullable
-    public Gcs getGcs() {
-        return mGcs;
+    public ArrayList<Gcs> getGcs() {
+        return mGcs != null ? new ArrayList<>(mGcs) : null;
     }
 
     /**
      * Set the Gcs object
      */
-    public void setGcs(@Nullable Gcs gcs) {
-        mGcs = gcs;
+    public void setGcs(@Nullable ArrayList<Gcs> gcs) {
+        mGcs = (gcs != null) ? new ArrayList<>(gcs) : null;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
@@ -144,4 +144,8 @@ public class Upload implements Serializable {
     public Gcs getGcs() {
         return mGcs;
     }
+
+    void setGcs(@Nullable Gcs gcs) {
+        mGcs = gcs;
+    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
@@ -38,6 +38,10 @@ public class Upload implements Serializable {
     private String mCompleteUri;
 
     @Nullable
+    @SerializedName("gcs")
+    private Gcs mGcs;
+
+    @Nullable
     @SerializedName("form")
     private String mForm;
 
@@ -131,5 +135,13 @@ public class Upload implements Serializable {
 
     void setUploadLink(@Nullable String uploadLink) {
         mUploadLink = uploadLink;
+    }
+
+    /**
+     * @return The Gcs object used for uploading if available
+     */
+    @Nullable
+    public Gcs getGcs() {
+        return mGcs;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
@@ -139,7 +139,8 @@ public class Upload implements Serializable {
     }
 
     /**
-     * @return The Gcs object used for uploading if available
+     * @return An array of Gcs objects used for uploading if available. The number of Gcs object will
+     * be equal to the number of parallel requests specified in the video upload creation step.
      */
     @Nullable
     public ArrayList<Gcs> getGcs() {
@@ -147,7 +148,7 @@ public class Upload implements Serializable {
     }
 
     /**
-     * Set the Gcs object
+     * Set the array of Gcs objects
      */
     public void setGcs(@Nullable ArrayList<Gcs> gcs) {
         mGcs = (gcs != null) ? new ArrayList<>(gcs) : null;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/upload/Upload.java
@@ -145,7 +145,10 @@ public class Upload implements Serializable {
         return mGcs;
     }
 
-    void setGcs(@Nullable Gcs gcs) {
+    /**
+     * Set the Gcs object
+     */
+    public void setGcs(@Nullable Gcs gcs) {
         mGcs = gcs;
     }
 }


### PR DESCRIPTION
#### Issue
https://github.com/vimeo//vimeo-networking-java/issues/VA-3460

#### Summary
This ticket is about adding support for GCS to the upload object. Here is an example of the response format.
```
"gcs":[  
         {  
            "upload_link":"https://www.googleapis.com/upload/storage/...",
            "start_byte":0,
            "end_byte":1057148,
            "metadata":{  
               "connections":{  
                  "upload_attempt":{  
                     "uri":"/upload/attempt/09d...",
                     "options":[  
                        "GET"
                     ]
                  }
               }
            }
         }
      ]
```

#### How to Test
No testing here. Can be confirmed on the application level.
