### PR TITLE
Fix Cache Control Header Formatting

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/interceptors/CacheControlInterceptor.java
@@ -49,7 +49,7 @@ public class CacheControlInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        final String cacheControlValue = Vimeo.HEADER_CACHE_PUBLIC + ", max-age:" + mMaxAge;
+        final String cacheControlValue = Vimeo.HEADER_CACHE_PUBLIC + ", max-age=" + mMaxAge;
         return chain.proceed(chain.request())
                 .newBuilder()
                 .header(Vimeo.HEADER_CACHE_CONTROL, cacheControlValue)


### PR DESCRIPTION
The cache control header interceptor adds a max age. However, the formatting of the directive was incorrect. It should be `max-age=XXXX`.