### PR TITLE
Implement certificate ssl pinning 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
-apply plugin: 'kotlin-kapt'
 apply from: '../publish.gradle'
 
 repositories {
@@ -8,14 +7,16 @@ repositories {
 }
 
 dependencies {
-    implementation project(':models')
+    api project(":models")
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+    api "com.squareup.retrofit2:retrofit:2.5.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.5.0"
-    implementation 'com.squareup.moshi:moshi-adapters:1.7.0'
+
+    // Moshi Adapters
+    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
 
 }

--- a/api/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -9,6 +9,10 @@ object ApiConstants {
 
     const val BASE_URL = "https://api.vimeo.com"
 
+    const val SSL_URL_PATTERN = "*.vimeo.com"
+
+    const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
+
     const val READ_CONNECTION_TIMEOUT_SECONDS = 60L
 
     const val SDK_VERSION = "2.0.0"

--- a/api/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -2,9 +2,11 @@ package com.vimeo.networking2.config
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.vimeo.networking2.ApiConstants
 import com.vimeo.networking2.ApiConstants.API_VERSION
 import com.vimeo.networking2.ApiConstants.SDK_VERSION
 import com.vimeo.networking2.internal.ErrorHandlingCallAdapterFactory
+import okhttp3.CertificatePinner
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -114,8 +116,17 @@ object RetrofitSetupModule {
             if (!customInterceptors.isNullOrEmpty()) {
                 interceptors().addAll(customInterceptors)
             }
-
+            if (serverConfig.certPinningEnabled) {
+                certificatePinner(createCertificatePinner())
+            }
         }.build()
+
+    /**
+     * Create certificate pinner to configure OkHttpClient.
+     */
+    private fun createCertificatePinner() = CertificatePinner.Builder()
+        .add(ApiConstants.SSL_URL_PATTERN, ApiConstants.SSL_PUBLIC_KEY)
+        .build()
 
     /**
      * Create [Retrofit] with OkHttpClient and Moshi.

--- a/api/src/main/java/com/vimeo/networking2/config/ServerConfig.kt
+++ b/api/src/main/java/com/vimeo/networking2/config/ServerConfig.kt
@@ -11,18 +11,18 @@ import okhttp3.Interceptor
  * @param clientSecret                Your client secret for authentication provided from https://developer.vimeo.com/apps/.
  * @param baseUrl                     The base url for all requests to the Vimeo API. This is can be overridden to test against a staging server.
  * @param scopes                      A list of your scopes. See https://developer.vimeo.com/api/authentication#scopes.
- * @param certPinningEnabled          Enable certificate pining. It is disabled by default.
+ * @param certPinningEnabled          Enable certificate pining. It is enabled by default. If you are using Kitkat, then you will have to disable certificate pinning.
  * @param timeoutSeconds              Read and connection timeout for a request. The default time is 60 seconds.
  * @param networkInterceptors         Network interceptors to add for requests.
  * @param customInterceptors          Custom network interceptors to add for requests.
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-class ServerConfig @JvmOverloads constructor(
+data class ServerConfig @JvmOverloads constructor(
     val clientId: String,
     val clientSecret: String,
     val baseUrl: String = ApiConstants.BASE_URL,
     val scopes: List<ScopeType> = listOf(ScopeType.PUBLIC),
-    val certPinningEnabled: Boolean = false,
+    val certPinningEnabled: Boolean = true,
     val timeoutSeconds: Long = ApiConstants.READ_CONNECTION_TIMEOUT_SECONDS,
     val networkInterceptors: List<Interceptor>? = null,
     val customInterceptors: List<Interceptor>? = null

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
-apply plugin: 'kotlin-kapt'
 apply from: '../publish.gradle'
 
 repositories {
@@ -8,13 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation project(':models')
-    implementation project(':api')
+    api project(':api')
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
-    // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@
 
 buildscript {
     ext.supportLibraryVersion = '28.0.0'
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/example-java-android/build.gradle
+++ b/example-java-android/build.gradle
@@ -19,9 +19,8 @@ android {
 }
 
 dependencies {
+    implementation project(':vimeo-networking')
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
-
-    implementation project(':vimeo-networking')
 }

--- a/example-kotlin-android/build.gradle
+++ b/example-kotlin-android/build.gradle
@@ -28,13 +28,12 @@ android {
 }
 
 dependencies {
+    implementation project(':vimeo-networking')
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
 
-    implementation project(':vimeo-networking')
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
 }

--- a/example-vimeo-networking2-android/build.gradle
+++ b/example-vimeo-networking2-android/build.gradle
@@ -24,20 +24,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':models')
     implementation project(':auth')
-    implementation project(':api')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.4.0'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
-    implementation 'com.squareup.moshi:moshi-adapters:1.7.0'
-
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
-
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,7 +88,7 @@ platform :android do
     # run the tests, but dont puke everywhere until the report is printed.
     begin
       gradle(
-        task: "vimeo-networking:test example-java-android:build example-kotlin-android:build models:build api:build auth:build"
+        task: "vimeo-networking:test example-java-android:build example-kotlin-android:build models:test api:test auth:test"
       )
     rescue => error
       begin

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,7 +88,7 @@ platform :android do
     # run the tests, but dont puke everywhere until the report is printed.
     begin
       gradle(
-        task: "vimeo-networking:test example-java-android:build example-kotlin-android:build models:build"
+        task: "vimeo-networking:test example-java-android:build example-kotlin-android:build models:build api:build auth:build"
       )
     rescue => error
       begin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply from: '../publish.gradle'
@@ -13,10 +13,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Moshi
-    kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.7.0'
-    implementation 'com.squareup.moshi:moshi:1.7.0'
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
+    implementation "com.squareup.moshi:moshi:1.8.0"
 
-    testImplementation 'junit:junit:4.12'
+    // Test dependencies
+    testImplementation "junit:junit:4.12"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
 }

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 compileJava {
@@ -32,24 +32,26 @@ repositories {
 tasks.withType(Javadoc).all { enabled = true }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    testImplementation "org.assertj:assertj-core:3.11.1"
-    implementation project(':models')
+    api project(':models')
 
     def retrofitVersion = '2.5.0'
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    api "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    api "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
+
+    implementation 'org.jetbrains:annotations:17.0.0'
 
     def stagVersion = '2.5.1'
     implementation ("com.vimeo.stag:stag-library:$stagVersion"){
         exclude group: 'com.intellij', module: 'annotations'
     }
     apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.assertj:assertj-core:3.11.1"
 }
 
 buildConfig {


### PR DESCRIPTION
#### Summary

This PR implements certificate pinning for the new networking library. OkHttp 3 provides a way to specify a public key for a url pattern when setting up OkHttpClient. `RetrofitSetupModule` now has a method to do this. The `ServerConfig` object has a flag which is set to true by default to determine whether to setup SSL pinning or not. This is flag is checked in the module when setting up certificate pinning. 

This PR also fixes the issue that implementation and api were not being recognized by api, auth, models and vimeo-networking modules. This is because they were using the java gradle plugin. The java-library plugin does know about how to handle implementation vs api. They were updated in the specific gradle files.


 