### PR TITLE
Added missing moshi annotations

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/AuthenticatedAccessToken.kt
+++ b/models/src/main/java/com/vimeo/networking2/AuthenticatedAccessToken.kt
@@ -1,11 +1,13 @@
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
 /**
  * Authenticate token that you would receive from email, Google or Facebook login. In addition to
  * the token, you get a user object representing the authenticated user.
  */
+@JsonClass(generateAdapter = true)
 data class AuthenticatedAccessToken(
 
     @Json(name = "access_token")

--- a/models/src/main/java/com/vimeo/networking2/InvalidParameter.kt
+++ b/models/src/main/java/com/vimeo/networking2/InvalidParameter.kt
@@ -1,6 +1,7 @@
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.ErrorCodeType
 import com.vimeo.networking2.enums.asEnum
 
@@ -8,6 +9,7 @@ import com.vimeo.networking2.enums.asEnum
  * Similar to [ApiError] object, this holds error codes/error messages relevant to a
  * specific invalid field.
  */
+@JsonClass(generateAdapter = true)
 data class InvalidParameter(
 
     /**


### PR DESCRIPTION

#### Summary
After bumping Moshi in the networking library to the latest it's required all models either be annotated with `@JsonClass` or the Moshi instance being used needs to be passed an instance of `KotlinJsonAdapterFactory`.  [See the Moshi changelog for more details](https://github.com/square/moshi/blob/master/CHANGELOG.md#version-190)

InvalidParameter was missing the `@JsonClass` annotation and caused the app the throw an `java.lang.IllegalArgumentException`

Adding the annotation fixes the crash.

Also added `@JsonClass` to `AuthenticatedAccessToken` as it was also missing it. 