### PR TITLE
Add max-age to cache header

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/RetrofitSetup.java
@@ -114,7 +114,7 @@ class RetrofitSetup {
         if (mCache != null) {
             retrofitClientBuilder.setCache(mCache);
         }
-        retrofitClientBuilder.addNetworkInterceptor(new CacheControlInterceptor())
+        retrofitClientBuilder.addNetworkInterceptor(new CacheControlInterceptor(mConfiguration.mCacheMaxAge))
                 .setReadTimeout(mConfiguration.mTimeout, TimeUnit.SECONDS)
                 .setConnectionTimeout(mConfiguration.mTimeout, TimeUnit.SECONDS)
                 .addInterceptor(new LoggingInterceptor())

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -97,8 +97,12 @@ public final class Vimeo {
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
 
-    // Header Values
-    public static final String HEADER_CACHE_PUBLIC = "public";
+    /**
+     * To get data from the cache, we set a max age to 7 hours. This prevents OkHttp
+     * from throwing a 504 exception. API no longer sends a max age in the header.
+     * OkHttp determines the cache to be invalid. This is a work around for this issue.
+     */
+    public static final String HEADER_CACHE_PUBLIC_WITH_MAX_AGE = "public, max-age:25200";
 
     // Video Analytics Parameters
     public static final String PARAMETER_SESSION_ID = "session_id";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -96,13 +96,7 @@ public final class Vimeo {
     public static final String HEADER_USER_AGENT = "User-Agent";
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
-
-    /**
-     * To get data from the cache, we set a max age to 7 hours. This prevents OkHttp
-     * from throwing a 504 exception. API no longer sends a max age in the header.
-     * OkHttp determines the cache to be invalid. This is a work around for this issue.
-     */
-    public static final String HEADER_CACHE_PUBLIC_WITH_MAX_AGE = "public, max-age:25200";
+    public static final String HEADER_CACHE_PUBLIC = "public";
 
     // Video Analytics Parameters
     public static final String PARAMETER_SESSION_ID = "session_id";

--- a/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/Vimeo.java
@@ -96,6 +96,8 @@ public final class Vimeo {
     public static final String HEADER_USER_AGENT = "User-Agent";
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
+
+    // Header Values
     public static final String HEADER_CACHE_PUBLIC = "public";
 
     // Video Analytics Parameters

--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
@@ -33,8 +33,8 @@ import okhttp3.Response;
 
 /**
  * Rewrite the server's cache-control header because our server sets all {@code Cache-Control} headers
- * to {@code no-store}
- * Created by brentwatson on 8/7/17.
+ * to {@code no-store}.
+ *
  */
 public class CacheControlInterceptor implements Interceptor {
 
@@ -42,7 +42,7 @@ public class CacheControlInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         return chain.proceed(chain.request())
                 .newBuilder()
-                .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC)
+                .header(Vimeo.HEADER_CACHE_CONTROL, Vimeo.HEADER_CACHE_PUBLIC_WITH_MAX_AGE)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary

API no longer includes a max age in the API response. Therefore, OkHttp no longer reads from the cache. It determines it to be invalid. This PR sets a max age of 7 hours in the cache header for every request. 

## Test

In the sample app of the SDK, modify the stack picks request to pull from cache and another request to pull from the network. Get data from the network. Verify the request is cached by looking at the data folder of the app. Get data from the cache. Verify a 504 exception is not thrown and you get data from the cache. 
