### PR TITLE
Vimeo Configuration refactor

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/AccountStore.kt
+++ b/request/src/main/java/com/vimeo/networking2/AccountStore.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2
+
+/**
+ * Interface responsible for handling the creation, deletion, and loading of Vimeo accounts on the client.
+ */
+interface AccountStore {
+    /**
+     * Load an account that has been saved previously. Returns `null` if no account was saved.
+     */
+    fun loadAccount(): VimeoAccount?
+
+    /**
+     * Save the provided account associated with an email.
+     *
+     * @param vimeoAccount The account to save.
+     * @param email The email associated with the account.
+     */
+    fun saveAccount(vimeoAccount: VimeoAccount, email: String)
+
+    /**
+     * Delete the provided account from the store.
+     *
+     * @param vimeoAccount The account to delete.
+     */
+    fun deleteAccount(vimeoAccount: VimeoAccount)
+}

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -246,27 +246,27 @@ data class Configuration(
         /**
          * The default max age of the cache, 2 hours.
          */
-        private const val DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2
+        const val DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2
 
         /**
-         * The default size of the cache, 10 Mib
+         * The default size of the cache, 10 Mib.
          */
-        private const val DEFAULT_CACHE_SIZE = 10L * 1024 * 1024
+        const val DEFAULT_CACHE_SIZE = 10L * 1024 * 1024
 
         /**
          * Default response timeout, 60 seconds.
          */
-        private const val DEFAULT_TIMEOUT = 60
+        const val DEFAULT_TIMEOUT = 60
 
         /**
          * An unspecified user agent.
          */
-        private const val DEFAULT_USER_AGENT = "UNSPECIFIED"
+        const val DEFAULT_USER_AGENT = "UNSPECIFIED"
 
         /**
          * The default base URL for the Vimeo API.
          */
-        private const val DEFAULT_BASE_URL = "https://api.vimeo.com/"
+        const val DEFAULT_BASE_URL = "https://api.vimeo.com/"
     }
 
 }

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -115,14 +115,14 @@ data class Configuration(
         private var cacheMaxAgeSeconds: Int = DEFAULT_CACHE_MAX_AGE
 
         /**
-         * Use a different base URL. Defaults to [DEFAULT_BASE_URL].
+         * Specify a base URL. Defaults to [DEFAULT_BASE_URL].
          *
          * @see Configuration.baseUrl
          */
         fun withBaseUrl(baseUrl: String) = apply { this.baseUrl = baseUrl }
 
         /**
-         * Use a different code grant redirect. Defaults to `vimeo{clientId}://auth`.
+         * Specify a code grant redirect. Defaults to `vimeo{clientId}://auth`.
          *
          * @see Configuration.codeGrantRedirectUri
          */
@@ -131,21 +131,21 @@ data class Configuration(
         }
 
         /**
-         * Use a different set of locales. Defaults to a list containing [Locale.US].
+         * Specify a set of locales. Defaults to a list containing [Locale.US].
          *
          * @see Configuration.locales
          */
         fun withLocales(locales: List<Locale>) = apply { this.locales = locales }
 
         /**
-         * Use a different store. Defaults to [InMemoryAccountStore].
+         * Specify a store. Defaults to [InMemoryAccountStore].
          *
          * @see Configuration.locales
          */
         fun withAccountStore(accountStore: AccountStore) = apply { this.accountStore = accountStore }
 
         /**
-         * Use a different set of network request interceptors. Defaults to none.
+         * Specify a set of network request interceptors. Defaults to none.
          *
          * @see Configuration.networkInterceptors
          */
@@ -154,21 +154,21 @@ data class Configuration(
         }
 
         /**
-         * Use a different set of regular interceptors. Defaults to none.
+         * Specify a set of application interceptors. Defaults to none.
          *
          * @see Configuration.interceptors
          */
         fun withInterceptors(interceptors: List<Interceptor>) = apply { this.interceptors = interceptors }
 
         /**
-         * Use a different supplemental user agent. Defaults to [DEFAULT_USER_AGENT].
+         * Specify a supplemental user agent. Defaults to [DEFAULT_USER_AGENT].
          *
          * @see Configuration.userAgent
          */
         fun withUserAgent(userAgent: String) = apply { this.userAgent = userAgent }
 
         /**
-         * Use a different request time out. Defaults to [DEFAULT_TIMEOUT].
+         * Specify a request time out. Defaults to [DEFAULT_TIMEOUT].
          *
          * @see Configuration.requestTimeoutSeconds
          */
@@ -184,36 +184,35 @@ data class Configuration(
         fun withCertPinning(certPinningEnabled: Boolean) = apply { this.isCertPinningEnabled = certPinningEnabled }
 
         /**
-         * Use a different log delegate, or none at all. Defaults to [DefaultLogDelegate] which logs to the system
-         * output.
+         * Specify a log delegate, or none at all. Defaults to [DefaultLogDelegate] which logs to the system output.
          *
          * @see Configuration.logDelegate
          */
         fun withLogDelegate(logDelegate: LogDelegate?) = apply { this.logDelegate = logDelegate }
 
         /**
-         * Use a different log level. Defaults to [LogDelegate.Level.DEBUG].
+         * Specify a log level. Defaults to [LogDelegate.Level.DEBUG].
          *
          * @see Configuration.logLevel
          */
         fun withLogLevel(logLevel: LogDelegate.Level) = apply { this.logLevel = logLevel }
 
         /**
-         * Use a different cache directory. Defaults to no cache.
+         * Specify a cache directory. Defaults to no cache.
          *
          * @see Configuration.cacheDirectory
          */
         fun withCacheDirectory(cacheDirectory: File) = apply { this.cacheDirectory = cacheDirectory }
 
         /**
-         * Use a different maximum cache size. Defaults to [DEFAULT_CACHE_SIZE].
+         * Specify a maximum cache size. Defaults to [DEFAULT_CACHE_SIZE].
          *
          * @see Configuration.cacheMaxSizeBytes
          */
         fun withCacheMaxSizeBytes(cacheMaxSizeBytes: Long) = apply { this.cacheMaxSizeBytes = cacheMaxSizeBytes }
 
         /**
-         * Use a different maximum cache age. Defaults to [DEFAULT_CACHE_MAX_AGE].
+         * Specify a maximum cache age. Defaults to [DEFAULT_CACHE_MAX_AGE].
          *
          * @see Configuration.cacheMaxAgeSeconds
          */

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.vimeo.networking2
 
 import com.vimeo.networking2.logging.LogDelegate

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -108,7 +108,7 @@ data class Configuration(
         private var isCertPinningEnabled: Boolean = true
 
         private var logDelegate: LogDelegate? = DefaultLogDelegate()
-        private var logLevel: LogDelegate.Level = LogDelegate.Level.DEBUG
+        private var logLevel: LogDelegate.Level = LogDelegate.Level.NONE
 
         private var cacheDirectory: File? = null
         private var cacheMaxSizeBytes: Long = DEFAULT_CACHE_SIZE
@@ -191,7 +191,7 @@ data class Configuration(
         fun withLogDelegate(logDelegate: LogDelegate?) = apply { this.logDelegate = logDelegate }
 
         /**
-         * Specify a log level. Defaults to [LogDelegate.Level.DEBUG].
+         * Specify a log level. Defaults to [LogDelegate.Level.NONE], which never logs.
          *
          * @see Configuration.logLevel
          */

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -38,8 +38,10 @@ import java.util.Locale
  * @param locales A list of locales which the API should use to localize responses. Locales are prioritized based on
  * index.
  * @param accountStore The store used to remember authenticated accounts.
- * @param networkInterceptors The interceptors that should be attached to network requests.
- * @param interceptors The interceptors that should be attached to all requests.
+ * @param networkInterceptors The interceptors that should be attached to network requests. See
+ * [https://square.github.io/okhttp/interceptors/].
+ * @param interceptors The interceptors that should be attached to all requests. See
+ * [https://square.github.io/okhttp/interceptors/].
  * @param userAgent The supplemental user agent string which will be added to the internal user agent, identifying the
  * client.
  * @param requestTimeoutSeconds The maximum number of seconds a request will wait to complete before timing out.
@@ -72,7 +74,7 @@ data class Configuration(
 
     val isCertPinningEnabled: Boolean,
 
-    val logDelegate: LogDelegate,
+    val logDelegate: LogDelegate?,
     val logLevel: LogDelegate.Level,
 
     val cacheDirectory: File?,
@@ -83,14 +85,14 @@ data class Configuration(
     /**
      * The builder for the [Configuration].
      *
-     * @param clientID The Vimeo API client ID, required to construct an instance.
+     * @param clientId The Vimeo API client ID, required to construct an instance.
      * @param clientSecret The Vimeo API client secret, required to construct an instance.
      * @param scope The permission scopes requested by the client, required to construct an instance.
      */
-    class Builder(private val clientID: String, private val clientSecret: String, private val scope: Scopes) {
+    class Builder(private val clientId: String, private val clientSecret: String, private val scope: Scopes) {
         private var baseUrl: String = DEFAULT_BASE_URL
 
-        private var codeGrantRedirectUrl: String = "vimeo$clientID://auth"
+        private var codeGrantRedirectUrl: String = "vimeo$clientId://auth"
 
         private var locales: List<Locale> = listOf(Locale.US)
 
@@ -105,7 +107,7 @@ data class Configuration(
 
         private var isCertPinningEnabled: Boolean = true
 
-        private var logDelegate: LogDelegate = DefaultLogDelegate()
+        private var logDelegate: LogDelegate? = DefaultLogDelegate()
         private var logLevel: LogDelegate.Level = LogDelegate.Level.DEBUG
 
         private var cacheDirectory: File? = null
@@ -182,11 +184,12 @@ data class Configuration(
         fun withCertPinning(certPinningEnabled: Boolean) = apply { this.isCertPinningEnabled = certPinningEnabled }
 
         /**
-         * Use a different log delegate. Defaults to [DefaultLogDelegate] which logs to the system output.
+         * Use a different log delegate, or none at all. Defaults to [DefaultLogDelegate] which logs to the system
+         * output.
          *
          * @see Configuration.logDelegate
          */
-        fun withLogDelegate(logDelegate: LogDelegate) = apply { this.logDelegate = logDelegate }
+        fun withLogDelegate(logDelegate: LogDelegate?) = apply { this.logDelegate = logDelegate }
 
         /**
          * Use a different log level. Defaults to [LogDelegate.Level.DEBUG].
@@ -221,7 +224,7 @@ data class Configuration(
          */
         fun build(): Configuration = Configuration(
             baseUrl = baseUrl,
-            clientId = clientID,
+            clientId = clientId,
             clientSecret = clientSecret,
             scope = scope,
             codeGrantRedirectUri = codeGrantRedirectUrl,

--- a/request/src/main/java/com/vimeo/networking2/Configuration.kt
+++ b/request/src/main/java/com/vimeo/networking2/Configuration.kt
@@ -1,0 +1,249 @@
+package com.vimeo.networking2
+
+import com.vimeo.networking2.logging.LogDelegate
+import com.vimeo.networking2.logging.DefaultLogDelegate
+import okhttp3.Interceptor
+import java.io.File
+import java.util.Locale
+
+/**
+ * The configuration for the client.
+ *
+ * @param baseUrl The base API URL to which all requests will be made.
+ * @param clientId The Vimeo API ID of the client application.
+ * @param clientSecret The Vimeo API secret of the client application.
+ * @param scope The [Scopes] required by the client application.
+ * @param codeGrantRedirectUri The code grant redirect used for OAuth.
+ * @param locales A list of locales which the API should use to localize responses. Locales are prioritized based on
+ * index.
+ * @param accountStore The store used to remember authenticated accounts.
+ * @param networkInterceptors The interceptors that should be attached to network requests.
+ * @param interceptors The interceptors that should be attached to all requests.
+ * @param userAgent The supplemental user agent string which will be added to the internal user agent, identifying the
+ * client.
+ * @param requestTimeoutSeconds The maximum number of seconds a request will wait to complete before timing out.
+ * @param isCertPinningEnabled True if the library should pin certificates, false otherwise. Note: should be turned off
+ * when debugging.
+ * @param logDelegate The instance to which logging will be delegated.
+ * @param logLevel The level of logging which will be performed by the library.
+ * @param cacheDirectory The optional directory in which requests will be cached.
+ * @param cacheMaxSizeBytes The maximum size of the cache, if one was provided.
+ * @param cacheMaxAgeSeconds The maximum age of items in the cache, if one was provided.
+ */
+data class Configuration(
+    val baseUrl: String,
+
+    val clientId: String,
+    val clientSecret: String,
+    val scope: Scopes,
+    val codeGrantRedirectUri: String,
+
+    val locales: List<Locale>,
+
+    val accountStore: AccountStore,
+
+    val networkInterceptors: List<Interceptor>,
+    val interceptors: List<Interceptor>,
+
+    val userAgent: String,
+
+    val requestTimeoutSeconds: Int,
+
+    val isCertPinningEnabled: Boolean,
+
+    val logDelegate: LogDelegate,
+    val logLevel: LogDelegate.Level,
+
+    val cacheDirectory: File?,
+    val cacheMaxSizeBytes: Long,
+    val cacheMaxAgeSeconds: Int
+) {
+
+    /**
+     * The builder for the [Configuration].
+     *
+     * @param clientID The Vimeo API client ID, required to construct an instance.
+     * @param clientSecret The Vimeo API client secret, required to construct an instance.
+     * @param scope The permission scopes requested by the client, required to construct an instance.
+     */
+    class Builder(private val clientID: String, private val clientSecret: String, private val scope: Scopes) {
+        private var baseUrl: String = DEFAULT_BASE_URL
+
+        private var codeGrantRedirectUrl: String = "vimeo$clientID://auth"
+
+        private var locales: List<Locale> = listOf(Locale.US)
+
+        private var accountStore: AccountStore = InMemoryAccountStore()
+
+        private var networkInterceptors: List<Interceptor> = emptyList()
+        private var interceptors: List<Interceptor> = emptyList()
+
+        private var userAgent: String = DEFAULT_USER_AGENT
+
+        private var requestTimeoutSeconds: Int = DEFAULT_TIMEOUT
+
+        private var isCertPinningEnabled: Boolean = true
+
+        private var logDelegate: LogDelegate = DefaultLogDelegate()
+        private var logLevel: LogDelegate.Level = LogDelegate.Level.DEBUG
+
+        private var cacheDirectory: File? = null
+        private var cacheMaxSizeBytes: Long = DEFAULT_CACHE_SIZE
+        private var cacheMaxAgeSeconds: Int = DEFAULT_CACHE_MAX_AGE
+
+        /**
+         * Use a different base URL. Defaults to [DEFAULT_BASE_URL].
+         *
+         * @see Configuration.baseUrl
+         */
+        fun withBaseUrl(baseUrl: String) = apply { this.baseUrl = baseUrl }
+
+        /**
+         * Use a different code grant redirect. Defaults to `vimeo{clientId}://auth`.
+         *
+         * @see Configuration.codeGrantRedirectUri
+         */
+        fun withCodeGrantRedirectUrl(codeGrantRedirectUrl: String) = apply {
+            this.codeGrantRedirectUrl = codeGrantRedirectUrl
+        }
+
+        /**
+         * Use a different set of locales. Defaults to a list containing [Locale.US].
+         *
+         * @see Configuration.locales
+         */
+        fun withLocales(locales: List<Locale>) = apply { this.locales = locales }
+
+        /**
+         * Use a different store. Defaults to [InMemoryAccountStore].
+         *
+         * @see Configuration.locales
+         */
+        fun withAccountStore(accountStore: AccountStore) = apply { this.accountStore = accountStore }
+
+        /**
+         * Use a different set of network request interceptors. Defaults to none.
+         *
+         * @see Configuration.networkInterceptors
+         */
+        fun withNetworkInterceptors(networkInterceptors: List<Interceptor>) = apply {
+            this.networkInterceptors = networkInterceptors
+        }
+
+        /**
+         * Use a different set of regular interceptors. Defaults to none.
+         *
+         * @see Configuration.interceptors
+         */
+        fun withInterceptors(interceptors: List<Interceptor>) = apply { this.interceptors = interceptors }
+
+        /**
+         * Use a different supplemental user agent. Defaults to [DEFAULT_USER_AGENT].
+         *
+         * @see Configuration.userAgent
+         */
+        fun withUserAgent(userAgent: String) = apply { this.userAgent = userAgent }
+
+        /**
+         * Use a different request time out. Defaults to [DEFAULT_TIMEOUT].
+         *
+         * @see Configuration.requestTimeoutSeconds
+         */
+        fun withRequestTimeout(requestTimeoutSeconds: Int) = apply {
+            this.requestTimeoutSeconds = requestTimeoutSeconds
+        }
+
+        /**
+         * Enable or disable certificate pinning. Defaults to true.
+         *
+         * @see Configuration.isCertPinningEnabled
+         */
+        fun withCertPinning(certPinningEnabled: Boolean) = apply { this.isCertPinningEnabled = certPinningEnabled }
+
+        /**
+         * Use a different log delegate. Defaults to [DefaultLogDelegate] which logs to the system output.
+         *
+         * @see Configuration.logDelegate
+         */
+        fun withLogDelegate(logDelegate: LogDelegate) = apply { this.logDelegate = logDelegate }
+
+        /**
+         * Use a different log level. Defaults to [LogDelegate.Level.DEBUG].
+         *
+         * @see Configuration.logLevel
+         */
+        fun withLogLevel(logLevel: LogDelegate.Level) = apply { this.logLevel = logLevel }
+
+        /**
+         * Use a different cache directory. Defaults to no cache.
+         *
+         * @see Configuration.cacheDirectory
+         */
+        fun withCacheDirectory(cacheDirectory: File) = apply { this.cacheDirectory = cacheDirectory }
+
+        /**
+         * Use a different maximum cache size. Defaults to [DEFAULT_CACHE_SIZE].
+         *
+         * @see Configuration.cacheMaxSizeBytes
+         */
+        fun withCacheMaxSizeBytes(cacheMaxSizeBytes: Long) = apply { this.cacheMaxSizeBytes = cacheMaxSizeBytes }
+
+        /**
+         * Use a different maximum cache age. Defaults to [DEFAULT_CACHE_MAX_AGE].
+         *
+         * @see Configuration.cacheMaxAgeSeconds
+         */
+        fun withCacheMaxAgeSeconds(cacheMaxAgeSeconds: Int) = apply { this.cacheMaxAgeSeconds = cacheMaxAgeSeconds }
+
+        /**
+         * Build the configuration instance using the chosen modifications and unspecified default values.
+         */
+        fun build(): Configuration = Configuration(
+            baseUrl = baseUrl,
+            clientId = clientID,
+            clientSecret = clientSecret,
+            scope = scope,
+            codeGrantRedirectUri = codeGrantRedirectUrl,
+            locales = locales,
+            accountStore = accountStore,
+            networkInterceptors = networkInterceptors,
+            interceptors = interceptors,
+            userAgent = userAgent,
+            requestTimeoutSeconds = requestTimeoutSeconds,
+            isCertPinningEnabled = isCertPinningEnabled,
+            logDelegate = logDelegate,
+            logLevel = logLevel,
+            cacheDirectory = cacheDirectory,
+            cacheMaxSizeBytes = cacheMaxSizeBytes,
+            cacheMaxAgeSeconds = cacheMaxAgeSeconds
+        )
+    }
+
+    companion object {
+        /**
+         * The default max age of the cache, 2 hours.
+         */
+        private const val DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2
+
+        /**
+         * The default size of the cache, 10 Mib
+         */
+        private const val DEFAULT_CACHE_SIZE = 10L * 1024 * 1024
+
+        /**
+         * Default response timeout, 60 seconds.
+         */
+        private const val DEFAULT_TIMEOUT = 60
+
+        /**
+         * An unspecified user agent.
+         */
+        private const val DEFAULT_USER_AGENT = "UNSPECIFIED"
+
+        /**
+         * The default base URL for the Vimeo API.
+         */
+        private const val DEFAULT_BASE_URL = "https://api.vimeo.com/"
+    }
+
+}

--- a/request/src/main/java/com/vimeo/networking2/InMemoryAccountStore.kt
+++ b/request/src/main/java/com/vimeo/networking2/InMemoryAccountStore.kt
@@ -1,0 +1,18 @@
+package com.vimeo.networking2
+
+/**
+ * An account store that just holds the accounts in memory.
+ */
+class InMemoryAccountStore : AccountStore {
+    private var vimeoAccount: VimeoAccount? = null
+
+    override fun loadAccount(): VimeoAccount? = vimeoAccount
+
+    override fun saveAccount(vimeoAccount: VimeoAccount, email: String) {
+        this.vimeoAccount = vimeoAccount
+    }
+
+    override fun deleteAccount(vimeoAccount: VimeoAccount) {
+        this.vimeoAccount = null
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/InMemoryAccountStore.kt
+++ b/request/src/main/java/com/vimeo/networking2/InMemoryAccountStore.kt
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.vimeo.networking2
 
 /**

--- a/request/src/main/java/com/vimeo/networking2/interceptors/AcceptHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/AcceptHeaderInterceptor.kt
@@ -28,7 +28,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 
 /**
- * Add custom `Accept` header to all requests.
+ * Add a custom `Accept` header to all requests.
  */
 class AcceptHeaderInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response = chain.proceed(

--- a/request/src/main/java/com/vimeo/networking2/interceptors/AcceptHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/AcceptHeaderInterceptor.kt
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.interceptors
+
+import com.vimeo.networking2.ApiConstants
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Add custom `Accept` header to all requests.
+ */
+class AcceptHeaderInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response = chain.proceed(
+        chain.request().newBuilder().header(HEADER_ACCEPT, HEADER_ACCEPT_VALUE).build())
+
+    companion object {
+        private const val HEADER_ACCEPT = "Accept"
+        private const val HEADER_ACCEPT_VALUE: String =
+                "application/vnd.vimeo.*+json; version=${ApiConstants.API_VERSION}"
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/interceptors/CacheControlHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/CacheControlHeaderInterceptor.kt
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.interceptors
+
+import com.vimeo.networking2.Configuration
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Rewrite the server's cache-control header because our server sets all `Cache-Control` headers to `no-store`. To get
+ * data from the cache, we set a max age to [Configuration.cacheMaxAgeSeconds]. This prevents OkHttp from throwing a 504
+ * exception. API no longer sends a max age in the header. OkHttp determines the cache to be invalid. This is a work
+ * around for this issue.
+ */
+class CacheControlHeaderInterceptor(private val mMaxAge: Int) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response =
+            chain.proceed(chain.request())
+                    .newBuilder()
+                    .header(HEADER_CACHE_CONTROL, "$HEADER_CACHE_PUBLIC, max-age=$mMaxAge")
+                    .build()
+
+    companion object {
+        private const val HEADER_CACHE_CONTROL = "Cache-Control"
+        private const val HEADER_CACHE_PUBLIC = "public"
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/interceptors/CacheControlHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/CacheControlHeaderInterceptor.kt
@@ -29,15 +29,17 @@ import okhttp3.Response
 
 /**
  * Rewrite the server's cache-control header because our server sets all `Cache-Control` headers to `no-store`. To get
- * data from the cache, we set a max age to [Configuration.cacheMaxAgeSeconds]. This prevents OkHttp from throwing a 504
- * exception. API no longer sends a max age in the header. OkHttp determines the cache to be invalid. This is a work
- * around for this issue.
+ * data from the cache, we set a max age to [Configuration.cacheMaxAgeSeconds]. Normally the API indicates that the
+ * contents should not be cached. Since most clients want common requests to be available via cache for performance
+ * reasons, we overwrite this behavior and set our own [maxAgeSeconds] expiration.
+ *
+ * @param maxAgeSeconds The max age of the cache before expiration in seconds.
  */
-class CacheControlHeaderInterceptor(private val mMaxAge: Int) : Interceptor {
+class CacheControlHeaderInterceptor(private val maxAgeSeconds: Int) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response =
             chain.proceed(chain.request())
                     .newBuilder()
-                    .header(HEADER_CACHE_CONTROL, "$HEADER_CACHE_PUBLIC, max-age=$mMaxAge")
+                    .header(HEADER_CACHE_CONTROL, "$HEADER_CACHE_PUBLIC, max-age=$maxAgeSeconds")
                     .build()
 
     companion object {

--- a/request/src/main/java/com/vimeo/networking2/interceptors/LanguageHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/LanguageHeaderInterceptor.kt
@@ -28,7 +28,10 @@ import okhttp3.Response
 import java.util.Locale
 
 /**
- * Add custom `Accept-Language` header to all requests.
+ * Add a custom `Accept-Language` header to all requests.
+ *
+ * @param locales The list of locales that should be supported, shouldn't be empty as this may result in undefined
+ * behavior of the API.
  */
 class LanguageHeaderInterceptor(locales: List<Locale>) : Interceptor {
     private val validLocales: String = locales.joinToString(separator = ",", transform = Locale::getLanguage)

--- a/request/src/main/java/com/vimeo/networking2/interceptors/LanguageHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/LanguageHeaderInterceptor.kt
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.Locale
+
+/**
+ * Add custom `Accept-Language` header to all requests.
+ */
+class LanguageHeaderInterceptor(locales: List<Locale>) : Interceptor {
+    private val validLocales: String = locales.joinToString(separator = ",", transform = Locale::getLanguage)
+
+    override fun intercept(chain: Interceptor.Chain): Response =
+            chain.proceed(
+                chain.request().newBuilder().header(
+                    HEADER_ACCEPT_LANGUAGE,
+                    validLocales
+                ).build()
+            )
+
+    companion object {
+        private const val HEADER_ACCEPT_LANGUAGE = "Accept-Language"
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/interceptors/UserAgentHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/UserAgentHeaderInterceptor.kt
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Add custom `User-Agent` header to all requests.
+ */
+class UserAgentHeaderInterceptor(private val userAgent: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response =
+            chain.proceed(chain.request().newBuilder().header(HEADER_USER_AGENT, userAgent).build())
+
+    companion object {
+        private const val HEADER_USER_AGENT = "User-Agent"
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/interceptors/UserAgentHeaderInterceptor.kt
+++ b/request/src/main/java/com/vimeo/networking2/interceptors/UserAgentHeaderInterceptor.kt
@@ -27,7 +27,9 @@ import okhttp3.Interceptor
 import okhttp3.Response
 
 /**
- * Add custom `User-Agent` header to all requests.
+ * Add a custom `User-Agent` header to all requests.
+ *
+ * @param userAgent The user agent that should be sent with every request.
  */
 class UserAgentHeaderInterceptor(private val userAgent: String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response =

--- a/request/src/main/java/com/vimeo/networking2/logging/DefaultLogDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/logging/DefaultLogDelegate.kt
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020 Vimeo (https://vimeo.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.vimeo.networking2.logging
 
 /**

--- a/request/src/main/java/com/vimeo/networking2/logging/DefaultLogDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/logging/DefaultLogDelegate.kt
@@ -1,0 +1,18 @@
+package com.vimeo.networking2.logging
+
+/**
+ * Default log delegate that logs to the system output.
+ */
+@Suppress("FunctionMinLength")
+internal class DefaultLogDelegate : LogDelegate {
+    override fun e(error: String) = println(error)
+
+    override fun e(error: String, exception: Exception) {
+        println(error)
+        exception.printStackTrace()
+    }
+
+    override fun d(message: String) = println(message)
+
+    override fun v(message: String) = println(message)
+}

--- a/request/src/main/java/com/vimeo/networking2/logging/LogDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/logging/LogDelegate.kt
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.logging
+
+/**
+ * A logger interface for the networking library.
+ */
+@Suppress("FunctionMinLength")
+interface LogDelegate {
+    /**
+     * Log an error.
+     *
+     * @param error A description of the error that occurred.
+     */
+    fun e(error: String)
+
+    /**
+     * Log an error.
+     *
+     * @param error A description of the error that occurred.
+     * @param exception The exception that caused the error.
+     */
+    fun e(error: String, exception: Exception)
+
+    /**
+     * Log a debug level message.
+     *
+     * @param message The message to be logged.
+     */
+    fun d(message: String)
+
+    /**
+     * Log a verbose level message.
+     *
+     * @param message The message to be logged.
+     */
+    fun v(message: String)
+
+    /**
+     * The level of logging to be performed.
+     *
+     * @param level The log level represented as an integer.
+     */
+    @Suppress("MagicNumber")
+    enum class Level(val level: Int) {
+        VERBOSE(0),
+        DEBUG(1),
+        ERROR(2),
+        NONE(3)
+    }
+}

--- a/request/src/main/java/com/vimeo/networking2/logging/VimeoLogger.kt
+++ b/request/src/main/java/com/vimeo/networking2/logging/VimeoLogger.kt
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Vimeo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.networking2.logging
+
+/**
+ * Internal logger that delegates to a [LogDelegate] based on the desired [LogDelegate.Level].
+ *
+ * @param logDelegate The class to which the logging implementation will be delegated. Default is no implementation.
+ * @param logLevel The level of logs that should be sent. Default is no logs.
+ */
+@Suppress("FunctionMinLength")
+internal class VimeoLogger(
+    private val logDelegate: LogDelegate? = null,
+    private val logLevel: LogDelegate.Level = LogDelegate.Level.NONE
+) : LogDelegate {
+
+    override fun e(error: String) {
+        if (logLevel.level <= LogDelegate.Level.ERROR.level) {
+            logDelegate?.e(error)
+        }
+    }
+
+    override fun e(error: String, exception: Exception) {
+        if (logLevel.level <= LogDelegate.Level.ERROR.level) {
+            logDelegate?.e(error, exception)
+        }
+    }
+
+    override fun d(message: String) {
+        if (logLevel.level <= LogDelegate.Level.DEBUG.level) {
+            logDelegate?.d(message)
+        }
+    }
+
+    override fun v(message: String) {
+        if (logLevel.level <= LogDelegate.Level.VERBOSE.level) {
+            logDelegate?.v(message)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
In this PR, I rewrote the `Configuration` class and its builder, and converted a few classes to Kotlin in order to support this refactor. All new classes live in the `request` module at the moment.

In this PR, I created
- `Configuration`
- `Configuration.Builder`
- `AccountStore` - converted from Kotlin
- `InMemoryAccountStore` - default implementation of `AccountStore`
- `AcceptHeaderInterceptor` - converted from Kotlin
- `CacheControlHeaderInterceptor` - converted from Kotlin
- `LanguageHeaderInterceptor` - converted from Kotlin
- `UserAgentHeaderInterceptor` - converted from Kotlin
- `LogDelegate` - replaces `LogProvider`
- `LogDelegate.Level` - replaces `LogLevel`
- `VimeoLogger` - replaces `ClientLogger`
- `DefaultLogDelegate` - replaces default behavior of `ClientLogger` when no `LogProvider` is specified

There are a couple differences with the new `Configuration`. 
- We now supply a default `AccountStore`.
- We now explicitly supply a default `LogDelegate` instead of implicitly logging if no provider was specified.
- We no longer allow a `Configuration` to be constructed using an access token. ID, secret, and scope are now always required.