### PR TITLE
VimeoError API improvement

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1718,7 +1718,7 @@ public class VimeoClient {
             }
         } catch (final Exception e) {
             vimeoError = new VimeoError();
-            vimeoError.setException(e);
+            vimeoError.setThrowable(e);
         }
 
         return vimeoError;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/callbacks/VimeoCallback.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/callbacks/VimeoCallback.java
@@ -47,7 +47,7 @@ public abstract class VimeoCallback<T> implements Callback<T> {
     public void onResponse(Call<T> call, Response<T> response) {
         // response.isSuccess() is true if the response code is 2xx
         if (response.isSuccessful()) {
-            T t = response.body();
+            final T t = response.body();
             success(t);
         } else {
             VimeoError vimeoError = VimeoNetworkUtil.getErrorFromResponse(response);
@@ -68,9 +68,7 @@ public abstract class VimeoCallback<T> implements Callback<T> {
          *      Cancelled request (cancelling may also lead to socket issues if request has been made)
          *      Retrofit deserialization errors in which Retrofit cannot determine the response
          */
-        t.printStackTrace();
-        VimeoError vimeoError = new VimeoError();
-        vimeoError.setDeveloperMessage(t.getMessage());
+        final VimeoError vimeoError = new VimeoError(t.getMessage(), t);
         vimeoError.setErrorMessage(t.getMessage());
         vimeoError.setIsCanceledError(call != null && call.isCanceled());
         failure(vimeoError);

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/VimeoError.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/VimeoError.java
@@ -74,7 +74,7 @@ public class VimeoError extends RuntimeException {
     @SerializedName("invalid_parameters")
     protected List<InvalidParameter> mInvalidParameters;
 
-    private Exception mException;
+    private Throwable mThrowable;
     private int mHttpStatusCode = Vimeo.NOT_FOUND;
 
     private boolean mIsCanceledError;
@@ -86,9 +86,9 @@ public class VimeoError extends RuntimeException {
         this.mDeveloperMessage = errorMessage;
     }
 
-    public VimeoError(String errorMessage, Exception exception) {
+    public VimeoError(String errorMessage, Throwable throwable) {
         this.mDeveloperMessage = errorMessage;
-        this.mException = exception;
+        this.mThrowable = throwable;
     }
 
     public Response getResponse() {
@@ -204,12 +204,12 @@ public class VimeoError extends RuntimeException {
         return getInvalidParameter() != null ? getInvalidParameter().getErrorCode() : null;
     }
 
-    public Exception getException() {
-        return mException;
+    public Throwable getThrowable() {
+        return mThrowable;
     }
 
-    public void setException(Exception exception) {
-        this.mException = exception;
+    public void setThrowable(Throwable throwable) {
+        this.mThrowable = throwable;
     }
 
     public int getHttpStatusCode() {
@@ -291,8 +291,8 @@ public class VimeoError extends RuntimeException {
             return getDeveloperMessage();
         } else if (this.mErrorMessage != null) {
             return this.mErrorMessage;
-        } else if (mException != null && mException.getMessage() != null) {
-            return "Exception: " + mException.getMessage();
+        } else if (mThrowable != null && mThrowable.getMessage() != null) {
+            return "Exception: " + mThrowable.getMessage();
         } else if (getErrorCode() != ErrorCode.DEFAULT) {
             return "Error Code " + getErrorCode();
         } else if (getHttpStatusCode() != Vimeo.NOT_FOUND) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/utils/VimeoNetworkUtil.java
@@ -30,6 +30,7 @@ import com.google.gson.GsonBuilder;
 import com.vimeo.networking.Vimeo;
 import com.vimeo.networking.VimeoClient;
 import com.vimeo.networking.callbacks.VimeoCallback;
+import com.vimeo.networking.logging.ClientLogger;
 import com.vimeo.networking.model.AlbumPrivacy;
 import com.vimeo.networking.model.AlbumPrivacy.AlbumPrivacyViewValue;
 import com.vimeo.networking.model.error.VimeoError;
@@ -63,7 +64,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by kylevenn on 10/30/15.
  */
 @SuppressWarnings("unused")
-public class VimeoNetworkUtil {
+public final class VimeoNetworkUtil {
 
     @Nullable
     private static Gson sGson;
@@ -112,18 +113,18 @@ public class VimeoNetworkUtil {
     public static Map<String, String> getSimpleQueryMap(@NotNull String uri) {
         final Map<String, String> queryPairs = new LinkedHashMap<>();
         try {
-            String query = uri.split("\\?")[1];
-            String[] pairs = query.split("&");
-            for (String pair : pairs) {
-                int idx = pair.indexOf("=");
+            final String query = uri.split("\\?")[1];
+            final String[] pairs = query.split("&");
+            for (final String pair : pairs) {
+                final int idx = pair.indexOf("=");
                 queryPairs.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
                                URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
             }
             return queryPairs;
-        } catch (UnsupportedEncodingException e) {
+        } catch (final UnsupportedEncodingException e) {
             // Just print the trace, we don't want to crash the app. If you ever get an empty query params
             // map back, then we know there was a malformed URL returned from the api (or a failure) 1/27/16 [KV]
-            e.printStackTrace();
+            ClientLogger.e("Error while encoding query map", e);
         }
 
         return queryPairs;
@@ -138,7 +139,7 @@ public class VimeoNetworkUtil {
      */
     @NotNull
     public static CacheControl.Builder getCacheControlBuilder(@NotNull CacheControl cacheControl) {
-        CacheControl.Builder builder = new CacheControl.Builder();
+        final CacheControl.Builder builder = new CacheControl.Builder();
         if (cacheControl.maxAgeSeconds() > -1) {
             builder.maxAge(cacheControl.maxAgeSeconds(), TimeUnit.SECONDS);
         }
@@ -170,7 +171,7 @@ public class VimeoNetworkUtil {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                for (Call call : callList) {
+                for (final Call call : callList) {
                     if (call != null) {
                         call.cancel();
                     }
@@ -199,8 +200,7 @@ public class VimeoNetworkUtil {
                         .responseBodyConverter(VimeoError.class, new Annotation[0]);
                 vimeoError = errorConverter.convert(response.errorBody());
             } catch (final Exception e) {
-                //noinspection CallToPrintStackTrace
-                e.printStackTrace();
+                ClientLogger.e("Error while attempting to convert response body to VimeoError", e);
             }
         }
         if (vimeoError == null) {


### PR DESCRIPTION
# Summary
Previously, `VimeoError` did not supply enough information about the cause of the error. Specifically, if an error occurred because there was no internet connection, the only information that could be used to determine if it was caused by lack of internet was checking the developer message if it matched a certain pattern "Unable to resolve host...". Checking the developer readable string message is not a reliable way of checking the cause within the program, and instead it would be better to check the type. So, I changed the internal `mException` property in `VimeoError` to `mThrowable`, and now within the `VimeoCallback`, the throwable cause is set along with the developer message. This will enable downstream consumers to more accurately determine what caused their issue.

Additionally, I removed usage of `printStackTrace` and replaced it with `ClientLogger.e`, except in `VimeoCallback` where the print was removed instead of replaced since we were already notifying the consumer.