### PR TITLE
Add the video status endpoint

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
@@ -1,0 +1,43 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.enums.VideoStateType
+import com.vimeo.networking2.enums.asEnum
+import java.io.Serializable
+
+/**
+ * The current status of the video transcoding process.
+ */
+@JsonClass(generateAdapter = true)
+data class VideoStatus(
+        /**
+         * The current state of the transcoding process.
+         */
+        @Json(name = "state")
+        val state: String? = null,
+
+        /**
+         * The percentage of the transcoding process that is complete.
+         */
+        @Json(name = "progress")
+        val progress: Int? = 0,
+
+        /**
+         * The remaining time in seconds before transcoding is complete.
+         */
+        @Json(name = "time_left")
+        val timeLeft: Long? = 0
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID = -72138L
+    }
+}
+
+/**
+ * @see VideoStatus.state
+ * @see VideoStateType
+ */
+val VideoStatus.videoStateType: VideoStateType
+        get() = state.asEnum(VideoStateType.UNKNOWN)

--- a/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
@@ -21,13 +21,13 @@ data class VideoStatus(
          * The percentage of the transcoding process that is complete.
          */
         @Json(name = "progress")
-        val progress: Int? = 0,
+        val progress: Int? = null,
 
         /**
          * The remaining time in seconds before transcoding is complete.
          */
         @Json(name = "time_left")
-        val timeLeft: Long? = 0
+        val timeLeft: Long? = null
 ) : Serializable {
 
     companion object {

--- a/models/src/main/java/com/vimeo/networking2/enums/VideoStateType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/VideoStateType.kt
@@ -1,0 +1,39 @@
+package com.vimeo.networking2.enums
+
+/**
+ * Video transcoding states.
+ */
+enum class VideoStateType(override val value: String?): StringValue {
+
+    ACTIVE("active"),
+
+    BLOCKED("blocked"),
+
+    EXCEEDS_QUOTA("exceeds_quota"),
+
+    EXCEEDS_TOTAL_CAP("exceeds_total_cap"),
+
+    FAILED("failed"),
+
+    FINISHING("finishing"),
+
+    INTERNAL_ERROR("internal_error"),
+
+    INVALID_FILE("invalid_file"),
+
+    PENDING("pending"),
+
+    READY("ready"),
+
+    RETRIEVED("retrieved"),
+
+    STANDBY("standby"),
+
+    STARTING("starting"),
+
+    UPLOAD_COMPLETE("upload_complete"),
+
+    UPLOAD_INCOMPLETE("upload_incomplete"),
+
+    UNKNOWN("unknown")
+}

--- a/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
@@ -153,7 +153,8 @@ class ModelsTest {
         VimeoAccount::class,
         WatchedInteraction::class,
         WatchLaterInteraction::class,
-        Website::class
+        Website::class,
+        VideoStatus::class
     )
 
     @Test

--- a/models/src/test/java/com/vimeo/networking2/enums/EnumsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/enums/EnumsTest.kt
@@ -51,7 +51,8 @@ class EnumsTest {
             VideoQualityType::class.java,
             VideoSourceType::class.java,
             VideoStatusType::class.java,
-            ViewPrivacyType::class.java
+            ViewPrivacyType::class.java,
+            VideoStateType::class.java
     )
 
     @Test

--- a/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/VimeoService.java
@@ -51,6 +51,7 @@ import com.vimeo.networking2.User;
 import com.vimeo.networking2.UserList;
 import com.vimeo.networking2.Video;
 import com.vimeo.networking2.VideoList;
+import com.vimeo.networking2.VideoStatus;
 import com.vimeo.networking2.VimeoAccount;
 import com.vimeo.networking2.params.BatchPublishToSocialMedia;
 import com.vimeo.networking2.PublishJob;
@@ -465,6 +466,12 @@ public interface VimeoService {
 
     @GET("products")
     Call<ProductList> getProducts(@Header("Authorization") String authHeader);
+
+    @GET
+    Call<VideoStatus> getVideoStatus(@Header("Authorization") String authHeader,
+                                     @Url String uri,
+                                     @QueryMap Map<String, String> options,
+                                     @Header("Cache-Control") String cacheHeaderValue);
     // </editor-fold>
 
     @PUT

--- a/vimeo-networking/src/main/java/com/vimeo/networking/callers/GetRequestCaller.java
+++ b/vimeo-networking/src/main/java/com/vimeo/networking/callers/GetRequestCaller.java
@@ -51,6 +51,7 @@ import com.vimeo.networking2.User;
 import com.vimeo.networking2.UserList;
 import com.vimeo.networking2.Video;
 import com.vimeo.networking2.VideoList;
+import com.vimeo.networking2.VideoStatus;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -549,6 +550,26 @@ public final class GetRequestCaller {
                                           @NotNull String cacheHeader,
                                           @NotNull VimeoService vimeoService) {
                     return vimeoService.getProduct(authHeader, uri, queryMap, cacheHeader);
+                }
+            };
+
+    /**
+     * Used in association with
+     * {@link VimeoClient#getContent(String, CacheControl, Caller, String, Map, String, VimeoCallback)} or
+     * {@link VimeoClient#getContentSync(String, CacheControl, String, Map, String, Caller)}
+     * to get a {@link VideoStatus} response from an API endpoint.
+     */
+    public static final Caller<VideoStatus> VIDEO_STATUS =
+            new Caller<VideoStatus>() {
+
+                @NotNull
+                @Override
+                public Call<VideoStatus> call(@NotNull String authHeader,
+                                          @NotNull String uri,
+                                          @NotNull Map<String, String> queryMap,
+                                          @NotNull String cacheHeader,
+                                          @NotNull VimeoService vimeoService) {
+                    return vimeoService.getVideoStatus(authHeader, uri, queryMap, cacheHeader);
                 }
             };
 


### PR DESCRIPTION
# Summary
Add support the /videos/{id}/status endpoint to the VimeoService

Was added:

- the data class `VideoStatus`
- the enum `VideoStateType`
- the new caller `GetRequestCaller.VIDEO_STATUS`

