### PR TITLE
Adding password as play status

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/playback/Play.java
@@ -61,7 +61,10 @@ public class Play implements Serializable {
         PURCHASE_REQUIRED("purchase_required"),
         // your region can not play or purchase this
         @SerializedName("restricted")
-        RESTRICTED("restricted");
+        RESTRICTED("restricted"),
+        // will require a re-request for the video, supply the password in the request
+        @SerializedName("password")
+        PASSWORD("password");
 
         @NotNull
         private final String string;


### PR DESCRIPTION
#### Issue

#### Summary
It's a security concern that password protected videos can show up in lists and be fully playable. So now if the play files aren't available because it's password protected, it'll have a new status. This will not be behind a version and will get rolled out at some point in the future. Since it's additive, it shouldn't break any cache/existing logic.

#### How to Test
Hit `api-video-play-status-password-api` as the base url and make a request for a likes list that has a password protected video in it (see my Android branch for a real example).
