### PR TITLE
VA-3896 showcase edit support

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/AlbumConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/AlbumConnections.kt
@@ -9,10 +9,16 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class AlbumConnections(
 
-    /**
-     * Connection to get all the videos in a album.
-     */
-    @Json(name = "videos")
-    val videos: Connection? = null
+        /**
+         * Connection to get all the videos in a album.
+         */
+        @Json(name = "videos")
+        val videos: Connection? = null,
+
+        /**
+         * Connection to get all the logged-in user's available videos that can be added to an album.
+         */
+        @Json(name = "available_videos")
+        val availableVideos: Connection? = null
 
 )

--- a/models/src/main/java/com/vimeo/networking2/AlbumInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/AlbumInteractions.kt
@@ -9,18 +9,29 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class AlbumInteractions(
 
-    /**
-     * An action indicating that the authenticated user is an admin of the album and may therefore
-     * add custom logos. This data requires a bearer token with the private scope.
-     */
-    @Json(name = "add_logos")
-    val addLogos: BasicInteraction? = null,
+        /**
+         * An action indicating that the authenticated user is an admin of the album and may therefore
+         * add custom logos. This data requires a bearer token with the private scope.
+         */
+        @Json(name = "add_logos")
+        val addLogos: BasicInteraction? = null,
 
-    /**
-     * An action indicating that the authenticated user is an admin of the album and may therefore
-     * add videos. This data requires a bearer token with the private scope.
-     */
-    @Json(name = "add_videos")
-    val addVideos: BasicInteraction? = null
+        /**
+         * An action indicating that the authenticated user is an admin of the album and may therefore
+         * add videos. This data requires a bearer token with the private scope.
+         */
+        @Json(name = "add_videos")
+        val addVideos: BasicInteraction? = null,
+
+        /**
+         * An interaction that will be present in [Album] objects returned from a request to an "available_albums"
+         * connection on a video object (/videos/{video_id}/available_albums). The [BasicInteraction.uri] will provide the
+         * endpoint needed to complete a subsequent add/remove action to add/remove the related video to/from the album. In the
+         * event that the video is not yet added to the album, [BasicInteraction.options] will contain "PUT". In the
+         * event that the video is already added to the album, [BasicInteraction.options] will contain "DELETE".
+         * This data requires a bearer token with the private scope.
+         */
+        @Json(name = "add_to")
+        val addTo: BasicInteraction? = null
 
 )

--- a/models/src/main/java/com/vimeo/networking2/ChannelInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/ChannelInteractions.kt
@@ -1,8 +1,8 @@
 package com.vimeo.networking2
 
-import com.vimeo.networking2.common.FollowableInteractions
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.FollowableInteractions
 
 /**
  * All action that can be taken on a channel.
@@ -10,35 +10,38 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ChannelInteractions(
 
-    /**
-     * An action indicating that the authenticated user is the owner of the channel and may
-     * therefore add other users as channel moderators. This data requires a bearer token with
-     * the private scope.
-     */
-    @Json(name = "add_moderators")
-    val addModerators: BasicInteraction? = null,
+        /**
+         * An action indicating that the authenticated user is the owner of the channel and may
+         * therefore add other users as channel moderators. This data requires a bearer token with
+         * the private scope.
+         */
+        @Json(name = "add_moderators")
+        val addModerators: BasicInteraction? = null,
 
-    /**
-     * When a channel appears in the context of adding or removing a video from it
-     * (/videos/{video_id}/available_channels), include information about adding or removing
-     * the video. This data requires a bearer token with the private scope.
-     */
-    @Json(name = "add_to")
-    val addTo: BasicInteraction? = null,
+        /**
+         * An interaction that will be present in [Channel] objects returned from a request to an "available_channels"
+         * connection on a video object (/videos/{video_id}/available_channels). The [BasicInteraction.uri] will provide the
+         * endpoint needed to complete a subsequent add/remove action to add/remove the related video to/from the channel. In the
+         * event that the video is not yet added to the channel, [BasicInteraction.options] will contain "PUT". In the
+         * event that the video is already added to the channel, [BasicInteraction.options] will contain "DELETE".
+         * This data requires a bearer token with the private scope.
+         */
+        @Json(name = "add_to")
+        val addTo: BasicInteraction? = null,
 
-    /**
-     * An action indicating if the authenticated user has followed this channel.
-     * This data requires a bearer token with the private scope.
-     */
-    @Json(name = "follow")
-    override val follow: ChannelFollowInteraction? = null,
+        /**
+         * An action indicating if the authenticated user has followed this channel.
+         * This data requires a bearer token with the private scope.
+         */
+        @Json(name = "follow")
+        override val follow: ChannelFollowInteraction? = null,
 
-    /**
-     * An action indicating that the authenticated user is a moderator of the channel and may
-     * therefore add or remove videos from the channel. This data requires a bearer token with
-     * the private scope.
-     */
-    @Json(name = "moderate_videos")
-    val moderateVideos: BasicInteraction? = null
+        /**
+         * An action indicating that the authenticated user is a moderator of the channel and may
+         * therefore add or remove videos from the channel. This data requires a bearer token with
+         * the private scope.
+         */
+        @Json(name = "moderate_videos")
+        val moderateVideos: BasicInteraction? = null
 
