### PR TITLE
Update Facebook token field name

### DIFF
--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -40,14 +40,32 @@ internal class AuthenticatorImpl(
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, AuthParam.FIELD_ID_TOKEN, "Google authentication error.", authCallback)
+    ): VimeoRequest {
+        return socialAuthenticate(
+            token,
+            email,
+            marketingOptIn,
+            AuthParam.FIELD_ID_TOKEN,
+            "Google authentication error.",
+            authCallback
+        )
+    }
 
     override fun facebook(
         token: String,
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, AuthParam.FIELD_TOKEN, "Facebook authentication error.", authCallback)
+    ): VimeoRequest {
+        return socialAuthenticate(
+            token,
+            email,
+            marketingOptIn,
+            AuthParam.FIELD_TOKEN,
+            "Facebook authentication error.",
+            authCallback
+        )
+    }
 
     /**
      * Performs a Google or Facebook auth request. It will first validate the auth params given the

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -40,14 +40,14 @@ internal class AuthenticatorImpl(
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, "Google authentication error.", authCallback)
+    ) = socialAuthenticate(token, email, marketingOptIn, SocialAuthType.GOOGLE, authCallback)
 
     override fun facebook(
         token: String,
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, "Facebook authentication error.", authCallback)
+    ) = socialAuthenticate(token, email, marketingOptIn, SocialAuthType.FACEBOOK, authCallback)
 
     /**
      * Performs a Google or Facebook auth request. It will first validate the auth params given the
@@ -58,12 +58,22 @@ internal class AuthenticatorImpl(
         token: String,
         email: String,
         marketingOptIn: Boolean,
-        authenticationErrorMessage: String,
+        socialAuthType: SocialAuthType,
         authCallback: AuthCallback
     ): VimeoRequest {
 
+        val tokenField = when(socialAuthType) {
+            SocialAuthType.GOOGLE -> AuthParam.FIELD_ID_TOKEN
+            else -> AuthParam.FIELD_TOKEN
+        }
+
+        val errorMessage = when(socialAuthType) {
+            SocialAuthType.GOOGLE -> "Google authentication error."
+            else -> "Facebook authentication error."
+        }
+
         val params = mapOf(
-            AuthParam.FIELD_TOKEN to token,
+            tokenField to token,
             AuthParam.FIELD_EMAIL to email,
             AuthParam.FIELD_MARKETING_OPT_IN to marketingOptIn.toString()
         )
@@ -73,7 +83,7 @@ internal class AuthenticatorImpl(
 
         return if (invalidAuthParams.isNotEmpty()) {
             val apiError = ApiError(
-                authenticationErrorMessage,
+                errorMessage,
                 invalidParameters = invalidAuthParams
             )
             call.enqueueAuthError(apiError, authCallback)
@@ -139,5 +149,14 @@ internal class AuthenticatorImpl(
             call.enqueueAuthRequest(authCallback)
         }
     }
+
+    /**
+     * Google or Facebook authentication.
+     */
+    private enum class SocialAuthType {
+        FACEBOOK,
+        GOOGLE
+    }
+
 
 }

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -40,14 +40,14 @@ internal class AuthenticatorImpl(
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, SocialAuthType.GOOGLE, authCallback)
+    ) = socialAuthenticate(token, email, marketingOptIn, AuthParam.FIELD_ID_TOKEN, "Google authentication error.", authCallback)
 
     override fun facebook(
         token: String,
         email: String,
         marketingOptIn: Boolean,
         authCallback: AuthCallback
-    ) = socialAuthenticate(token, email, marketingOptIn, SocialAuthType.FACEBOOK, authCallback)
+    ) = socialAuthenticate(token, email, marketingOptIn, AuthParam.FIELD_TOKEN, "Facebook authentication error.", authCallback)
 
     /**
      * Performs a Google or Facebook auth request. It will first validate the auth params given the
@@ -58,19 +58,10 @@ internal class AuthenticatorImpl(
         token: String,
         email: String,
         marketingOptIn: Boolean,
-        socialAuthType: SocialAuthType,
+        tokenField: AuthParam,
+        errorMessage: String,
         authCallback: AuthCallback
     ): VimeoRequest {
-
-        val tokenField = when(socialAuthType) {
-            SocialAuthType.GOOGLE -> AuthParam.FIELD_ID_TOKEN
-            else -> AuthParam.FIELD_TOKEN
-        }
-
-        val errorMessage = when(socialAuthType) {
-            SocialAuthType.GOOGLE -> "Google authentication error."
-            else -> "Facebook authentication error."
-        }
 
         val params = mapOf(
             tokenField to token,
@@ -149,14 +140,5 @@ internal class AuthenticatorImpl(
             call.enqueueAuthRequest(authCallback)
         }
     }
-
-    /**
-     * Google or Facebook authentication.
-     */
-    private enum class SocialAuthType {
-        FACEBOOK,
-        GOOGLE
-    }
-
 
 }

--- a/models/src/main/java/com/vimeo/networking2/internal/AuthParam.kt
+++ b/models/src/main/java/com/vimeo/networking2/internal/AuthParam.kt
@@ -28,7 +28,10 @@ enum class AuthParam(
     FIELD_PASSWORD(ErrorCodeType.INVALID_INPUT_NO_PASSWORD, "An empty password was provided."),
 
     @Json(name = "id_token")
-    FIELD_TOKEN(ErrorCodeType.UNABLE_TO_LOGIN_NO_TOKEN, "An empty access token was provided."),
+    FIELD_ID_TOKEN(ErrorCodeType.INVALID_TOKEN, "An empty id token provided"),
+
+    @Json(name = "token")
+    FIELD_TOKEN(ErrorCodeType.INVALID_TOKEN, "An empty access token was provided."),
 
     @Json(name = "grant_type")
     FIELD_GRANT_TYPE(ErrorCodeType.INVALID_INPUT_GRANT_TYPE, "Grant type not provided."),


### PR DESCRIPTION
Facebook authentication requires the Facebook token name to be `token` whereas the token name for Google should be `id_token`. I created an enum `SocialAuthType` to determine which token param field name to use in the `socialAuthenticate` method.