### PR TITLE
Converting compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ git submodule add git@github.com:vimeo/vimeo-networking-java.git
 ```
 Then in your `build.gradle` use:
 ```groovy
-compile project(':vimeo-networking-java:vimeo-networking')
+implementation project(':vimeo-networking-java:vimeo-networking')
 ```
 
 ### Initialization

--- a/example-java-android/build.gradle
+++ b/example-java-android/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    compile project(':vimeo-networking')
+    implementation project(':vimeo-networking')
 }

--- a/example-vimeo-networking2-android/build.gradle
+++ b/example-vimeo-networking2-android/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
     implementation 'com.squareup.moshi:moshi-adapters:1.7.0'
 
-    compile 'com.squareup.okhttp3:logging-interceptor:3.9.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
 
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
 }

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -32,22 +32,21 @@ repositories {
 tasks.withType(Javadoc).all { enabled = true }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    testCompile "org.assertj:assertj-core:3.11.1"
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':models')
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.assertj:assertj-core:3.11.1"
+    implementation project(':models')
 
     def retrofitVersion = '2.5.0'
-    compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
-    compile "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    compile "com.squareup.moshi:moshi-adapters:1.7.0"
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
+    implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
-    compile 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
 
     def stagVersion = '2.5.1'
-    compile ("com.vimeo.stag:stag-library:$stagVersion"){
+    implementation ("com.vimeo.stag:stag-library:$stagVersion"){
         exclude group: 'com.intellij', module: 'annotations'
     }
     apt "com.vimeo.stag:stag-library-compiler:$stagVersion"


### PR DESCRIPTION
# Summary
I thought maybe that changing to `implementation` from `compile` would fix a dexing bug we were experiencing client side, but it turned out not to. Regardless, I decided that we could still change all the usage of `compile` to be consistent throughout the library.

I also removed the `compile` entry that added jars, since we had no jars we were explicitly adding from resources.