### PR TITLE
MPS-538: Remove wildcard imports from models module

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/Album.kt
+++ b/models/src/main/java/com/vimeo/networking2/Album.kt
@@ -10,7 +10,7 @@ import com.vimeo.networking2.enums.AlbumThemeType
 import com.vimeo.networking2.enums.SortType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Group of videos to share publicly or privately.

--- a/models/src/main/java/com/vimeo/networking2/BuyInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/BuyInteraction.kt
@@ -10,7 +10,7 @@ import com.vimeo.networking2.enums.DownloadType
 import com.vimeo.networking2.enums.StreamAccessType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * The buy interaction for a On Demand video.

--- a/models/src/main/java/com/vimeo/networking2/Category.kt
+++ b/models/src/main/java/com/vimeo/networking2/Category.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Entity
 import com.vimeo.networking2.common.Followable
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Category information.

--- a/models/src/main/java/com/vimeo/networking2/Channel.kt
+++ b/models/src/main/java/com/vimeo/networking2/Channel.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Entity
 import com.vimeo.networking2.common.Followable
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Channel information.

--- a/models/src/main/java/com/vimeo/networking2/ChannelFollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/ChannelFollowInteraction.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.common.UpdatableInteraction
 import com.vimeo.networking2.enums.FollowType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Follow a channel interaction.

--- a/models/src/main/java/com/vimeo/networking2/Comment.kt
+++ b/models/src/main/java/com/vimeo/networking2/Comment.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.common.Entity
 import com.vimeo.networking2.enums.CommentType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Comment data.

--- a/models/src/main/java/com/vimeo/networking2/ConnectedApp.kt
+++ b/models/src/main/java/com/vimeo/networking2/ConnectedApp.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.common.Entity
 import com.vimeo.networking2.enums.ConnectedAppType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * A [ConnectedApp] represents a connection to a social media platform. Some activities, like simultaneously live

--- a/models/src/main/java/com/vimeo/networking2/DashVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DashVideoFile.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.annotations.Internal
 import com.vimeo.networking2.common.VideoFile
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * A video file that represents a DASH stream.

--- a/models/src/main/java/com/vimeo/networking2/FeedItem.kt
+++ b/models/src/main/java/com/vimeo/networking2/FeedItem.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.AttributionType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * An item in the user's feed.

--- a/models/src/main/java/com/vimeo/networking2/FollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/FollowInteraction.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.UpdatableInteraction
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Follow a object.

--- a/models/src/main/java/com/vimeo/networking2/Group.kt
+++ b/models/src/main/java/com/vimeo/networking2/Group.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Entity
 import com.vimeo.networking2.common.Followable
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Group DTO.

--- a/models/src/main/java/com/vimeo/networking2/GroupFollowInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/GroupFollowInteraction.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.common.UpdatableInteraction
 import com.vimeo.networking2.enums.FollowType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Follow a group interaction.

--- a/models/src/main/java/com/vimeo/networking2/HlsVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/HlsVideoFile.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.annotations.Internal
 import com.vimeo.networking2.common.VideoFile
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Video file data.

--- a/models/src/main/java/com/vimeo/networking2/LikeInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/LikeInteraction.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.UpdatableInteraction
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Information on liking a video.

--- a/models/src/main/java/com/vimeo/networking2/Live.kt
+++ b/models/src/main/java/com/vimeo/networking2/Live.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.annotations.Internal
 import com.vimeo.networking2.enums.LiveStatusType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Live video information.

--- a/models/src/main/java/com/vimeo/networking2/Notification.kt
+++ b/models/src/main/java/com/vimeo/networking2/Notification.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.NotificationType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Notification data.

--- a/models/src/main/java/com/vimeo/networking2/NotificationSubscriptions.kt
+++ b/models/src/main/java/com/vimeo/networking2/NotificationSubscriptions.kt
@@ -3,7 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * A collection of push notifications the user is subscribed to.

