### PR TITLE
File share DTO

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/FileTransferPage.kt
+++ b/models/src/main/java/com/vimeo/networking2/FileTransferPage.kt
@@ -1,0 +1,20 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.annotations.Internal
+
+/**
+ * Information about the file transfer page.
+ */
+@Internal
+@JsonClass(generateAdapter = true)
+data class FileTransferPage(
+
+    /**
+     * The link to the file transfer page.
+     */
+    @Internal
+    @Json(name = "link")
+    val link: String? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -168,6 +168,14 @@ data class Video(
     val reviewPage: ReviewPage? = null,
 
     /**
+     * Information about the file transfer page associated with this video. This data
+     * requires a bearer token with the private scope.
+     */
+    @Internal
+    @Json(name = "file_transfer")
+    val fileTransferPage: FileTransferPage? = null,
+
+    /**
      * 360 spatial data.
      */
     @Json(name = "spatial")

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/FileTransferPage.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/FileTransferPage.java
@@ -1,0 +1,51 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A model representing info about the file transfer page.
+ */
+@SuppressWarnings("unused")
+@UseStag
+public class FileTransferPage implements Serializable {
+
+    private static final long serialVersionUID = 4370717113633153800L;
+
+    @Nullable
+    @SerializedName("link")
+    private String mLink;
+
+    @Nullable
+    public String getLink() {
+        return mLink;
+    }
+
+    public void setLink(@Nullable String link) {
+        mLink = link;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || !getClass().equals(o.getClass())) { return false; }
+        final FileTransferPage that = (FileTransferPage) o;
+        return mLink == null || mLink.equals(that.mLink);
+    }
+
+    @Override
+    public int hashCode() {
+        return mLink != null ? mLink.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "FileTransferPage{" +
+               "mLink='" + mLink + '\'' +
+               '}';
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Video.java
@@ -211,6 +211,10 @@ public class Video implements Serializable, Entity {
     private ReviewPage mReviewPage;
 
     @Nullable
+    @SerializedName("file_transfer")
+    private FileTransferPage mFileTransferPage;
+
+    @Nullable
     @SerializedName("play")
     public Play mPlay;
 
@@ -341,12 +345,21 @@ public class Video implements Serializable, Entity {
         return mUpload;
     }
 
+    @Nullable
+    public FileTransferPage getFileTransferPage() {
+        return mFileTransferPage;
+    }
+
     // </editor-fold>
 
     // -----------------------------------------------------------------------------------------------------
     // Setters
     // -----------------------------------------------------------------------------------------------------
     // <editor-fold desc="Setters">
+
+    public void setFileTransferPage(@Nullable FileTransferPage fileTransferPage) {
+        mFileTransferPage = fileTransferPage;
+    }
 
     public void setDescription(String description) {
         mDescription = description;

--- a/vimeo-networking/src/test/java/com/vimeo/networking/model/FileTransferPageTest.java
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/model/FileTransferPageTest.java
@@ -1,0 +1,17 @@
+package com.vimeo.networking.model;
+
+import com.vimeo.networking.Utils;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link FileTransferPage}.
+ */
+public class FileTransferPageTest {
+
+    @Test
+    public void verifyTypeAdapterWasGenerated() throws Exception {
+        Utils.verifyTypeAdapterGeneration(FileTransferPage.class);
+    }
+
+}


### PR DESCRIPTION
# Summary
We need to add internal support for the file transfer page. The link to the transfer page is held by the transfer page object. The API adds the information to the video as `file_transfer.link`, so I have created the appropriate `FileTransferPage` DTO which mimics the way the `ReviewPage` DTO works.

I created a legacy DTO in Java in `vimeo-networking` and a new DTO in Kotlin in `models`.