-): FollowableInteractions
+) : FollowableInteractions

--- a/models/src/main/java/com/vimeo/networking2/VideoConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoConnections.kt
@@ -81,6 +81,18 @@ data class VideoConnections(
      * Information about the user privacy of this video, if the video privacy is users.
      */
     @Json(name = "users_with_access")
-    val usersWithAccess: Connection? = null
+    val usersWithAccess: Connection? = null,
+
+    /**
+     * Connection to get all the logged-in user's available albums that this video can be added to.
+     */
+    @Json(name = "available_albums")
+    val availableAlbums: Connection? = null,
+
+    /**
+     * Connection to get all the logged-in user's available channels that this video can be added to.
+     */
+    @Json(name = "available_channels")
+    val availableChannels: Connection? = null
 
 )

--- a/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
@@ -169,7 +169,7 @@ enum class ErrorCodeType(override val value: String?) : StringValue {
     ALBUM_EDIT_FORBIDDEN_FOR_AUTHENTICATED_USER("3429"),
 
     ADD_VIDEO_TO_ALBUM_FORBIDDEN("3433"),
-    
+
     UNEXPECTED_ALBUM_THUMBNAIL_EXCEPTION("4016"),
 
     // Generic Auth Errors

--- a/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
@@ -163,6 +163,15 @@ enum class ErrorCodeType(override val value: String?) : StringValue {
 
     UNABLE_TO_CREATE_USER_GOOGLE_COULD_NOT_VERIFY_TOKEN("2337"),
 
+    // Albums
+    ALBUM_THUMBNAIL_ACCESS_FORBIDDEN("3200"),
+
+    ALBUM_EDIT_FORBIDDEN_FOR_AUTHENTICATED_USER("3429"),
+
+    ADD_VIDEO_TO_ALBUM_FORBIDDEN("3433"),
+    
+    UNEXPECTED_ALBUM_THUMBNAIL_EXCEPTION("4016"),
+
     // Generic Auth Errors
     USER_EXISTS("2400"),
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -33,6 +33,7 @@ import com.vimeo.networking.model.Album;
 import com.vimeo.networking.model.AlbumPrivacy;
 import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.Document;
+import com.vimeo.networking.model.ModifyVideosInAlbum;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
@@ -40,6 +41,7 @@ import com.vimeo.networking.model.Privacy;
 import com.vimeo.networking.model.TextTrackList;
 import com.vimeo.networking.model.User;
 import com.vimeo.networking.model.Video;
+import com.vimeo.networking.model.VideoList;
 import com.vimeo.networking.model.VimeoAccount;
 import com.vimeo.networking.model.error.ErrorCode;
 import com.vimeo.networking.model.error.LocalErrorCode;
@@ -1081,6 +1083,23 @@ public class VimeoClient {
         call.enqueue(callback);
         return call;
     }
+
+    @Nullable
+    public Call modifyVideosInAlbum(@NotNull final Album album,
+                                    @NotNull final ModifyVideosInAlbum modificationSpecs,
+                                    @NotNull VimeoCallback<VideoList> callback) {
+        if (!VimeoNetworkUtil.validateString(album.getUri(),
+                                             "Album uri cannot be empty in modifyVideosInAlbum",
+                                             callback)) {
+            return null;
+        }
+        final Call<VideoList> call = mVimeoService.modifyVideosInAlbum(getAuthHeader(),
+                                                                       album.getUri() + "/videos",
+                                                                       modificationSpecs);
+        call.enqueue(callback);
+        return call;
+    }
+
 
     @Nullable
     public Call<Video> editVideo(@Nullable String uri,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -33,7 +33,7 @@ import com.vimeo.networking.model.Album;
 import com.vimeo.networking.model.AlbumPrivacy;
 import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.Document;
-import com.vimeo.networking.model.ModifyVideosInAlbum;
+import com.vimeo.networking.model.ModifyVideosInAlbumSpecs;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
@@ -1084,9 +1084,22 @@ public class VimeoClient {
         return call;
     }
 
+
+    /**
+     * Call this method to batch add/remove videos to/from an album.
+     *
+     * @param album             The album whose video list will be modified.
+     * @param modificationSpecs The {@link ModifyVideosInAlbumSpecs} object containing the specifications for which
+     *                          videos should be added and removed.
+     * @param callback          A callback to be notified when the album's video list is modified. A {@link VideoList}
+     *                          containing the modified list of videos in the album will be returned in the event of
+     *                          success.
+     * @return A Call object or null if a client-side initialization error has occurred. In the event of an error,
+     * the callback will still be notified.
+     */
     @Nullable
     public Call modifyVideosInAlbum(@NotNull final Album album,
-                                    @NotNull final ModifyVideosInAlbum modificationSpecs,
+                                    @NotNull final ModifyVideosInAlbumSpecs modificationSpecs,
                                     @NotNull VimeoCallback<VideoList> callback) {
         if (!VimeoNetworkUtil.validateString(album.getUri(),
                                              "Album uri cannot be empty in modifyVideosInAlbum",

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -34,6 +34,7 @@ import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.CommentList;
 import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.FeedList;
+import com.vimeo.networking.model.ModifyVideosInAlbum;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
@@ -182,6 +183,11 @@ public interface VimeoService {
 
     @DELETE
     Call<Object> removeFromAlbum(@Header("Authorization") String authHeader, @Url String addToAlbumUri);
+
+    @PATCH
+    Call<VideoList> modifyVideosInAlbum(@Header("Authorization") String authHeader,
+                                        @Url String uri,
+                                        @Body ModifyVideosInAlbum modificationSpecs);
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -34,7 +34,7 @@ import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.CommentList;
 import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.FeedList;
-import com.vimeo.networking.model.ModifyVideosInAlbum;
+import com.vimeo.networking.model.ModifyVideosInAlbumSpecs;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
 import com.vimeo.networking.model.PinCodeInfo;
@@ -187,7 +187,7 @@ public interface VimeoService {
     @PATCH
     Call<VideoList> modifyVideosInAlbum(@Header("Authorization") String authHeader,
                                         @Url String uri,
-                                        @Body ModifyVideosInAlbum modificationSpecs);
+                                        @Body ModifyVideosInAlbumSpecs modificationSpecs);
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
@@ -14,17 +14,17 @@ public class AddVideoToAlbum implements Serializable {
 
     private static final long serialVersionUID = -855083653273120166L;
 
-    public AddVideoToAlbum(@NotNull String uri, int position) {
-        mUri = uri;
-        mPosition = position;
-    }
-
     @NotNull
     @SerializedName("uri")
     private final String mUri;
 
     @SerializedName("position")
     private final int mPosition;
+
+    public AddVideoToAlbum(@NotNull String uri, int position) {
+        mUri = uri;
+        mPosition = position;
+    }
 
     /**
      * @return The uri for the video to be added to the album.

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
@@ -1,0 +1,53 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * An object that is used to patch video addition updates to an Album.
+ */
+public class AddVideoToAlbum implements Serializable {
+
+    private static final long serialVersionUID = -855083653273120166L;
+
+    public AddVideoToAlbum(@NotNull String uri, int position) {
+        mUri = uri;
+        mPosition = position;
+    }
+
+    @NotNull
+    @SerializedName("uri")
+    public String mUri;
+
+    @SerializedName("position")
+    public int mPosition;
+
+    public String getUri() {
+        return mUri;
+    }
+
+    public int getPosition() {
+        return mPosition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || !getClass().equals(o.getClass())) { return false; }
+
+        final AddVideoToAlbum that = (AddVideoToAlbum) o;
+
+        if (mPosition != that.mPosition) { return false; }
+        return mUri.equals(that.mUri);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mUri.hashCode();
+        result = 31 * result + mPosition;
+        return result;
+    }
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 /**
  * An object that is used to patch video addition updates to an Album.
  */
+@SuppressWarnings("unused")
 public class AddVideoToAlbum implements Serializable {
 
     private static final long serialVersionUID = -855083653273120166L;
@@ -20,15 +21,22 @@ public class AddVideoToAlbum implements Serializable {
 
     @NotNull
     @SerializedName("uri")
-    public String mUri;
+    private final String mUri;
 
     @SerializedName("position")
-    public int mPosition;
+    private final int mPosition;
 
+    /**
+     * @return The uri for the video to be added to the album.
+     */
+    @NotNull
     public String getUri() {
         return mUri;
     }
 
+    /**
+     * @return The position in the album where the video should be added.
+     */
     public int getPosition() {
         return mPosition;
     }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Album.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Album.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @SuppressWarnings({"unused"})
 @UseStag(FieldOption.SERIALIZED_NAME)
-public class Album implements Serializable {
+public class Album implements Serializable, Entity {
 
     private static final long serialVersionUID = 1587389468069117149L;
 
@@ -513,5 +513,11 @@ public class Album implements Serializable {
         result = 31 * result + (mUri != null ? mUri.hashCode() : 0);
         result = 31 * result + (mResourceKey != null ? mResourceKey.hashCode() : 0);
         return result;
+    }
+
+    @Nullable
+    @Override
+    public String getIdentifier() {
+        return mResourceKey;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ConnectionCollection.java
@@ -154,6 +154,18 @@ public class ConnectionCollection implements Serializable {
     protected Connection mRecommendedChannels;
 
     @Nullable
+    @SerializedName("available_channels")
+    protected Connection mAvailableChannels;
+
+    @Nullable
+    @SerializedName("available_albums")
+    protected Connection mAvailableAlbums;
+
+    @Nullable
+    @SerializedName("available_videos")
+    protected Connection mAvailableVideos;
+
+    @Nullable
     @SerializedName("recommended_users")
     protected Connection mRecommendedUsers;
 
@@ -332,6 +344,33 @@ public class ConnectionCollection implements Serializable {
     @Nullable
     public Connection getRecommendedChannels() {
         return mRecommendedChannels;
+    }
+
+    /**
+     * @return A {@link Connection} for channels managed by the logged-in user. This {@link Connection}
+     * will be present for {@link Video} objects when available.
+     */
+    @Nullable
+    public Connection getAvailableChannels() {
+        return mAvailableChannels;
+    }
+
+    /**
+     * @return A {@link Connection} for albums managed by the logged-in user. This {@link Connection}
+     * will be present for {@link Video} objects when available.
+     */
+    @Nullable
+    public Connection getAvailableAlbums() {
+        return mAvailableAlbums;
+    }
+
+    /**
+     * @return A {@link Connection} for videos managed by the logged-in user. This {@link Connection}
+     * will be present for {@link Album} or {@link Channel} objects when available.
+     */
+    @Nullable
+    public Connection getAvailableVideos() {
+        return mAvailableVideos;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Interaction.java
@@ -94,6 +94,10 @@ public class Interaction implements Serializable {
         }
     }
 
+    @Nullable
+    @SerializedName("options")
+    protected ArrayList<String> mOptions;
+
     @SerializedName("added")
     protected boolean mAdded;
 
@@ -157,5 +161,14 @@ public class Interaction implements Serializable {
     @Nullable
     public List<String> getReportingReasons() {
         return mReportingReasons;
+    }
+
+    /**
+     * @return a {@code List<String>} containing the options that are available for the {@link #getUri()}
+     * endpoint in this {@link Interaction}. The options will be things like "PUT", "DELETE", etc.
+     */
+    @Nullable
+    public List<String> getOptions() {
+        return new ArrayList<String>(mOptions);
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -98,6 +98,10 @@ public class InteractionCollection implements Serializable {
     private Interaction mAddVideos;
 
     @Nullable
+    @SerializedName("album")
+    private Interaction mAlbum;
+
+    @Nullable
     @SerializedName("add_to")
     private Interaction mAddTo;
 
@@ -180,6 +184,24 @@ public class InteractionCollection implements Serializable {
 
     void setAddVideos(@Nullable Interaction addVideos) {
         mAddVideos = addVideos;
+    }
+
+    /**
+     * @return An {@link Interaction} that will be present in the Video objects returned from
+     * a request to an "available_videos" connection on an album object. The
+     * {@link Interaction#getUri()} will provide the uri needed to pass to
+     * {@link VimeoClient#putContent(String, Map, IgnoreResponseVimeoCallback)} to add or remove the video
+     * from the collection.  In the event that the video is not yet added to the album,
+     * {@link Interaction#getOptions()} will contain "PUT". In the event that the video is already added to the
+     * album/channel, {@link Interaction#getOptions()} will contain "DELETE".
+     */
+    @Nullable
+    public Interaction getAlbum() {
+        return mAlbum;
+    }
+
+    void setAlbum(@Nullable Interaction album) {
+        mAlbum = album;
     }
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/InteractionCollection.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Map;
 
 import okhttp3.CacheControl;
 
@@ -95,6 +96,10 @@ public class InteractionCollection implements Serializable {
     @Nullable
     @SerializedName("add_videos")
     private Interaction mAddVideos;
+
+    @Nullable
+    @SerializedName("add_to")
+    private Interaction mAddTo;
 
     @Nullable
     public Interaction getWatchLater() {
@@ -175,6 +180,24 @@ public class InteractionCollection implements Serializable {
 
     void setAddVideos(@Nullable Interaction addVideos) {
         mAddVideos = addVideos;
+    }
+
+    /**
+     * @return An {@link Interaction} that will be present in the Album or Channel objects returned from
+     * a request to an "available_channels" or "available_albums" connection on a video object. The
+     * {@link Interaction#getUri()} will provide the uri needed to pass to
+     * {@link VimeoClient#putContent(String, Map, IgnoreResponseVimeoCallback)} to add or remove the video
+     * from the collection.  In the event that the video is not yet added to the album/channel,
+     * {@link Interaction#getOptions()} will contain "PUT". In the event that the video is already added to the
+     * album/channel, {@link Interaction#getOptions()} will contain "DELETE".
+     */
+    @Nullable
+    public Interaction getAddTo() {
+        return mAddTo;
+    }
+
+    void setAddTo(@Nullable Interaction addTo) {
+        mAddTo = addTo;
     }
 
     @Nullable

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -15,21 +15,45 @@ public class ModifyVideosInAlbum implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
+    private class NamedWrapperForAdd implements Serializable{
+
+        private static final long serialVersionUID = 8713902512465812810L;
+
+        NamedWrapperForAdd(List<AddVideoToAlbum> addVideoList) {
+            mAddVideosToAlbums = new ArrayList<>(addVideoList);
+        }
+
+        @SerializedName("video")
+        public List<AddVideoToAlbum> mAddVideosToAlbums;
+    }
+
+    private class NamedWrapperForRemove implements Serializable{
+
+        private static final long serialVersionUID = -8122735684596463036L;
+
+        NamedWrapperForRemove(List<RemoveVideoFromAlbum> removeVideoList) {
+            mRemoveVideosFromAlbums = new ArrayList<>(removeVideoList);
+        }
+
+        @SerializedName("video")
+        public List<RemoveVideoFromAlbum> mRemoveVideosFromAlbums;
+    }
+
     public ModifyVideosInAlbum(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
                                @Nullable List<AddVideoToAlbum> addVideoList) {
         if (removeVideoList != null) {
-            mRemoveVideoList = new ArrayList<>(removeVideoList);
+            mRemoveVideoList = new NamedWrapperForRemove(removeVideoList);
         }
         if (addVideoList != null) {
-            mAddVideoList = new ArrayList<>(addVideoList);
+            mAddVideoList = new NamedWrapperForAdd(addVideoList);
         }
     }
 
     @Nullable
     @SerializedName("remove")
-    public List<RemoveVideoFromAlbum> mRemoveVideoList;
+    public NamedWrapperForRemove mRemoveVideoList;
 
     @Nullable
     @SerializedName("set")
-    public List<AddVideoToAlbum> mAddVideoList;
+    public NamedWrapperForAdd mAddVideoList;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -15,45 +15,51 @@ public class ModifyVideosInAlbum implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
-    private class NamedWrapperForAdd implements Serializable{
+    private class NamedWrapperForAdd implements Serializable {
 
         private static final long serialVersionUID = 8713902512465812810L;
 
-        NamedWrapperForAdd(List<AddVideoToAlbum> addVideoList) {
-            mAddVideosToAlbums = new ArrayList<>(addVideoList);
+        NamedWrapperForAdd(AddVideoToAlbum addVideoToAlbum) {
+            mAddVideoToAlbum = addVideoToAlbum;
         }
 
         @SerializedName("video")
-        public List<AddVideoToAlbum> mAddVideosToAlbums;
+        public AddVideoToAlbum mAddVideoToAlbum;
     }
 
-    private class NamedWrapperForRemove implements Serializable{
+    private class NamedWrapperForRemove implements Serializable {
 
         private static final long serialVersionUID = -8122735684596463036L;
 
-        NamedWrapperForRemove(List<RemoveVideoFromAlbum> removeVideoList) {
-            mRemoveVideosFromAlbums = new ArrayList<>(removeVideoList);
+        NamedWrapperForRemove(RemoveVideoFromAlbum removeVideoFromAlbum) {
+            mRemoveVideoFromAlbum = removeVideoFromAlbum;
         }
 
         @SerializedName("video")
-        public List<RemoveVideoFromAlbum> mRemoveVideosFromAlbums;
+        public RemoveVideoFromAlbum mRemoveVideoFromAlbum;
     }
 
     public ModifyVideosInAlbum(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
                                @Nullable List<AddVideoToAlbum> addVideoList) {
         if (removeVideoList != null) {
-            mRemoveVideoList = new NamedWrapperForRemove(removeVideoList);
+            mRemoveVideoList = new ArrayList<>();
+            for (final RemoveVideoFromAlbum curRemove : removeVideoList) {
+                mRemoveVideoList.add(new NamedWrapperForRemove(curRemove));
+            }
         }
         if (addVideoList != null) {
-            mAddVideoList = new NamedWrapperForAdd(addVideoList);
+            mAddVideoList = new ArrayList<>();
+            for (final AddVideoToAlbum curAdd : addVideoList) {
+                mAddVideoList.add(new NamedWrapperForAdd(curAdd));
+            }
         }
     }
 
     @Nullable
     @SerializedName("remove")
-    public NamedWrapperForRemove mRemoveVideoList;
+    public List<NamedWrapperForRemove> mRemoveVideoList;
 
     @Nullable
     @SerializedName("set")
-    public NamedWrapperForAdd mAddVideoList;
+    public List<NamedWrapperForAdd> mAddVideoList;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -1,0 +1,29 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An object that is used to patch video addition and deletion updates to an Album.
+ */
+public class ModifyVideosInAlbum implements Serializable {
+
+    private static final long serialVersionUID = -3094719083671086785L;
+
+    public ModifyVideosInAlbum(ArrayList<RemoveVideoFromAlbum> removeVideoList) {
+        mRemoveVideoList = new ArrayList<>(removeVideoList);
+    }
+
+    @Nullable
+    @SerializedName("remove")
+    public List<RemoveVideoFromAlbum> mRemoveVideoList;
+
+    @Nullable
+    @SerializedName("add")
+    public List<RemoveVideoFromAlbum> mAddVideoList;
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -30,6 +30,6 @@ public class ModifyVideosInAlbum implements Serializable {
     public List<RemoveVideoFromAlbum> mRemoveVideoList;
 
     @Nullable
-    @SerializedName("add")
+    @SerializedName("set")
     public List<AddVideoToAlbum> mAddVideoList;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -15,8 +15,14 @@ public class ModifyVideosInAlbum implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
-    public ModifyVideosInAlbum(ArrayList<RemoveVideoFromAlbum> removeVideoList) {
-        mRemoveVideoList = new ArrayList<>(removeVideoList);
+    public ModifyVideosInAlbum(@Nullable ArrayList<RemoveVideoFromAlbum> removeVideoList,
+                               @Nullable ArrayList<AddVideoToAlbum> addVideoList) {
+        if (removeVideoList != null) {
+            mRemoveVideoList = new ArrayList<>(removeVideoList);
+        }
+        if (addVideoList != null) {
+            mAddVideoList = new ArrayList<>(addVideoList);
+        }
     }
 
     @Nullable
@@ -25,5 +31,5 @@ public class ModifyVideosInAlbum implements Serializable {
 
     @Nullable
     @SerializedName("add")
-    public List<RemoveVideoFromAlbum> mAddVideoList;
+    public List<AddVideoToAlbum> mAddVideoList;
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -15,8 +15,8 @@ public class ModifyVideosInAlbum implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
-    public ModifyVideosInAlbum(@Nullable ArrayList<RemoveVideoFromAlbum> removeVideoList,
-                               @Nullable ArrayList<AddVideoToAlbum> addVideoList) {
+    public ModifyVideosInAlbum(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
+                               @Nullable List<AddVideoToAlbum> addVideoList) {
         if (removeVideoList != null) {
             mRemoveVideoList = new ArrayList<>(removeVideoList);
         }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbum.java
@@ -11,33 +11,18 @@ import java.util.List;
 /**
  * An object that is used to patch video addition and deletion updates to an Album.
  */
+@SuppressWarnings("unused")
 public class ModifyVideosInAlbum implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
-    private class NamedWrapperForAdd implements Serializable {
+    @Nullable
+    @SerializedName("remove")
+    private List<NamedWrapperForRemove> mRemoveVideoList;
 
-        private static final long serialVersionUID = 8713902512465812810L;
-
-        NamedWrapperForAdd(AddVideoToAlbum addVideoToAlbum) {
-            mAddVideoToAlbum = addVideoToAlbum;
-        }
-
-        @SerializedName("video")
-        public AddVideoToAlbum mAddVideoToAlbum;
-    }
-
-    private class NamedWrapperForRemove implements Serializable {
-
-        private static final long serialVersionUID = -8122735684596463036L;
-
-        NamedWrapperForRemove(RemoveVideoFromAlbum removeVideoFromAlbum) {
-            mRemoveVideoFromAlbum = removeVideoFromAlbum;
-        }
-
-        @SerializedName("video")
-        public RemoveVideoFromAlbum mRemoveVideoFromAlbum;
-    }
+    @Nullable
+    @SerializedName("set")
+    private List<NamedWrapperForAdd> mAddVideoList;
 
     public ModifyVideosInAlbum(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
                                @Nullable List<AddVideoToAlbum> addVideoList) {
@@ -55,11 +40,75 @@ public class ModifyVideosInAlbum implements Serializable {
         }
     }
 
+    /**
+     * @return A nullable list of RemoveVideoFromAlbum objects, containing the wrapped list of videos to be removed
+     * from the album.
+     */
     @Nullable
-    @SerializedName("remove")
-    public List<NamedWrapperForRemove> mRemoveVideoList;
+    public List<RemoveVideoFromAlbum> getRemoveVideoList() {
+        if (mRemoveVideoList == null) {
+            return null;
+        }
+        final List<RemoveVideoFromAlbum> retVal = new ArrayList<>();
+        for (final NamedWrapperForRemove curRemove : mRemoveVideoList) {
+            retVal.add(curRemove.getRemoveVideoFromAlbum());
+        }
+        return retVal;
+    }
 
+    /**
+     * @return A nullable list of AddVideoToAlbum objects, containing the wrapped list of videos to be added
+     * to the album.
+     */
     @Nullable
-    @SerializedName("set")
-    public List<NamedWrapperForAdd> mAddVideoList;
+    public List<AddVideoToAlbum> getAddVideoList() {
+        if (mAddVideoList == null) {
+            return null;
+        }
+        final List<AddVideoToAlbum> retVal = new ArrayList<>();
+        for (final NamedWrapperForAdd curAdd : mAddVideoList) {
+            retVal.add(curAdd.getAddVideoToAlbum());
+        }
+        return retVal;
+    }
+
+    private class NamedWrapperForAdd implements Serializable {
+
+        private static final long serialVersionUID = 8713902512465812810L;
+
+        @SerializedName("video")
+        private final AddVideoToAlbum mAddVideoToAlbum;
+
+        NamedWrapperForAdd(AddVideoToAlbum addVideoToAlbum) {
+            mAddVideoToAlbum = addVideoToAlbum;
+        }
+
+        /**
+         * @return The wrapped AddVideoToAlbum object.
+         */
+        AddVideoToAlbum getAddVideoToAlbum() {
+            return mAddVideoToAlbum;
+        }
+    }
+
+    private class NamedWrapperForRemove implements Serializable {
+
+        private static final long serialVersionUID = -8122735684596463036L;
+
+        @SerializedName("video")
+        private final RemoveVideoFromAlbum mRemoveVideoFromAlbum;
+
+        NamedWrapperForRemove(RemoveVideoFromAlbum removeVideoFromAlbum) {
+            mRemoveVideoFromAlbum = removeVideoFromAlbum;
+        }
+
+        /**
+         * @return The wrapped RemoveVideoFromAlbum object.
+         */
+        RemoveVideoFromAlbum getRemoveVideoFromAlbum() {
+            return mRemoveVideoFromAlbum;
+        }
+    }
+
+
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -1,41 +1,44 @@
 package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * An object that is used to patch video addition and deletion updates to an Album.
  */
 @SuppressWarnings("unused")
+@UseStag(FieldOption.SERIALIZED_NAME)
 public class ModifyVideosInAlbumSpecs implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
     @Nullable
     @SerializedName("remove")
-    private List<NamedWrapperForRemove> mRemoveVideoList;
+    private Set<NamedWrapperForRemove> mRemoveVideoSet;
 
     @Nullable
     @SerializedName("set")
-    private List<NamedWrapperForAdd> mAddVideoList;
+    private Set<NamedWrapperForAdd> mAddVideoSet;
 
-    public ModifyVideosInAlbumSpecs(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
-                                    @Nullable List<AddVideoToAlbum> addVideoList) {
-        if (removeVideoList != null) {
-            mRemoveVideoList = new ArrayList<>();
-            for (final RemoveVideoFromAlbum curRemove : removeVideoList) {
-                mRemoveVideoList.add(new NamedWrapperForRemove(curRemove));
+    public ModifyVideosInAlbumSpecs(@Nullable Set<RemoveVideoFromAlbum> removeVideoSet,
+                                    @Nullable Set<AddVideoToAlbum> addVideoSet) {
+        if (removeVideoSet != null) {
+            mRemoveVideoSet = new LinkedHashSet<>();
+            for (final RemoveVideoFromAlbum curRemove : removeVideoSet) {
+                mRemoveVideoSet.add(new NamedWrapperForRemove(curRemove));
             }
         }
-        if (addVideoList != null) {
-            mAddVideoList = new ArrayList<>();
-            for (final AddVideoToAlbum curAdd : addVideoList) {
-                mAddVideoList.add(new NamedWrapperForAdd(curAdd));
+        if (addVideoSet != null) {
+            mAddVideoSet = new LinkedHashSet<>();
+            for (final AddVideoToAlbum curAdd : addVideoSet) {
+                mAddVideoSet.add(new NamedWrapperForAdd(curAdd));
             }
         }
     }
@@ -45,12 +48,12 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
      * from the album.
      */
     @Nullable
-    public List<RemoveVideoFromAlbum> getRemoveVideoList() {
-        if (mRemoveVideoList == null) {
+    public Set<RemoveVideoFromAlbum> getRemoveVideoSet() {
+        if (mRemoveVideoSet == null) {
             return null;
         }
-        final List<RemoveVideoFromAlbum> retVal = new ArrayList<>();
-        for (final NamedWrapperForRemove curRemove : mRemoveVideoList) {
+        final Set<RemoveVideoFromAlbum> retVal = new LinkedHashSet<>();
+        for (final NamedWrapperForRemove curRemove : mRemoveVideoSet) {
             retVal.add(curRemove.getRemoveVideoFromAlbum());
         }
         return retVal;
@@ -61,12 +64,12 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
      * to the album.
      */
     @Nullable
-    public List<AddVideoToAlbum> getAddVideoList() {
-        if (mAddVideoList == null) {
+    public Set<AddVideoToAlbum> getAddVideoSet() {
+        if (mAddVideoSet == null) {
             return null;
         }
-        final List<AddVideoToAlbum> retVal = new ArrayList<>();
-        for (final NamedWrapperForAdd curAdd : mAddVideoList) {
+        final Set<AddVideoToAlbum> retVal = new LinkedHashSet<>();
+        for (final NamedWrapperForAdd curAdd : mAddVideoSet) {
             retVal.add(curAdd.getAddVideoToAlbum());
         }
         return retVal;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -18,11 +18,11 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
 
     @Nullable
     @SerializedName("remove")
-    private Set<NamedWrapperForRemove> mRemoveVideoSet;
+    private final Set<NamedWrapperForRemove> mRemoveVideoSet;
 
     @Nullable
     @SerializedName("set")
-    private Set<NamedWrapperForAdd> mAddVideoSet;
+    private final Set<NamedWrapperForAdd> mAddVideoSet;
 
     public ModifyVideosInAlbumSpecs(@Nullable Set<RemoveVideoFromAlbum> removeVideoSet,
                                     @Nullable Set<AddVideoToAlbum> addVideoSet) {
@@ -31,12 +31,16 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
             for (final RemoveVideoFromAlbum curRemove : removeVideoSet) {
                 mRemoveVideoSet.add(new NamedWrapperForRemove(curRemove));
             }
+        } else {
+            mRemoveVideoSet = null;
         }
         if (addVideoSet != null) {
             mAddVideoSet = new LinkedHashSet<>();
             for (final AddVideoToAlbum curAdd : addVideoSet) {
                 mAddVideoSet.add(new NamedWrapperForAdd(curAdd));
             }
+        } else {
+            mAddVideoSet = null;
         }
     }
 

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -12,7 +12,7 @@ import java.util.List;
  * An object that is used to patch video addition and deletion updates to an Album.
  */
 @SuppressWarnings("unused")
-public class ModifyVideosInAlbum implements Serializable {
+public class ModifyVideosInAlbumSpecs implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;
 
@@ -24,8 +24,8 @@ public class ModifyVideosInAlbum implements Serializable {
     @SerializedName("set")
     private List<NamedWrapperForAdd> mAddVideoList;
 
-    public ModifyVideosInAlbum(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
-                               @Nullable List<AddVideoToAlbum> addVideoList) {
+    public ModifyVideosInAlbumSpecs(@Nullable List<RemoveVideoFromAlbum> removeVideoList,
+                                    @Nullable List<AddVideoToAlbum> addVideoList) {
         if (removeVideoList != null) {
             mRemoveVideoList = new ArrayList<>();
             for (final RemoveVideoFromAlbum curRemove : removeVideoList) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -1,8 +1,6 @@
 package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
-import com.vimeo.stag.UseStag;
-import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -14,7 +12,6 @@ import java.util.Set;
  * An object that is used to patch video addition and deletion updates to an Album.
  */
 @SuppressWarnings("unused")
-@UseStag(FieldOption.SERIALIZED_NAME)
 public class ModifyVideosInAlbumSpecs implements Serializable {
 
     private static final long serialVersionUID = -3094719083671086785L;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/RemoveVideoFromAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/RemoveVideoFromAlbum.java
@@ -1,0 +1,43 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * An object that is used to patch video addition updates to an Album.
+ */
+public class RemoveVideoFromAlbum implements Serializable {
+
+    private static final long serialVersionUID = 5352714439194578175L;
+
+    public RemoveVideoFromAlbum(@NotNull final String uri) {
+        mUri = uri;
+    }
+
+    @NotNull
+    @SerializedName("uri")
+    public String mUri;
+
+    public String getUri() {
+        return mUri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || !getClass().equals(o.getClass())) { return false; }
+
+        final RemoveVideoFromAlbum that = (RemoveVideoFromAlbum) o;
+
+        return mUri.equals(that.mUri);
+    }
+
+    @Override
+    public int hashCode() {
+        return mUri.hashCode();
+    }
+
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/RemoveVideoFromAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/RemoveVideoFromAlbum.java
@@ -19,8 +19,12 @@ public class RemoveVideoFromAlbum implements Serializable {
 
     @NotNull
     @SerializedName("uri")
-    public String mUri;
+    private final String mUri;
 
+    /**
+     * @return The uri for the video to be removed from the album.
+     */
+    @NotNull
     public String getUri() {
         return mUri;
     }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -289,6 +289,15 @@ public enum ErrorCode {
     UPLOAD_QUOTA_SIZE_EXCEEDED,
     @SerializedName("4102")
     UPLOAD_QUOTA_COUNT_EXCEEDED,
+    // Albums
+    @SerializedName("3200")
+    ALBUM_THUMBNAIL_ACCESS_FORBIDDEN,
+    @SerializedName("3429")
+    ALBUM_EDIT_FORBIDDEN_FOR_AUTHENTICATED_USER,
+    @SerializedName("3433")
+    ADD_VIDEO_TO_ALBUM_FORBIDDEN,
+    @SerializedName("4016")
+    UNEXPECTED_ALBUM_THUMBNAIL_EXCEPTION,
     // Unused
     // These most likely won't affect the Vimeo app since we don't currently have these settings
     @SerializedName("2254")


### PR DESCRIPTION
#### Issue
https://github.com/vimeo//vimeo-networking-java/issues/VA-3896

#### Summary
Videos will have:
`metadata.connections.available_channels`
`metadata.connections.available_albums`

These connections will have a uri like follows:
`/videos/:video_id/available_channels/videos/:video_id/available_albums`

The response from this endpoint provides all of the logged in user's albums/channels (paginated). Each album/channel object in the list will contain:
`metadata.interactions.add_to`

There will be a `metadata.interactions.add_to.uri` for the interaction to add/remove. The uri will be the same in both cases. In the event that the video is not yet added to the album/channel, metadata.interactions.add_to.options = PUT. In the event that the video is already added to the album/channel, metadata.interactions.add_to.options = DELETE.
```
GET /videos/123

{
"uri": "/videos/123",
"metadata": {
"connections": {
"available_albums":

{ 
"uri": "/videos/123/available_albums", 
"options": [ "GET" ], 
"total": 2 
}

}
}
}

GET /videos/123/available_albums

{
"uri": "/albums/100",
"metadata": {
"interactions": {
"add_to":
{ 
"uri": "/albums/100/videos/123", "options": [ "PUT" ] }
},
{
"uri": "/albums/200",
"metadata": {
"interactions": {
"add_to":
{ 
"uri": "/albums/200/videos/123", 
"options": [ "DELETE" ] 
}
}
```
Additionally, we will need the ability to get a list of a user's videos for a specific album where the response will be a list of videos that have interactions similar to those described above for albums where the there is an "album" interaction with a uri and a "PUT" or "DELETE" option depending on whether the video is already in the album. The specs for this endpoint are described here: 
https://vimean.atlassian.net/browse/COL-1061

Batch adding of videos to an album is currently supported by the API via a patch request to the album.metadata.interactions.add_videos.uri as follows:

```
PATCH /users/173181/albums/5260655/videos
{
“remove”: [
{“video”: {“uri”: “/videos/223022"}},
{“video”: {“uri”: “/videos/254785”}}
],
“set”: [
{“video”: {“uri”: “/videos/261621”, “position”: 2}},
{“video”: {“uri”: “/videos/345195”, “position”: 1}}
]
}
```

Batch adding of a video to multiple albums is still undefined at the time of writing and will need to be implemented as part of this ticket: https://vimean.atlassian.net/browse/VA-4037
