### PR TITLE
Changing response type variance

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/VimeoResponse.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/VimeoResponse.kt
@@ -9,7 +9,7 @@ import com.vimeo.networking2.VimeoResponse.Success
  *
  * @param httpStatusCode HTTP status code.
  */
-sealed class VimeoResponse<in T>(open val httpStatusCode: Int) {
+sealed class VimeoResponse<out T>(open val httpStatusCode: Int) {
 
     /**
      * A successful response.


### PR DESCRIPTION
# Summary
The variance of the `VimeoResponse` type was preventing assignment of a created `VimeoResponse.Error` type to the generic `VimeoResponse<T>` type. This was because the variance of the `T` was contravariant, which meant that `T` had to be `T` or a supertype. Since `VimeoResponse.Error` is of the type `Nothing`, a subtype of `T`, we needed to change it to covariant. As a result, this allows easier assignment when constructing instances of the response.

## How to Test
Ensure tests compile.
