### PR TITLE
Fix app id field name in live chat configuration

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/LiveChatConfiguration.kt
+++ b/models/src/main/java/com/vimeo/networking2/LiveChatConfiguration.kt
@@ -22,7 +22,7 @@ data class LiveChatConfiguration(
      * The live chat Firebase app ID.
      */
     @Internal
-    @Json(name = "api_id")
+    @Json(name = "app_id")
     val appId: String? = null,
 
     /**


### PR DESCRIPTION
Change api_id -> app_id in `LiveChatConfiguraiton` DTO.