### PR TITLE
Password requirements

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/ErrorCodeType.kt
@@ -103,6 +103,10 @@ enum class ErrorCodeType(override val value: String?) : StringValue {
 
     INVALID_INPUT_PASSWORD_TOO_LONG("3102"),
 
+    INVALID_INPUT_PASSWORD_TOO_COMMON("3127"),
+
+    INVALID_INPUT_PASSWORD_REUSED("3128"),
+
     INVALID_INPUT_NO_NAME("2213"),
 
     INVALID_INPUT_NO_EMAIL("2214"),


### PR DESCRIPTION
# Summary
Password requirements are becoming more strict. As a result, two new error codes have been added:
- `INVALID_INPUT_PASSWORD_TOO_COMMON` - 3127
- `INVALID_INPUT_PASSWORD_REUSED` - 3128