### PR TITLE
Add Error mapping for INVALID_INPUT_PASSWORD_TOO_LONG

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -154,6 +154,8 @@ public enum ErrorCode {
     INVALID_INPUT_EMAIL_NOT_RECOGNIZED,
     @SerializedName("2218")
     INVALID_INPUT_PASSWORD_EMAIL_MISMATCH,
+    @SerializedName("3102")
+    INVALID_INPUT_PASSWORD_TOO_LONG,
     // Auth Errors
     @SerializedName("2303")
     UNABLE_TO_CREATE_USER_INVALID_TOKEN,
@@ -217,8 +219,6 @@ public enum ErrorCode {
     URL_UNAVAILABLE,
     @SerializedName("2406")
     USER_NOT_AUTHORIZED_TO_DELETE_ACCOUNT,
-    @SerializedName("3102")
-    INVALID_INPUT_PASSWORD_TOO_LONG,
     // </editor-fold>
 
     // ---- Video Settings ----

--- a/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/model/error/ErrorCode.java
@@ -217,6 +217,8 @@ public enum ErrorCode {
     URL_UNAVAILABLE,
     @SerializedName("2406")
     USER_NOT_AUTHORIZED_TO_DELETE_ACCOUNT,
+    @SerializedName("3102")
+    INVALID_INPUT_PASSWORD_TOO_LONG,
     // </editor-fold>
 
     // ---- Video Settings ----


### PR DESCRIPTION
#### Issue
[VA-4146](https://vimean.atlassian.net/browse/VA-4146)

#### Summary
Added missing error code to `ErrorCode` enum to make it easier to show the proper error message.


