### PR TITLE
VA-4204 publish api cleanup

### DIFF
--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoClient.java
@@ -1355,32 +1355,40 @@ public class VimeoClient {
      * The {@link PublishJob} will always reflect the latest publish job to a social media platform, new jobs overwrite
      * old data for the same platform. The last job status for each platform is returned.
      *
-     * @param videoId      The id of the {@link Video} that has been published to social media.
+     * @param publishUri   The uri of the publish to social endpoint for a {@link Video}. This uri is available at
+     *                     Video.getMetadata().getConnections().getPublishJobConnection().getUri(). A user's
+     *                     has access to this method when
+     *                     Video.getMetadata().getConnections().getPublishJobConnection().getOptions()
+     *                     has a "GET" command listed.
      * @param cacheControl The cache control.
      * @return A {@link PublishJob} containing information about previous posts of the {@link Video} to social media.
      */
-    public Call<PublishJob> getPublishJob(@NotNull final String videoId,
+    public Call<PublishJob> getPublishJob(@NotNull final String publishUri,
                                           @NotNull final CacheControl cacheControl) {
-        if (VimeoNetworkUtil.isStringEmpty(videoId)) {
+        if (VimeoNetworkUtil.isStringEmpty(publishUri)) {
             throw new AssertionError("Video Id is not valid for publish job.");
         }
-        return mVimeoService.getPublishJob(getAuthHeader(), videoId, createCacheControlString(cacheControl));
+        return mVimeoService.getPublishJob(getAuthHeader(), publishUri, createCacheControlString(cacheControl));
     }
 
     /**
      * Publishes a {@link Video} to social media as defined by {@link BatchPublishToSocialMedia}.
      *
-     * @param videoId     The id of the {@link Video} that has been published to social media.
+     * @param publishUri  The uri of the publish to social endpoint for a {@link Video}. This uri is available at
+     *                    Video.getMetadata().getConnections().getPublishJobConnection().getUri(). A user's
+     *                    has access to this method when
+     *                    Video.getMetadata().getConnections().getPublishJobConnection().getOptions()
+     *                    has a "PUT" command listed.
      * @param publishData The {@link BatchPublishToSocialMedia} that encapsulates the data and third party
      *                    social media platforms that a {@link Video} will natively be posted to.
      * @return A {@link PublishJob} containing information about the post of the {@link Video} to social media.
      */
-    public Call<PublishJob> putPublishJob(@NotNull final String videoId,
+    public Call<PublishJob> putPublishJob(@NotNull final String publishUri,
                                           @NotNull final BatchPublishToSocialMedia publishData) {
-        if (VimeoNetworkUtil.isStringEmpty(videoId)) {
+        if (VimeoNetworkUtil.isStringEmpty(publishUri)) {
             throw new AssertionError("Video Id is not valid for publish job.");
         }
-        return mVimeoService.putPublishJob(getAuthHeader(), videoId, publishData);
+        return mVimeoService.putPublishJob(getAuthHeader(), publishUri, publishData);
     }
 
     // </editor-fold>

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -201,11 +201,13 @@ public interface VimeoService {
      * -----------------------------------------------------------------------------------------------------
      */
     // <editor-fold desc="Publish Jobs">
+    @GET
     @Serializer(converter = ConverterType.MOSHI)
     Call<PublishJob> getPublishJob(@Header("Authorization") String authHeader,
                                    @Url String url,
                                    @Header("Cache-Control") String cacheHeader);
 
+    @PUT
     @Serializer(converter = ConverterType.MOSHI)
     @Headers("Cache-Control: no-cache, no-store")
     Call<PublishJob> putPublishJob(@Header("Authorization") String authHeader,

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -201,17 +201,15 @@ public interface VimeoService {
      * -----------------------------------------------------------------------------------------------------
      */
     // <editor-fold desc="Publish Jobs">
-    @GET("videos/{video_id}/publish_to_social")
     @Serializer(converter = ConverterType.MOSHI)
     Call<PublishJob> getPublishJob(@Header("Authorization") String authHeader,
-                                   @Path("video_id") String videoId,
+                                   @Url String url,
                                    @Header("Cache-Control") String cacheHeader);
 
-    @PUT("videos/{video_id}/publish_to_social")
     @Serializer(converter = ConverterType.MOSHI)
     @Headers("Cache-Control: no-cache, no-store")
     Call<PublishJob> putPublishJob(@Header("Authorization") String authHeader,
-                                   @Path("video_id") String videoId,
+                                   @Url String url,
                                    @Body BatchPublishToSocialMedia publishData);
     // </editor-fold>
 


### PR DESCRIPTION
#### Issue
https://github.com/vimeo//vimeo-networking-java/issues/VA-4204

#### Summary
Changing Video ID requirement to uri since Video objects do not explicitly expose the numeric ID needed. It is expected that `video.metadata.connections.publish_to_social.uri` will be used instead.


