### PR TITLE
Fix Gson Deserializer Null Crash

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Configuration.java
@@ -26,6 +26,7 @@ import com.vimeo.networking.Vimeo.LogLevel;
 import com.vimeo.networking.logging.LogProvider;
 import com.vimeo.networking.model.VimeoAccount;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -188,7 +189,7 @@ public class Configuration {
         private String accessToken;
 
         private AccountStore accountStore;
-        private GsonDeserializer deserializer = new GsonDeserializer();
+        private GsonDeserializer deserializer;
 
         private String apiVersionString = DEFAULT_VERSION_STRING;
         private File cacheDirectory;
@@ -258,7 +259,7 @@ public class Configuration {
             this.clientSecret = clientSecret;
             this.scope = scope;
             this.accountStore = accountStore;
-            this.deserializer = deserializer;
+            this.deserializer = (deserializer == null) ? new GsonDeserializer() : deserializer;
         }
 
         public Builder setBaseUrl(String baseUrl) {
@@ -278,7 +279,7 @@ public class Configuration {
             return this;
         }
 
-        public Builder setGsonDeserializer(GsonDeserializer deserializer) {
+        public Builder setGsonDeserializer(@NotNull GsonDeserializer deserializer) {
             this.deserializer = deserializer;
             return this;
         }


### PR DESCRIPTION
#### Summary

The builders below are setting the deserialization field to null.  Even though the deserialization field was set to default value, it was being overridden to null by the constructors. This problem was brought up in the  issue https://github.com/vimeo/vimeo-networking-java/issues/385.

```
 public Builder(String clientID, String clientSecret, String scope) {
            this(null, clientID, clientSecret, scope, null, null);
        }

        @Deprecated
        public Builder(String baseURLString, String clientID, String clientSecret, String scope) {
            this(baseURLString, clientID, clientSecret, scope, null, null);
        }

        public Builder(String clientId, String clientSecret, String scope,
                       @Nullable AccountStore accountStore, @Nullable GsonDeserializer deserializer) {
            this(null, clientId, clientSecret, scope, accountStore, deserializer);
        }
```

To resolve this issue, I added a null check in the constructor and initialize it when a non null deserializer is given. Otherwise, I set a default value for it in the constructor.


#### How to Test

Configure VimeoClient with a client id and client secret and verify the following request succeeds and parses:

```
 VimeoClient.getInstance().fetchNetworkContent("/videos/"+id, object : ModelCallback<Video>(Video::class.java) {

            override fun success(video: Video) {
                println("video = [${video}]")
            }

            override fun failure(error: VimeoError) {
                println("error = [${error}]")
            }

        })
```
