### PR TITLE
[WIP] Extensions extraction for DTO enum fields

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/Album.kt
+++ b/models/src/main/java/com/vimeo/networking2/Album.kt
@@ -1,3 +1,5 @@
+@file:JvmName("AlbumUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/Album.kt
+++ b/models/src/main/java/com/vimeo/networking2/Album.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.AlbumLayoutType
 import com.vimeo.networking2.enums.AlbumThemeType
 import com.vimeo.networking2.enums.SortType
+import com.vimeo.networking2.enums.asEnum
 import java.util.*
 
 /**
@@ -60,7 +61,7 @@ data class Album(
      * The album's layout preference.
      */
     @Json(name = "layout")
-    val layout: AlbumLayoutType? = null,
+    val layout: String? = null,
 
     /**
      * The URL to access the album.
@@ -120,7 +121,7 @@ data class Album(
      * The album's color theme preference.
      */
     @Json(name = "theme")
-    val theme: AlbumThemeType? = null,
+    val theme: String? = null,
 
     /**
      * The album's URI.
@@ -139,3 +140,15 @@ data class Album(
     override val identifier: String? = resourceKey
 
 }
+
+/**
+ * @see Album.layout
+ */
+val Album.albumLayoutType: AlbumLayoutType
+    get() = layout?.asEnum() ?: AlbumLayoutType.UNKNOWN
+
+/**
+ * @see Album.theme
+ */
+val Album.themeType: AlbumThemeType
+    get() = theme?.asEnum() ?: AlbumThemeType.UNKNOWN

--- a/models/src/main/java/com/vimeo/networking2/AlbumPrivacy.kt
+++ b/models/src/main/java/com/vimeo/networking2/AlbumPrivacy.kt
@@ -3,6 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.AlbumPrivacyViewValue
+import com.vimeo.networking2.enums.asEnum
 
 /**
  * The privacy set for an album.
@@ -20,5 +21,11 @@ data class AlbumPrivacy(
      * Who can view the album.
      */
     @Json(name = "view")
-    val viewingPermissions: AlbumPrivacyViewValue? = null
+    val viewingPermissions: String? = null
 )
+
+/**
+ * @see AlbumPrivacy.viewingPermissions
+ */
+val AlbumPrivacy.viewingPermissionsType: AlbumPrivacyViewValue
+    get() = viewingPermissions?.asEnum() ?: AlbumPrivacyViewValue.UNKNOWN

