### PR TITLE
VA-4037 batch add video to albums

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -30,9 +30,11 @@ import com.vimeo.networking.callers.GetRequestCaller;
 import com.vimeo.networking.interceptors.LanguageHeaderInterceptor;
 import com.vimeo.networking.logging.ClientLogger;
 import com.vimeo.networking.model.Album;
+import com.vimeo.networking.model.AlbumList;
 import com.vimeo.networking.model.AlbumPrivacy;
 import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.Document;
+import com.vimeo.networking.model.ModifyVideoInAlbumsSpecs;
 import com.vimeo.networking.model.ModifyVideosInAlbumSpecs;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
@@ -1108,6 +1110,34 @@ public class VimeoClient {
         }
         final Call<VideoList> call = mVimeoService.modifyVideosInAlbum(getAuthHeader(),
                                                                        album.getUri() + "/videos",
+                                                                       modificationSpecs);
+        call.enqueue(callback);
+        return call;
+    }
+
+    /**
+     * Call this method to batch add/remove a video to/from albums.
+     *
+     * @param video             The video that will be added/removed from a series of albums.
+     * @param modificationSpecs The {@link ModifyVideoInAlbumsSpecs} object containing the specifications for which
+     *                          albums should be adding or removing a video.
+     * @param callback          A callback to be notified when the video membership is modified for one or more albums.
+     *                          An {@link AlbumList} containing the modified list of albums containing the video
+     *                          will be returned in the event of success.
+     * @return A Call object or null if a client-side initialization error has occurred. In the event of an error,
+     * the callback will still be notified.
+     */
+    @Nullable
+    public Call modifyVideoInAlbums(@NotNull final Video video,
+                                    @NotNull final ModifyVideoInAlbumsSpecs modificationSpecs,
+                                    @NotNull VimeoCallback<AlbumList> callback) {
+        if (!VimeoNetworkUtil.validateString(video.getUri(),
+                                             "Video uri cannot be empty in modifyVideoInAlbums",
+                                             callback)) {
+            return null;
+        }
+        final Call<AlbumList> call = mVimeoService.modifyVideoInAlbums(getAuthHeader(),
+                                                                       video.getUri() + "/albums",
                                                                        modificationSpecs);
         call.enqueue(callback);
         return call;

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -34,6 +34,7 @@ import com.vimeo.networking.model.Comment;
 import com.vimeo.networking.model.CommentList;
 import com.vimeo.networking.model.Document;
 import com.vimeo.networking.model.FeedList;
+import com.vimeo.networking.model.ModifyVideoInAlbumsSpecs;
 import com.vimeo.networking.model.ModifyVideosInAlbumSpecs;
 import com.vimeo.networking.model.PictureCollection;
 import com.vimeo.networking.model.PictureResource;
@@ -188,6 +189,11 @@ public interface VimeoService {
     Call<VideoList> modifyVideosInAlbum(@Header("Authorization") String authHeader,
                                         @Url String uri,
                                         @Body ModifyVideosInAlbumSpecs modificationSpecs);
+
+    @PATCH
+    Call<AlbumList> modifyVideoInAlbums(@Header("Authorization") String authHeader,
+                                        @Url String uri,
+                                        @Body ModifyVideoInAlbumsSpecs modificationSpecs);
     // </editor-fold>
 
     /**

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/AddVideoToAlbum.java
@@ -3,6 +3,7 @@ package com.vimeo.networking.model;
 import com.google.gson.annotations.SerializedName;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 
@@ -18,10 +19,11 @@ public class AddVideoToAlbum implements Serializable {
     @SerializedName("uri")
     private final String mUri;
 
+    @Nullable
     @SerializedName("position")
-    private final int mPosition;
+    private final Integer mPosition;
 
-    public AddVideoToAlbum(@NotNull String uri, int position) {
+    public AddVideoToAlbum(@NotNull String uri, @Nullable Integer position) {
         mUri = uri;
         mPosition = position;
     }
@@ -37,7 +39,8 @@ public class AddVideoToAlbum implements Serializable {
     /**
      * @return The position in the album where the video should be added.
      */
-    public int getPosition() {
+    @Nullable
+    public Integer getPosition() {
         return mPosition;
     }
 
@@ -48,14 +51,14 @@ public class AddVideoToAlbum implements Serializable {
 
         final AddVideoToAlbum that = (AddVideoToAlbum) o;
 
-        if (mPosition != that.mPosition) { return false; }
-        return mUri.equals(that.mUri);
+        if (!mUri.equals(that.mUri)) { return false; }
+        return mPosition != null ? mPosition.equals(that.mPosition) : that.mPosition == null;
     }
 
     @Override
     public int hashCode() {
         int result = mUri.hashCode();
-        result = 31 * result + mPosition;
+        result = 31 * result + (mPosition != null ? mPosition.hashCode() : 0);
         return result;
     }
 }

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideoInAlbumsSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideoInAlbumsSpecs.java
@@ -1,0 +1,57 @@
+package com.vimeo.networking.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * An object that is used to patch video addition and deletion updates to an Album.
+ */
+@SuppressWarnings("unused")
+public class ModifyVideoInAlbumsSpecs implements Serializable {
+
+    private static final long serialVersionUID = -1909177613077524718L;
+
+    @Nullable
+    @SerializedName("remove")
+    private final Set<RemoveVideoFromAlbum> mRemoveVideoSet;
+
+    @Nullable
+    @SerializedName("add")
+    private final Set<AddVideoToAlbum> mAddVideoSet;
+
+    public ModifyVideoInAlbumsSpecs(@Nullable Set<RemoveVideoFromAlbum> removeVideoSet,
+                                    @Nullable Set<AddVideoToAlbum> addVideoSet) {
+        mRemoveVideoSet = removeVideoSet != null ? new LinkedHashSet<>(removeVideoSet) : null;
+        mAddVideoSet = addVideoSet != null ? new LinkedHashSet<>(addVideoSet) : null;
+    }
+
+    /**
+     * @return A nullable set of RemoveVideoFromAlbum objects, containing the wrapped list of albums from which a
+     * video will be removed.
+     */
+    @Nullable
+    public Set<RemoveVideoFromAlbum> getRemoveVideoSet() {
+        if (mRemoveVideoSet == null) {
+            return null;
+        }
+        return new LinkedHashSet<>(mRemoveVideoSet);
+    }
+
+    /**
+     * @return A nullable set of AddVideoToAlbum objects, containing the wrapped list of albums from which a video
+     * will be added.
+     */
+    @Nullable
+    public Set<AddVideoToAlbum> getAddVideoSet() {
+        if (mAddVideoSet == null) {
+            return null;
+        }
+        return new LinkedHashSet<>(mAddVideoSet);
+    }
+
+}

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -18,11 +18,11 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
 
     @Nullable
     @SerializedName("remove")
-    transient private final Set<NamedWrapperForRemove> mRemoveVideoSet;
+    private final Set<NamedWrapperForRemove> mRemoveVideoSet;
 
     @Nullable
     @SerializedName("set")
-    transient private final Set<NamedWrapperForAdd> mAddVideoSet;
+    private final Set<NamedWrapperForAdd> mAddVideoSet;
 
     public ModifyVideosInAlbumSpecs(@Nullable Set<RemoveVideoFromAlbum> removeVideoSet,
                                     @Nullable Set<AddVideoToAlbum> addVideoSet) {

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/ModifyVideosInAlbumSpecs.java
@@ -18,11 +18,11 @@ public class ModifyVideosInAlbumSpecs implements Serializable {
 
     @Nullable
     @SerializedName("remove")
-    private final Set<NamedWrapperForRemove> mRemoveVideoSet;
+    transient private final Set<NamedWrapperForRemove> mRemoveVideoSet;
 
     @Nullable
     @SerializedName("set")
-    private final Set<NamedWrapperForAdd> mAddVideoSet;
+    transient private final Set<NamedWrapperForAdd> mAddVideoSet;
 
     public ModifyVideosInAlbumSpecs(@Nullable Set<RemoveVideoFromAlbum> removeVideoSet,
                                     @Nullable Set<AddVideoToAlbum> addVideoSet) {


### PR DESCRIPTION
#### Issue
https://github.com/vimeo//vimeo-networking-java/issues/VA-4037
https://vimean.atlassian.net/browse/COL-1109
https://github.vimeows.com/Vimeo/vimeo/pull/47472

#### Summary
Added a new `modifyVideoInAlbums` method to VimeoClient that allows for batch additions/removals of a video to/from a set of albums.

#### How to Test
I can supply some sample code for testing if needed.
