### PR TITLE
Adding InvalidToken error

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/VimeoResponse.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/VimeoResponse.kt
@@ -47,6 +47,20 @@ sealed class VimeoResponse<in T>(open val httpStatusCode: Int) {
         ) : Error("API error: ${reason.errorCode ?: NA}", httpStatusCode)
 
         /**
+         * The Vimeo API returned a fatal error that indicates that the token used to make the request is invalid. The
+         * token should be discarded and a new token should be acquired. Further requests should not be made with the
+         * token.
+         *
+         * @param reason Info on the error.
+         * @param httpStatusCode HTTP status code, [HTTP_NONE] if not applicable or if the error was
+         * created locally.
+         */
+        data class InvalidToken(
+            val reason: ApiError?,
+            override val httpStatusCode: Int
+        ) : Error("Unauthorized error: ${reason?.errorCode ?: NA}", httpStatusCode)
+
+        /**
          * An exception was thrown when making the request, e.g. the internet connection failed and a
          * [java.io.IOException] is thrown. This should only be used if a response was not received from the server. If
          * a response is received from the server, an [Api] should be created instead, or if one cannot be parsed, an


### PR DESCRIPTION
# Summary
In the previous definition of `VimeoError`, an "invalid token" error was defined as an error where a specific header `WWW-Authenticate` was set with value `Bearer error="invalid_token"`. Using this definition was strange considering the available information in the `ApiError`, so when the `VimeoResponse.Error` type was created, the invalid token error was defined as a `VimeoResponse.Error.Api` where the `errorCode` was either 8000 or 8003. However, testing showed that requests to the `/feed` URI with a logged out token would return an 8000 error code under certain circumstances. As a result, this check is not reliable. Instead, I opted to go back to the original error definition and check the headers manually when the response is constructed.

I created a new error type, `VimeoResponse.Error.InvalidToken`, explicitly for an invalid token. Any token used to make a request that results in this response should be discarded.

## Testing
Make a request with an invalid token, verify that an `InvalidToken` response is returned.