--- a/models/src/main/java/com/vimeo/networking2/AlbumPrivacy.kt
+++ b/models/src/main/java/com/vimeo/networking2/AlbumPrivacy.kt
@@ -1,3 +1,5 @@
+@file:JvmName("AlbumPrivacyUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/BuyInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/BuyInteraction.kt
@@ -3,7 +3,6 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Interaction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.vimeo.networking2.enums.DownloadType
 import com.vimeo.networking2.enums.StreamType
 import java.util.*
@@ -63,7 +62,7 @@ data class BuyInteraction(
     val streamType: StreamType? = null,
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null

--- a/models/src/main/java/com/vimeo/networking2/ChannelFollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/ChannelFollowInteraction.kt
@@ -1,9 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.UpdatableInteraction
 import com.vimeo.networking2.enums.FollowType
 import java.util.*
 
@@ -20,7 +19,7 @@ data class ChannelFollowInteraction(
     override val addedTime: Date? = null,
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null,

--- a/models/src/main/java/com/vimeo/networking2/FollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/FollowInteraction.kt
@@ -1,7 +1,6 @@
 package com.vimeo.networking2
 
 import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import java.util.*
 
 /**
@@ -13,7 +12,7 @@ data class FollowInteraction(
 
     override val addedTime: Date? = null,
 
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     override val uri: String? = null
 

--- a/models/src/main/java/com/vimeo/networking2/GroupFollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/GroupFollowInteraction.kt
@@ -1,7 +1,6 @@
 package com.vimeo.networking2
 
 import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.vimeo.networking2.enums.FollowType
 import java.util.*
 
@@ -14,7 +13,7 @@ data class GroupFollowInteraction(
 
     override val addedTime: Date? = null,
 
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     override val uri: String? = null,
 

--- a/models/src/main/java/com/vimeo/networking2/LikeInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/LikeInteraction.kt
@@ -1,10 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-
+import com.vimeo.networking2.common.UpdatableInteraction
 import java.util.*
 
 /**
@@ -20,7 +18,7 @@ data class LikeInteraction(
     override val addedTime: Date? = null,
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null

--- a/models/src/main/java/com/vimeo/networking2/PurchaseInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/PurchaseInteraction.kt
@@ -1,9 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.Interaction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.Interaction
 import com.vimeo.networking2.enums.PurchaseStatusType
 
 /**
@@ -13,7 +12,7 @@ import com.vimeo.networking2.enums.PurchaseStatusType
 data class PurchaseInteraction(
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null,

--- a/models/src/main/java/com/vimeo/networking2/User.kt
+++ b/models/src/main/java/com/vimeo/networking2/User.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Followable
 import com.vimeo.networking2.enums.AccountType
 import com.vimeo.networking2.enums.ContentFilterType
+import com.vimeo.networking2.enums.asEnum
 import java.util.*
 
 /**
@@ -17,7 +18,7 @@ data class User(
      * The user's account type
      */
     @Json(name = "account")
-    val account: AccountType? = null,
+    val account: String? = null,
 
     /**
      * Information about the user's badge.
@@ -137,8 +138,15 @@ data class User(
     @Json(name = "websites")
     val websites: List<Website>? = null
 
-): Followable, Entity {
+) : Followable, Entity {
 
     override val identifier: String? = resourceKey
 
 }
+
+
+/**
+ * @see User.account
+ */
+val User.accountType: AccountType
+    get() = account?.asEnum() ?: AccountType.UNKNOWN

--- a/models/src/main/java/com/vimeo/networking2/User.kt
+++ b/models/src/main/java/com/vimeo/networking2/User.kt
@@ -1,3 +1,5 @@
+@file:JvmName("UserUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/WatchLaterInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/WatchLaterInteraction.kt
@@ -1,9 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.UpdatableInteraction
 import java.util.*
 
 /**
@@ -19,7 +18,7 @@ data class WatchLaterInteraction(
     override val addedTime: Date? = null,
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null

--- a/models/src/main/java/com/vimeo/networking2/WatchedInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/WatchedInteraction.kt
@@ -1,9 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.UpdatableInteraction
-import com.vimeo.networking2.enums.ApiOptionsType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.UpdatableInteraction
 import java.util.*
 
 /**
@@ -19,7 +18,7 @@ data class WatchedInteraction(
     override val addedTime: Date? = null,
 
     @Json(name = "options")
-    override val options: List<ApiOptionsType>? = null,
+    override val options: List<String>? = null,
 
     @Json(name = "uri")
     override val uri: String? = null

--- a/models/src/main/java/com/vimeo/networking2/common/Interaction.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Interaction.kt
@@ -1,3 +1,5 @@
+@file:JvmName("InteractionUtils")
+
 package com.vimeo.networking2.common
 
 import com.vimeo.networking2.enums.ApiOptionsType

--- a/models/src/main/java/com/vimeo/networking2/common/Interaction.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Interaction.kt
@@ -1,6 +1,7 @@
 package com.vimeo.networking2.common
 
 import com.vimeo.networking2.enums.ApiOptionsType
+import com.vimeo.networking2.enums.asEnum
 
 /**
  * Information on how to take action on an entity. Take an action on the
@@ -13,7 +14,7 @@ interface Interaction {
     /**
      * An array of the HTTP methods permitted on this URI.
      */
-    val options: List<ApiOptionsType>?
+    val options: List<String>?
 
     /**
      * The API URI that resolves to the connection data.
@@ -21,3 +22,9 @@ interface Interaction {
     val uri: String?
 
 }
+
+/**
+ * @see Interaction.options
+ */
+val Interaction.optionsTypes
+    get() = options?.map { it.asEnum() ?: ApiOptionsType.UNKNOWN }

--- a/models/src/main/java/com/vimeo/networking2/enums/AccountType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/AccountType.kt
@@ -1,69 +1,58 @@
 package com.vimeo.networking2.enums
 
-import com.squareup.moshi.Json
-
 /**
  * User account type.
  */
-enum class AccountType {
+enum class AccountType(override val value: String?) : StringValue {
 
     /**
      * The user has a Vimeo Basic subscription.
      */
-    @Json(name = "basic")
-    BASIC,
+    BASIC("basic"),
 
     /**
      * The user has a Vimeo Business subscription.
      */
-    @Json(name = "business")
-    BUSINESS,
+    BUSINESS("business"),
 
     /**
      * The user has a Live Business subscription.
      */
-    @Json(name = "live_business")
-    LIVE_BUSINESS,
+    LIVE_BUSINESS("live_business"),
 
     /**
      * The user has a Live Premium subscription.
      */
-    @Json(name = "live_premium")
-    LIVE_PREMIUM,
+    LIVE_PREMIUM("live_premium"),
 
     /**
      * The user has a Live PRO subscription
      */
-    @Json(name = "live_pro")
-    LIVE_PRO,
+    LIVE_PRO("live_pro"),
 
     /**
      * The user has a Vimeo Plus subscription.
      */
-    @Json(name = "plus")
-    PLUS,
+    PLUS("plus"),
 
     /**
      * The user has a Vimeo PRO subscription.
      */
-    @Json(name = "pro")
-    PRO,
+    PRO("pro"),
 
     /**
      * The user has a Vimeo PRO Unlimited subscription.
      */
-    @Json(name = "pro_unlimited")
-    PRO_UNLIMITED,
+    PRO_UNLIMITED("pro_unlimited"),
 
     /**
      * The user has a Vimeo Producer subscription.
      */
-    @Json(name = "producer")
-    PRODUCER,
+    PRODUCER("producer"),
 
     /**
      * Unknown account type.
      */
-    UNKNOWN
+    UNKNOWN(null)
 
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/AlbumLayoutType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/AlbumLayoutType.kt
@@ -1,26 +1,22 @@
 package com.vimeo.networking2.enums
 
-import com.squareup.moshi.Json
-
 /**
  * Different type of layouts an album could be shown in.
  */
-enum class AlbumLayoutType {
+enum class AlbumLayoutType(override val value: String?) : StringValue {
 
     /**
      * Grid layout.
      */
-    @Json(name = "grid")
-    GRID,
+    GRID("grid"),
 
     /**
      * Player layout.
      */
-    @Json(name = "player")
-    PLAYER,
+    PLAYER("player"),
 
     /**
      * Unknown layout.
      */
-    UNKNOWN
+    UNKNOWN(null)
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/AlbumPrivacyViewValue.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/AlbumPrivacyViewValue.kt
@@ -1,32 +1,27 @@
 package com.vimeo.networking2.enums
 
-import com.squareup.moshi.Json
-
 /**
  * Privacy settings for albums.
  */
-enum class AlbumPrivacyViewValue {
+enum class AlbumPrivacyViewValue(override val value: String?): StringValue {
 
     /**
      * Anyone can view the album.
      */
-    @Json(name = "anybody")
-    ANYBODY,
+    ANYBODY("anybody"),
 
     /**
      * Only owner can see album, can be embedded off-site.
      */
-    @Json(name = "embed_only")
-    EMBED_ONLY,
+    EMBED_ONLY("embed_only"),
 
     /**
      * Only those with the password can view the album.
      */
-    @Json(name = "password")
-    PASSWORD,
+    PASSWORD("password"),
 
     /**
      * Unknown privacy setting.
      */
-    UNKNOWN
+    UNKNOWN(null)
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/AlbumThemeType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/AlbumThemeType.kt
@@ -1,26 +1,22 @@
 package com.vimeo.networking2.enums
 
-import com.squareup.moshi.Json
-
 /**
  * Album themes.
  */
-enum class AlbumThemeType {
+enum class AlbumThemeType(override val value: String?) : StringValue {
 
     /**
      * Dark theme.
      */
-    @Json(name = "dark")
-    DARK,
+    DARK("dark"),
 
     /**
      * Standard theme.
      */
-    @Json(name = "standard")
-    STANDARD,
+    STANDARD("standard"),
 
     /**
      * Unknown theme.
      */
-    UNKNOWN
+    UNKNOWN(null)
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/ApiOptionsType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/ApiOptionsType.kt
@@ -3,10 +3,10 @@ package com.vimeo.networking2.enums
 /**
  * Type of request that can be made for a URI.
  */
-enum class ApiOptionsType {
-    GET,
-    POST,
-    PUT,
-    DELETE,
-    UNKNOWN
+enum class ApiOptionsType(override val value: String?) : StringValue {
+    GET("GET"),
+    POST("POST"),
+    PUT("PUT"),
+    DELETE("DELETE"),
+    UNKNOWN(null)
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/EnumExtensions.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/EnumExtensions.kt
@@ -1,0 +1,21 @@
+package com.vimeo.networking2.enums
+
+/**
+ * Converts the [String] to its enum counterpart [T] reflectively.
+ */
+inline fun <reified T> String.asEnum(): T? where T : Enum<T>, T : StringValue =
+    T::class.java.enumConstants
+        .filterIsInstance<T>()
+        .find { it.value == this }
+
+/**
+ * A class that has a string value.
+ */
+interface StringValue {
+
+    /**
+     * The value held by this class, may be null.
+     */
+    val value: String?
+
+}


### PR DESCRIPTION
# Summary
The nature of our API is such that enum values may be added that are publicly available and are also backwards compatible. An example is if a new account type is created, that account type must be accessible to old consumers of the API. As such, we cannot guarantee that the list of enums shipped with any specific version of the library will be comprehensive, and so we must make a fallback available.

## Implementation
I created an inline extension function on `String` that can convert the value to an `enum`. The enum must also implement a `StringValue` interface. Using this `asEnum` function, extensions can be created on a DTO that allow an enum value to be extracted from a `String` property on the DTO. It does this by grabbing all the enum values from the enum and checking the `StringValue.value` property that each enum is required to provide against the `String` provided. So for instance, on the `User` class, an extension property was created called `accountType: AccountType` and it converts the `account` property to its enum representation or defaults to `AccountType.UNKNOWN` if the type is unknown. This extension function can be consumed from Java or Kotlin:

```java
final User user = ...
final AccountType accountType = UserExtensions.getAccountType(user);
```

```kotlin
val user = ...
val accountType = user.accountType
```

As this is a WIP, here are the enums I converted so far are:
- AccountType
- AlbumLayoutType
- AlbumPrivacyViewValue
- AlbumThemeType
- ApiOptionsType