### PR TITLE
Update VimeoClient for using Moshi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
+        //classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -19,11 +19,11 @@ allprojects {
         google()
         jcenter()
     }
-    apply plugin: "com.jfrog.bintray"
+    //apply plugin: "com.jfrog.bintray"
 
-    tasks.withType(Javadoc).all { enabled = false }
+    //tasks.withType(Javadoc).all { enabled = false }
 
-    tasks.withType(JavaCompile) { options.fork = true }
+    //tasks.withType(JavaCompile) { options.fork = true }
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        //classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -19,11 +19,11 @@ allprojects {
         google()
         jcenter()
     }
-    //apply plugin: "com.jfrog.bintray"
+    apply plugin: "com.jfrog.bintray"
 
-    //tasks.withType(Javadoc).all { enabled = false }
+    tasks.withType(Javadoc).all { enabled = false }
 
-    //tasks.withType(JavaCompile) { options.fork = true }
+    tasks.withType(JavaCompile) { options.fork = true }
 }
 
 task clean(type: Delete) {

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -5,6 +5,31 @@ apply plugin: 'maven-publish'
 
 group = 'com.vimeo.networking'
 
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT License"
+            url "http://www.opensource.org/licenses/mit-license.php"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "vimeo"
+            name "Vimeo Mobile"
+            email "mobileops@vimeo.com"
+            organisation "Vimeo"
+            organisationUrl "https://github.com/vimeo"
+        }
+    }
+
+    scm {
+        connection "scm:git:git://github.com/vimeo/vimeo-networking-java.git"
+        developerConnection "scm:git:ssh://github.com:vimeo/vimeo-networking-java.git"
+        url "https://github.com/vimeo/vimeo-networking-java"
+    }
+}
+
 // Create the publication with the pom configuration:
 // Requires apply plugin: maven-publish
 publishing {

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'maven-publish'
 
+group = 'com.vimeo.networking'
+
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -9,6 +9,24 @@ repositories {
     jcenter()
 }
 
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
 dependencies {
 
     // Kotlin

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,6 +1,21 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'maven-publish'
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar, javadocJar
+}
 
 repositories {
     jcenter()

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,9 +1,31 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'com.vimeo.networking'
+
+// Create the publication with the pom configuration:
+// Requires apply plugin: maven-publish
+publishing {
+    publications {
+        MyPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId project.group
+            artifactId 'vimeo-networking'
+            version project.version
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'vimeo-networking is a Java networking library used for interacting with the Vimeo API.')
+                root.appendNode('name', 'vimeo-networking')
+                root.appendNode('url', 'https://github.com/vimeo/vimeo-networking-java')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'maven-publish'
+apply plugin: 'maven'
 
 group = 'com.vimeo.networking'
 

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'maven'
+
+group = 'com.vimeo.networking'
 
 repositories {
     jcenter()

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,30 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'maven'
-
-group = 'com.vimeo.networking'
 
 repositories {
     jcenter()
-}
-
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
 }
 
 dependencies {

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'maven-publish'
 
 group = 'com.vimeo.networking'
 
+// Create the pom configuration
+// All the fields below are required by Maven Central
 def pomConfig = {
     licenses {
         license {
@@ -39,7 +41,7 @@ publishing {
             artifact sourcesJar
             artifact javadocJar
             groupId project.group
-            artifactId 'vimeo-networking'
+            artifactId 'models'
             version project.version
             pom.withXml {
                 def root = asNode()

--- a/settings-parent.gradle
+++ b/settings-parent.gradle
@@ -1,8 +1,0 @@
-apply from: 'settings.gradle'
-
-// for all modules in vimeo-networking-java, set the project directory. This enables us to
-// say :vimeo-networking, rather than :vimeo-networking-java:vimeo-networking
-rootProject.children.each { project ->
-    String relativeProjectPath = project.projectDir.path.replace(settingsDir.path, "")
-    project.projectDir = new File("vimeo-networking-java/$relativeProjectPath")
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,5 @@
 include ':vimeo-networking', ':models'
 
-/*
 if (!System.env.JITPACK) {
     include ':example-java-android', ':example-kotlin-android', ':example-vimeo-networking2-android'
 }
-*/

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-include ':vimeo-networking', 'models'
+include ':vimeo-networking', ':models'
 
 if (!System.env.JITPACK) {
     include ':example-java-android', ':example-kotlin-android', ':example-vimeo-networking2-android'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,7 @@
 include ':vimeo-networking', ':models'
 
+/*
 if (!System.env.JITPACK) {
     include ':example-java-android', ':example-kotlin-android', ':example-vimeo-networking2-android'
 }
+*/

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':models')
+    api project(':models')
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 compileJava {
     sourceCompatibility = 1.7
@@ -78,7 +78,7 @@ artifacts {
     archives sourcesJar, javadocJar
 }
 
-/*// Create the pom configuration
+// Create the pom configuration
 // All the fields below are required by Maven Central
 def pomConfig = {
     licenses {
@@ -97,7 +97,7 @@ def pomConfig = {
             organisationUrl "https://github.com/vimeo"
         }
     }
-    
+
     scm {
         connection "scm:git:git://github.com/vimeo/vimeo-networking-java.git"
         developerConnection "scm:git:ssh://github.com:vimeo/vimeo-networking-java.git"
@@ -167,7 +167,7 @@ allprojects {
             }
         }
     }
-}*/
+}
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -29,7 +29,7 @@ repositories {
     jcenter()
 }
 
-/*tasks.withType(Javadoc).all { enabled = true }*/
+tasks.withType(Javadoc).all { enabled = true }
 
 dependencies {
     testCompile 'junit:junit:4.12'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    api project(':models')
+    implementation project(':models')
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,10 +36,13 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile project(':models')
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    compile "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
+    compile "com.squareup.moshi:moshi-adapters:1.7.0"
 
     compile 'org.jetbrains:annotations:16.0.2@jar'
 

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     testCompile "org.assertj:assertj-core:3.10.0"
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':models')
+    compile project(':models')
 
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -18,12 +18,12 @@ buildscript {
     }
     dependencies {
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.16'
-        //classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
+        classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
     }
 }
 
 apply plugin: 'net.ltgt.apt'
-//apply plugin: 'de.fuerstenau.buildconfig'
+apply plugin: 'de.fuerstenau.buildconfig'
 
 repositories {
     jcenter()
@@ -55,13 +55,13 @@ dependencies {
 
 group = 'com.vimeo.networking'
 
-/*buildConfig {
+buildConfig {
     appName = project.name
     version = project.version
 
     clsName = 'BuildConfig'
     packageName = project.group
-}*/
+}
 
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
-apply plugin: 'maven-publish'
+apply plugin: 'maven'
 
 compileJava {
     sourceCompatibility = 1.7
@@ -18,18 +18,18 @@ buildscript {
     }
     dependencies {
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.16'
-        classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
+        //classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
     }
 }
 
 apply plugin: 'net.ltgt.apt'
-apply plugin: 'de.fuerstenau.buildconfig'
+//apply plugin: 'de.fuerstenau.buildconfig'
 
 repositories {
     jcenter()
 }
 
-tasks.withType(Javadoc).all { enabled = true }
+/*tasks.withType(Javadoc).all { enabled = true }*/
 
 dependencies {
     testCompile 'junit:junit:4.12'
@@ -55,13 +55,13 @@ dependencies {
 
 group = 'com.vimeo.networking'
 
-buildConfig {
+/*buildConfig {
     appName = project.name
     version = project.version
 
     clsName = 'BuildConfig'
     packageName = project.group
-}
+}*/
 
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -78,7 +78,7 @@ artifacts {
     archives sourcesJar, javadocJar
 }
 
-// Create the pom configuration
+/*// Create the pom configuration
 // All the fields below are required by Maven Central
 def pomConfig = {
     licenses {
@@ -167,7 +167,7 @@ allprojects {
             }
         }
     }
-}
+}*/
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
@@ -25,6 +25,7 @@ public final class AnnotatedConverterFactory extends Converter.Factory {
     @Retention(RetentionPolicy.RUNTIME)
     @interface Serializer {
 
+        @NotNull
         ConverterType converter();
 
     }
@@ -62,8 +63,9 @@ public final class AnnotatedConverterFactory extends Converter.Factory {
     }
 
     @Override
-    public Converter<ResponseBody, ?> responseBodyConverter(final Type type, final Annotation[] annotations,
-                                                            final Retrofit retrofit) {
+    public Converter<ResponseBody, ?> responseBodyConverter(@NotNull final Type type,
+                                                            @NotNull final Annotation[] annotations,
+                                                            @NotNull final Retrofit retrofit) {
         Converter.Factory converterFactory = gsonFactory;
 
         for (final Annotation annotation : annotations) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
@@ -1,91 +1,81 @@
 package com.vimeo.networking;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
-import retrofit2.Converter.Factory;
 import retrofit2.Retrofit;
 
 /**
  * This is a converter factory that allows you to specify different converters to use for each request.
  * This was taken from https://stackoverflow.com/questions/40824122/android-retrofit-2-multiple-converters-gson-simplexml-error.
  * It provides two annotations - Gson and Moshi that should be used on a Retrofit request service to specify which
- * serialization framework to use.
- * <p>
- * Ex:
- *
- * @<code>
- *
- *  @GET
- *  @Moshi Call<com.vimeo.networking2.VideoList> getVideoList(
- *  @Header("Authorization") String authHeader,
- *  @Url String uri,
- *  @QueryMap Map<String, String> options,
- *  @Header("Cache-Control") String cacheHeaderValue);
- *
- * </code>
- *
- * If a annotation is not specified, Gson will be used.
+ * serialization framework to use. If a annotation is not specified, Gson will be used.
  */
 public final class AnnotatedConverterFactory extends Converter.Factory {
 
+    /**
+     * Annotate a method to specify the type of serialization to use. Gson or Moshi.
+     */
     @Retention(RetentionPolicy.RUNTIME)
-    @interface Gson {}
+    @interface Serializer {
 
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Moshi {}
+        ConverterType converter();
 
-    private final Map<Class<?>, Converter.Factory> mFactoryMap;
+    }
 
-    private AnnotatedConverterFactory(final Map<Class<?>, Converter.Factory> factoryMap) {
-        mFactoryMap = factoryMap;
+    /**
+     * Different types of converter that can be specified in the serializer annotation.
+     */
+    enum ConverterType {
+        GSON, MOSHI;
+    }
+
+    /**
+     * Gson converter.
+     */
+    @NotNull
+    private final Converter.Factory gsonFactory;
+
+    /**
+     * Moshi converter.
+     */
+    @NotNull
+    private final Converter.Factory moshiFactory;
+
+    /**
+     * Specify all serialization converters that can be used in the SDK. The type of serialization
+     * framework to use could be chosen by specifying it in the serializer annotation.
+     *
+     * @param gsonFactory  Gson converter factory.
+     * @param moshiFactory Moshi converter factory.
+     */
+    AnnotatedConverterFactory(@NotNull final Converter.Factory gsonFactory,
+                              @NotNull final Converter.Factory moshiFactory) {
+        this.gsonFactory = gsonFactory;
+        this.moshiFactory = moshiFactory;
     }
 
     @Override
-    public Converter<ResponseBody, ?> responseBodyConverter(final Type type,
-                                                            final Annotation[] annotations,
+    public Converter<ResponseBody, ?> responseBodyConverter(final Type type, final Annotation[] annotations,
                                                             final Retrofit retrofit) {
+        Converter.Factory converterFactory = gsonFactory;
+
         for (final Annotation annotation : annotations) {
-            final Converter.Factory factory = mFactoryMap.get(annotation.annotationType());
-            if (factory != null) {
-                System.out.println(factory);
-                return factory.responseBodyConverter(type, annotations, retrofit);
+            if (annotation instanceof Serializer) {
+                final ConverterType converterType = ((Serializer) annotation).converter();
+                if (converterType == ConverterType.MOSHI) {
+                    converterFactory = moshiFactory;
+                    break;
+                }
             }
         }
-
-        //try to default to gson in case no annotation on current method was found
-        final Converter.Factory gsonFactory = mFactoryMap.get(Gson.class);
-        System.out.println(gsonFactory);
-        if (gsonFactory != null) {
-            return gsonFactory.responseBodyConverter(type, annotations, retrofit);
-        }
-        return null;
+        return converterFactory.responseBodyConverter(type, annotations, retrofit);
     }
 
-    static class Builder {
-
-        Map<Class<?>, Factory> mFactoryMap = new LinkedHashMap<>();
-
-        Builder add(final Class<? extends Annotation> factoryType, final Converter.Factory factory) {
-            if (factoryType == null) {
-                throw new NullPointerException("factoryType is null");
-            }
-            if (factory == null) {
-                throw new NullPointerException("factory is null");
-            }
-            mFactoryMap.put(factoryType, factory);
-            return this;
-        }
-
-        public AnnotatedConverterFactory build() {
-            return new AnnotatedConverterFactory(mFactoryMap);
-        }
-
-    }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/AnnotatedConverterFactory.java
@@ -1,0 +1,91 @@
+package com.vimeo.networking;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Converter.Factory;
+import retrofit2.Retrofit;
+
+/**
+ * This is a converter factory that allows you to specify different converters to use for each request.
+ * This was taken from https://stackoverflow.com/questions/40824122/android-retrofit-2-multiple-converters-gson-simplexml-error.
+ * It provides two annotations - Gson and Moshi that should be used on a Retrofit request service to specify which
+ * serialization framework to use.
+ * <p>
+ * Ex:
+ *
+ * @<code>
+ *
+ *  @GET
+ *  @Moshi Call<com.vimeo.networking2.VideoList> getVideoList(
+ *  @Header("Authorization") String authHeader,
+ *  @Url String uri,
+ *  @QueryMap Map<String, String> options,
+ *  @Header("Cache-Control") String cacheHeaderValue);
+ *
+ * </code>
+ *
+ * If a annotation is not specified, Gson will be used.
+ */
+public final class AnnotatedConverterFactory extends Converter.Factory {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Gson {}
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Moshi {}
+
+    private final Map<Class<?>, Converter.Factory> mFactoryMap;
+
+    private AnnotatedConverterFactory(final Map<Class<?>, Converter.Factory> factoryMap) {
+        mFactoryMap = factoryMap;
+    }
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(final Type type,
+                                                            final Annotation[] annotations,
+                                                            final Retrofit retrofit) {
+        for (final Annotation annotation : annotations) {
+            final Converter.Factory factory = mFactoryMap.get(annotation.annotationType());
+            if (factory != null) {
+                System.out.println(factory);
+                return factory.responseBodyConverter(type, annotations, retrofit);
+            }
+        }
+
+        //try to default to gson in case no annotation on current method was found
+        final Converter.Factory gsonFactory = mFactoryMap.get(Gson.class);
+        System.out.println(gsonFactory);
+        if (gsonFactory != null) {
+            return gsonFactory.responseBodyConverter(type, annotations, retrofit);
+        }
+        return null;
+    }
+
+    static class Builder {
+
+        Map<Class<?>, Factory> mFactoryMap = new LinkedHashMap<>();
+
+        Builder add(final Class<? extends Annotation> factoryType, final Converter.Factory factory) {
+            if (factoryType == null) {
+                throw new NullPointerException("factoryType is null");
+            }
+            if (factory == null) {
+                throw new NullPointerException("factory is null");
+            }
+            mFactoryMap.put(factoryType, factory);
+            return this;
+        }
+
+        public AnnotatedConverterFactory build() {
+            return new AnnotatedConverterFactory(mFactoryMap);
+        }
+
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -25,6 +25,8 @@
 package com.vimeo.networking;
 
 import com.google.gson.Gson;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter;
 import com.vimeo.networking.interceptors.AcceptHeaderInterceptor;
 import com.vimeo.networking.interceptors.CacheControlInterceptor;
 import com.vimeo.networking.interceptors.UserAgentInterceptor;
@@ -35,6 +37,7 @@ import com.vimeo.networking.utils.VimeoNetworkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Cache;
@@ -42,6 +45,7 @@ import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.converter.moshi.MoshiConverterFactory;
 
 /**
  * Retrofit setup code.  Used to create an instance of {@link Retrofit} to make API requests.
@@ -89,7 +93,19 @@ class RetrofitSetup {
     public Retrofit createRetrofit() {
         return new Retrofit.Builder().baseUrl(mConfiguration.getBaseUrl())
                 .client(createOkHttpClient())
-                .addConverterFactory(GsonConverterFactory.create(mGson))
+                .addConverterFactory(new AnnotatedConverterFactory.Builder()
+                                    .add(AnnotatedConverterFactory.Gson.class, GsonConverterFactory.create(mGson))
+                                    .add(AnnotatedConverterFactory.Moshi.class, MoshiConverterFactory.create(createMoshi()))
+                                    .build())
+                .build();
+    }
+
+    /**
+     * Create an instance of Moshi with a date adapter.
+     */
+    private Moshi createMoshi() {
+        return new Moshi.Builder()
+                .add(Date.class, new Rfc3339DateJsonAdapter().nullSafe())
                 .build();
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -93,10 +93,9 @@ class RetrofitSetup {
     public Retrofit createRetrofit() {
         return new Retrofit.Builder().baseUrl(mConfiguration.getBaseUrl())
                 .client(createOkHttpClient())
-                .addConverterFactory(new AnnotatedConverterFactory.Builder()
-                                    .add(AnnotatedConverterFactory.Gson.class, GsonConverterFactory.create(mGson))
-                                    .add(AnnotatedConverterFactory.Moshi.class, MoshiConverterFactory.create(createMoshi()))
-                                    .build())
+                .addConverterFactory(new AnnotatedConverterFactory(GsonConverterFactory.create(mGson),
+                                                                   MoshiConverterFactory.create(
+                                                                           createMoshi())))
                 .build();
     }
 
@@ -104,16 +103,13 @@ class RetrofitSetup {
      * Create an instance of Moshi with a date adapter.
      */
     private Moshi createMoshi() {
-        return new Moshi.Builder()
-                .add(Date.class, new Rfc3339DateJsonAdapter().nullSafe())
-                .build();
+        return new Moshi.Builder().add(Date.class, new Rfc3339DateJsonAdapter().nullSafe()).build();
     }
 
     /**
      * OkHttp setup.
      */
-    @NotNull
-    OkHttpClient createOkHttpClient() {
+    @NotNull OkHttpClient createOkHttpClient() {
         final RetrofitClientBuilder retrofitClientBuilder = new RetrofitClientBuilder();
         if (mCache != null) {
             retrofitClientBuilder.setCache(mCache);
@@ -147,11 +143,11 @@ class RetrofitSetup {
     /**
      * @return value used for {@code User-Agent} HTTP header value.
      */
-    @NotNull
-    String createUserAgent() {
+    @NotNull String createUserAgent() {
         final String userProvidedAgent = mConfiguration.getUserAgentString();
 
-        if (userProvidedAgent != null && !userProvidedAgent.isEmpty() && isValidUserAgent(userProvidedAgent)) {
+        if (userProvidedAgent != null && !userProvidedAgent.isEmpty() &&
+            isValidUserAgent(userProvidedAgent)) {
             return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
         } else {
             return mLibraryUserAgentComponent;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -75,13 +75,13 @@ class RetrofitSetup {
      * Value appended to {@code User-Agent} header to identify which version of this library is used.
      */
     @NotNull
-    private final String mLibraryUserAgentComponent = "";
+    private final String mLibraryUserAgentComponent;
 
     RetrofitSetup(@NotNull Configuration configuration, @Nullable Cache cache) {
         mConfiguration = configuration;
         mCache = cache;
         mGson = VimeoNetworkUtil.getGson();
-        //mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
+        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -94,14 +94,14 @@ class RetrofitSetup {
         return new Retrofit.Builder().baseUrl(mConfiguration.getBaseUrl())
                 .client(createOkHttpClient())
                 .addConverterFactory(new AnnotatedConverterFactory(GsonConverterFactory.create(mGson),
-                                                                   MoshiConverterFactory.create(
-                                                                           createMoshi())))
+                                                                   MoshiConverterFactory.create(createMoshi())))
                 .build();
     }
 
     /**
      * Create an instance of Moshi with a date adapter.
      */
+    @NotNull
     private Moshi createMoshi() {
         return new Moshi.Builder().add(Date.class, new Rfc3339DateJsonAdapter().nullSafe()).build();
     }
@@ -146,8 +146,9 @@ class RetrofitSetup {
     @NotNull String createUserAgent() {
         final String userProvidedAgent = mConfiguration.getUserAgentString();
 
-        if (userProvidedAgent != null && !userProvidedAgent.isEmpty() &&
-            isValidUserAgent(userProvidedAgent)) {
+        if (userProvidedAgent != null
+            && !userProvidedAgent.isEmpty()
+            && isValidUserAgent(userProvidedAgent)) {
             return userProvidedAgent + ' ' + mLibraryUserAgentComponent;
         } else {
             return mLibraryUserAgentComponent;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -75,13 +75,13 @@ class RetrofitSetup {
      * Value appended to {@code User-Agent} header to identify which version of this library is used.
      */
     @NotNull
-    private final String mLibraryUserAgentComponent;
+    private final String mLibraryUserAgentComponent = "";
 
     RetrofitSetup(@NotNull Configuration configuration, @Nullable Cache cache) {
         mConfiguration = configuration;
         mCache = cache;
         mGson = VimeoNetworkUtil.getGson();
-        mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
+        //mLibraryUserAgentComponent = "VimeoNetworking/" + BuildConfig.VERSION + " (Java)";
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -60,7 +60,6 @@ import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -22,7 +22,8 @@
 
 package com.vimeo.networking;
 
-import com.vimeo.networking.AnnotatedConverterFactory.Moshi;
+import com.vimeo.networking.AnnotatedConverterFactory.ConverterType;
+import com.vimeo.networking.AnnotatedConverterFactory.Serializer;
 import com.vimeo.networking.model.Category;
 import com.vimeo.networking.model.CategoryList;
 import com.vimeo.networking.model.Channel;
@@ -314,7 +315,7 @@ public interface VimeoService {
                                @Header("Cache-Control") String cacheHeaderValue);
 
     @GET
-    @Moshi
+    @Serializer(converter =  ConverterType.MOSHI)
     Call<com.vimeo.networking2.FeedList> getFeedListMoshi(@Header("Authorization") String authHeader,
                                                           @Url String uri,
                                                           @QueryMap Map<String, String> options,
@@ -363,7 +364,7 @@ public interface VimeoService {
                                @Header("Cache-Control") String cacheHeaderValue);
 
     @GET
-    @Moshi
+    @Serializer(converter =  ConverterType.MOSHI)
     Call<com.vimeo.networking2.UserList> getUserListMoshi(@Header("Authorization") String authHeader,
                                                           @Url String uri,
                                                           @QueryMap Map<String, String> options,
@@ -376,7 +377,7 @@ public interface VimeoService {
                                  @Header("Cache-Control") String cacheHeaderValue);
 
     @GET
-    @Moshi
+    @Serializer(converter =  ConverterType.MOSHI)
     Call<com.vimeo.networking2.VideoList> getVideoListMoshi(@Header("Authorization") String authHeader,
                                                             @Url String uri,
                                                             @QueryMap Map<String, String> options,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -22,6 +22,7 @@
 
 package com.vimeo.networking;
 
+import com.vimeo.networking.AnnotatedConverterFactory.Moshi;
 import com.vimeo.networking.model.Category;
 import com.vimeo.networking.model.CategoryList;
 import com.vimeo.networking.model.Channel;
@@ -313,6 +314,13 @@ public interface VimeoService {
                                @Header("Cache-Control") String cacheHeaderValue);
 
     @GET
+    @Moshi
+    Call<com.vimeo.networking2.FeedList> getFeedListMoshi(@Header("Authorization") String authHeader,
+                                                          @Url String uri,
+                                                          @QueryMap Map<String, String> options,
+                                                          @Header("Cache-Control") String cacheHeaderValue);
+
+    @GET
     Call<NotificationList> getNotificationList(@Header("Authorization") String authHeader,
                                                @Url String uri,
                                                @QueryMap Map<String, String> options,
@@ -355,10 +363,24 @@ public interface VimeoService {
                                @Header("Cache-Control") String cacheHeaderValue);
 
     @GET
+    @Moshi
+    Call<com.vimeo.networking2.UserList> getUserListMoshi(@Header("Authorization") String authHeader,
+                                                          @Url String uri,
+                                                          @QueryMap Map<String, String> options,
+                                                          @Header("Cache-Control") String cacheHeaderValue);
+
+    @GET
     Call<VideoList> getVideoList(@Header("Authorization") String authHeader,
                                  @Url String uri,
                                  @QueryMap Map<String, String> options,
                                  @Header("Cache-Control") String cacheHeaderValue);
+
+    @GET
+    @Moshi
+    Call<com.vimeo.networking2.VideoList> getVideoListMoshi(@Header("Authorization") String authHeader,
+                                                            @Url String uri,
+                                                            @QueryMap Map<String, String> options,
+                                                            @Header("Cache-Control") String cacheHeaderValue);
 
 
     @GET

--- a/vimeo-networking/src/main/java/com/vimeo/networking/callers/MoshiGetRequestCaller.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/callers/MoshiGetRequestCaller.java
@@ -43,7 +43,7 @@ import retrofit2.Call;
  * This is a collection of classes that should be used for GET requests to
  * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
  * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
- *
+ * <p>
  * These classes are for specifically getting data using the new models.
  */
 public final class MoshiGetRequestCaller {
@@ -54,19 +54,16 @@ public final class MoshiGetRequestCaller {
      * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
      * to get a {@link FeedList} response from an API endpoint.
      */
-    public static final Caller<FeedList> FEED_LIST =
-            new Caller<FeedList>() {
+    public static final Caller<FeedList> FEED_LIST = new Caller<FeedList>() {
 
-                @NotNull
-                @Override
-                public Call<FeedList> call(@NotNull String authHeader,
-                                           @NotNull String uri,
-                                           @NotNull Map<String, String> queryMap,
-                                           @NotNull String cacheHeader,
-                                           @NotNull VimeoService vimeoService) {
-                    return vimeoService.getFeedListMoshi(authHeader, uri, queryMap, cacheHeader);
-                }
-            };
+        @NotNull
+        @Override
+        public Call<FeedList> call(@NotNull String authHeader, @NotNull String uri,
+                                   @NotNull Map<String, String> queryMap, @NotNull String cacheHeader,
+                                   @NotNull VimeoService vimeoService) {
+            return vimeoService.getFeedListMoshi(authHeader, uri, queryMap, cacheHeader);
+        }
+    };
 
     /**
      * Used in association with
@@ -74,19 +71,16 @@ public final class MoshiGetRequestCaller {
      * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
      * to get a {@link UserList} response from an API endpoint.
      */
-    public static final Caller<UserList> USER_LIST =
-            new Caller<UserList>() {
+    public static final Caller<UserList> USER_LIST = new Caller<UserList>() {
 
-                @NotNull
-                @Override
-                public Call<UserList> call(@NotNull String authHeader,
-                                           @NotNull String uri,
-                                           @NotNull Map<String, String> queryMap,
-                                           @NotNull String cacheHeader,
-                                           @NotNull VimeoService vimeoService) {
-                    return vimeoService.getUserListMoshi(authHeader, uri, queryMap, cacheHeader);
-                }
-            };
+        @NotNull
+        @Override
+        public Call<UserList> call(@NotNull String authHeader, @NotNull String uri,
+                                   @NotNull Map<String, String> queryMap, @NotNull String cacheHeader,
+                                   @NotNull VimeoService vimeoService) {
+            return vimeoService.getUserListMoshi(authHeader, uri, queryMap, cacheHeader);
+        }
+    };
 
     /**
      * Used in association with
@@ -100,14 +94,15 @@ public final class MoshiGetRequestCaller {
                 @NotNull
                 @Override
                 public Call<com.vimeo.networking2.VideoList> call(@NotNull String authHeader,
-                                            @NotNull String uri,
-                                            @NotNull Map<String, String> queryMap,
-                                            @NotNull String cacheHeader,
-                                            @NotNull VimeoService vimeoService) {
+                                                                  @NotNull String uri,
+                                                                  @NotNull Map<String, String> queryMap,
+                                                                  @NotNull String cacheHeader,
+                                                                  @NotNull VimeoService vimeoService) {
                     return vimeoService.getVideoListMoshi(authHeader, uri, queryMap, cacheHeader);
                 }
             };
 
-    private MoshiGetRequestCaller() {}
+    private MoshiGetRequestCaller() {
+    }
 
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/callers/MoshiGetRequestCaller.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/callers/MoshiGetRequestCaller.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.vimeo.networking.callers;
+
+import com.vimeo.networking.VimeoClient;
+import com.vimeo.networking.VimeoClient.Caller;
+import com.vimeo.networking.VimeoService;
+import com.vimeo.networking.callbacks.VimeoCallback;
+import com.vimeo.networking2.FeedList;
+import com.vimeo.networking2.UserList;
+import com.vimeo.networking2.VideoList;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+import okhttp3.CacheControl;
+import retrofit2.Call;
+
+/**
+ * This is a collection of classes that should be used for GET requests to
+ * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
+ * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
+ *
+ * These classes are for specifically getting data using the new models.
+ */
+public final class MoshiGetRequestCaller {
+
+    /**
+     * Used in association with
+     * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
+     * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
+     * to get a {@link FeedList} response from an API endpoint.
+     */
+    public static final Caller<FeedList> FEED_LIST =
+            new Caller<FeedList>() {
+
+                @NotNull
+                @Override
+                public Call<FeedList> call(@NotNull String authHeader,
+                                           @NotNull String uri,
+                                           @NotNull Map<String, String> queryMap,
+                                           @NotNull String cacheHeader,
+                                           @NotNull VimeoService vimeoService) {
+                    return vimeoService.getFeedListMoshi(authHeader, uri, queryMap, cacheHeader);
+                }
+            };
+
+    /**
+     * Used in association with
+     * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
+     * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
+     * to get a {@link UserList} response from an API endpoint.
+     */
+    public static final Caller<UserList> USER_LIST =
+            new Caller<UserList>() {
+
+                @NotNull
+                @Override
+                public Call<UserList> call(@NotNull String authHeader,
+                                           @NotNull String uri,
+                                           @NotNull Map<String, String> queryMap,
+                                           @NotNull String cacheHeader,
+                                           @NotNull VimeoService vimeoService) {
+                    return vimeoService.getUserListMoshi(authHeader, uri, queryMap, cacheHeader);
+                }
+            };
+
+    /**
+     * Used in association with
+     * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
+     * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
+     * to get a {@link VideoList} response from an API endpoint.
+     */
+    public static final Caller<com.vimeo.networking2.VideoList> VIDEO_LIST =
+            new Caller<com.vimeo.networking2.VideoList>() {
+
+                @NotNull
+                @Override
+                public Call<com.vimeo.networking2.VideoList> call(@NotNull String authHeader,
+                                            @NotNull String uri,
+                                            @NotNull Map<String, String> queryMap,
+                                            @NotNull String cacheHeader,
+                                            @NotNull VimeoService vimeoService) {
+                    return vimeoService.getVideoListMoshi(authHeader, uri, queryMap, cacheHeader);
+                }
+            };
+
+    private MoshiGetRequestCaller() {}
+
+}


### PR DESCRIPTION
## Summary

The purpose of this PR is to add support for the new models in the current implementation of `VimeoClient`.  Using the new models will require using Moshi for serialization and deserialization. The changes made to `VimeoClient` should be backward compatible. The client should be able to continue to use the old models. 

In order to achieve these requirements, these are the changes that were made:

1. [AdapterConverterFactory](https://github.com/vimeo/vimeo-networking-java/compare/v2.0.0...staff-picks-test?expand=1#diff-6ee966a68e85fa09ead8b7bf1389c920) was added to be able to use the Moshi or Gson converter with Retrofit. The converter that you wish to use should be specified as an annotation on `VimeoService`. Here is an example [Get users request using the new models](https://github.com/vimeo/vimeo-networking-java/compare/v2.0.0...staff-picks-test?expand=1#diff-ad54125240d6234452e1b230ba362e18R317). If you do not specify an annotation, the Gson converter will be used by default.

2. Caller classes were created for the new models. [Request Callers for New Models](https://github.com/vimeo/vimeo-networking-java/compare/v2.0.0...staff-picks-test?expand=1#diff-866fb795429064a803d34426b80b44e3R49). If a request needs to be made using the new models, use one of the callers in this class and specify the new models in the request.

Ex:

```
mApiClient.getContent(STAFF_PICKS_VIDEO_URI, 
                       CacheControl.FORCE_NETWORK, 
                       MoshiGetRequestCaller.VIDEO_LIST, null, null, null, 
                       new VimeoCallback<com.vimeo.networking2.VideoList>() {
            
                          @Override
                          public void success(com.vimeo.networking2.VideoList videoList) { ... }

                           @Override
                           public void failure(VimeoError error) { ... }

});
```

