### PR TITLE
Downgrade Moshi

### DIFF
--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -19,7 +19,4 @@ dependencies {
     // Moshi Adapters
     implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
-    // Okio used by Moshi
-    implementation "com.squareup.okio:okio:2.2.2"
-
 }

--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -19,4 +19,7 @@ dependencies {
     // Moshi Adapters
     implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
+    // Okio used by Moshi
+    implementation "com.squareup.okio:okio:2.2.2"
+
 }

--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-moshi:2.5.0"
 
     // Moshi Adapters
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
 }

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -12,9 +12,6 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    // Okio used by Moshi
-    implementation "com.squareup.okio:okio:2.2.2"
-
     // Moshi
     kapt "com.squareup.moshi:moshi-kotlin-codegen:1.7.0"
     implementation "com.squareup.moshi:moshi:1.7.0"

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:1.7.0"
     implementation "com.squareup.moshi:moshi:1.7.0"
 
+    // Okio used by Moshi
+    implementation "com.squareup.okio:okio:2.2.2"
+
     // Test dependencies
     testImplementation "junit:junit:4.12"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Moshi
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.8.0"
-    implementation "com.squareup.moshi:moshi:1.8.0"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.7.0"
+    implementation "com.squareup.moshi:moshi:1.7.0"
 
     // Test dependencies
     testImplementation "junit:junit:4.12"

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
-    implementation "com.squareup.moshi:moshi-adapters:1.8.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
     implementation 'org.jetbrains:annotations:17.0.0'
 

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -39,7 +39,11 @@ dependencies {
     api "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
+    // Moshi
     implementation "com.squareup.moshi:moshi-adapters:1.7.0"
+
+    // Okio used by Moshi
+    implementation "com.squareup.okio:okio:2.2.2"
 
     implementation 'org.jetbrains:annotations:17.0.0'
 

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -42,9 +42,6 @@ dependencies {
     // Moshi
     implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 
-    // Okio used by Moshi
-    implementation "com.squareup.okio:okio:2.2.2"
-
     implementation 'org.jetbrains:annotations:17.0.0'
 
     def stagVersion = '2.5.1'

--- a/vimeo-networking/build.gradle
+++ b/vimeo-networking/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     api "com.squareup.retrofit2:retrofit:$retrofitVersion"
     api "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    
-    implementation "com.squareup.okio:okio:2.2.2"
 
     implementation "com.squareup.moshi:moshi-adapters:1.7.0"
 


### PR DESCRIPTION
Version 1.8.0 of Moshi is causing proguard to run indefinitely. This PR downgrades the version to 1.7.0. This change was tested in the app.