### PR TITLE
[TECH] Enable Stag on Privacy object

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/Privacy.java
@@ -24,6 +24,7 @@ package com.vimeo.networking.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.UseStag;
+import com.vimeo.stag.UseStag.FieldOption;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,8 +35,7 @@ import java.io.Serializable;
  * Created by hanssena on 4/23/15.
  */
 @SuppressWarnings("unused")
-// TODO: Figure out how to enable UseStag on this class without breaking deserialization due to the API giving us back integers for add and download 2/1/17 [AR]
-// @UseStag(FieldOption.SERIALIZED_NAME)
+ @UseStag(FieldOption.SERIALIZED_NAME)
 public class Privacy implements Serializable {
 
     private static final long serialVersionUID = -1679908652622815871L;

--- a/vimeo-networking/src/test/java/com/vimeo/networking/model/PrivacyTest.java
+++ b/vimeo-networking/src/test/java/com/vimeo/networking/model/PrivacyTest.java
@@ -16,7 +16,7 @@ public class PrivacyTest {
 
     @Test
     public void verifyTypeAdapterWasNotGenerated() throws Exception {
-        Utils.verifyNoTypeAdapterGeneration(Privacy.class);
+        Utils.verifyTypeAdapterGeneration(Privacy.class);
     }
 
     @Test


### PR DESCRIPTION
# Summary
In early 2017, Stag was disabled on the `Privacy` object. This was due to the API returning 1 or 0 in place of `true` or `false` for certain properties. That bug was fixed in version 3.3.5 of the API, and since we are on version 3.4.2, we can safely use Stag again. The motivation for this change was a crash I was seeing in the `ReflectiveTypeAdapterFactory$Adapter` class during deserialization of this class when reading the `Privacy` object off disk. In order to get more insight into what might be going on and because it's more performant, I am enabling Stag on this class.

#### How to Test
See if the privacy object can be successfully deserialized.