--- a/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
@@ -9,7 +9,7 @@ import com.vimeo.networking2.enums.VideoQualityType
 import com.vimeo.networking2.enums.VideoSourceType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * The representation of a video file that could be one of a number of types.

--- a/models/src/main/java/com/vimeo/networking2/Publish.kt
+++ b/models/src/main/java/com/vimeo/networking2/Publish.kt
@@ -3,7 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * [TvodItem] publish information.

--- a/models/src/main/java/com/vimeo/networking2/PublishJob.kt
+++ b/models/src/main/java/com/vimeo/networking2/PublishJob.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Entity
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * A representation of the status of any attempts to upload/post a video to a

--- a/models/src/main/java/com/vimeo/networking2/RentInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/RentInteraction.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.annotations.Internal
 import com.vimeo.networking2.enums.StreamAccessType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * The Rent interaction for an On Demand video.

--- a/models/src/main/java/com/vimeo/networking2/SubscriptionInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/SubscriptionInteraction.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.annotations.Internal
 import com.vimeo.networking2.enums.StreamAccessType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Information on the subscription video action.

--- a/models/src/main/java/com/vimeo/networking2/SubscriptionRenewal.kt
+++ b/models/src/main/java/com/vimeo/networking2/SubscriptionRenewal.kt
@@ -3,7 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Information about the user's next renewal.

--- a/models/src/main/java/com/vimeo/networking2/TextTrack.kt
+++ b/models/src/main/java/com/vimeo/networking2/TextTrack.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.enums.TextTrackType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Information on a text text.

--- a/models/src/main/java/com/vimeo/networking2/User.kt
+++ b/models/src/main/java/com/vimeo/networking2/User.kt
@@ -10,7 +10,7 @@ import com.vimeo.networking2.common.Followable
 import com.vimeo.networking2.enums.ContentFilterType
 import com.vimeo.networking2.enums.asEnumList
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * User information.

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -10,7 +10,7 @@ import com.vimeo.networking2.enums.LicenseType
 import com.vimeo.networking2.enums.VideoStatusType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * Video data.

--- a/models/src/main/java/com/vimeo/networking2/VideoSourceFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoSourceFile.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.enums.VideoQualityType
 import com.vimeo.networking2.enums.VideoSourceType
 import com.vimeo.networking2.enums.asEnum
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * A video file that is a source for a published video.

--- a/models/src/main/java/com/vimeo/networking2/VimeoAccount.kt
+++ b/models/src/main/java/com/vimeo/networking2/VimeoAccount.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
-import java.util.*
+import java.util.Date
 
 /**
  * This class represents an authenticated account with Vimeo. It can be through client credentials

--- a/models/src/main/java/com/vimeo/networking2/WatchLaterInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/WatchLaterInteraction.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.UpdatableInteraction
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * All actions for watch later.

--- a/models/src/main/java/com/vimeo/networking2/WatchedInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/WatchedInteraction.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.UpdatableInteraction
 import java.io.Serializable
-import java.util.*
+import java.util.Date
 
 /**
  * All actions for the watched list for a user.

--- a/models/src/main/java/com/vimeo/networking2/common/UpdatableInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/UpdatableInteraction.kt
@@ -1,6 +1,6 @@
 package com.vimeo.networking2.common
 
-import java.util.*
+import java.util.Date
 
 /**
  * Interactions that update the state of a video, category, channel, etc..

--- a/models/src/main/java/com/vimeo/networking2/common/VideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/VideoFile.kt
@@ -1,6 +1,6 @@
 package com.vimeo.networking2.common
 
-import java.util.*
+import java.util.Date
 
 /**
  * The representation of a file that can be downloaded for playback.


### PR DESCRIPTION

#### Summary
The library (KotlinPoet) that is being used to generate new models doesn’t work with wildcard imports, so removing them is necessary to generate new models.  

We currently only use them for `java.util.Date` so just updated those imports.
