### PR TITLE
Removing `storage_warning` enum value since it is not supported by the API

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/enums/NotificationType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/NotificationType.kt
@@ -51,11 +51,6 @@ enum class NotificationType(override val value: String?) : StringValue {
     SHARE("share"),
 
     /**
-     * You’re approaching your weekly storage limit.
-     */
-    STORAGE_WARNING("storage_warning"),
-
-    /**
      * New upload transcode complete (new video is posted).
      */
     VIDEO_AVAILABLE("video_available"),


### PR DESCRIPTION
# Summary
Removing `storage_warning` enum value since it is not supported by the API. We were running into an issue where the `NotificationType` causing issues when requesting the API for notifications. It turns out this enum entry is not supported by the API. It's unclear why it was added, but it's the only entry that is not in the blueprint for the notification enum.