### PR TITLE
adding user role

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/Team.kt
+++ b/models/src/main/java/com/vimeo/networking2/Team.kt
@@ -35,6 +35,12 @@ data class Team(
     val owner: User? = null,
 
     /**
+     * A translated name of the logged in user's role on the team.
+     */
+    @Json(name = "user_role")
+    val userRole: String? = null,
+
+    /**
      * Whether or not the team has content shared with any team members yet.
      */
     @Json(name = "has_content_shared")


### PR DESCRIPTION
#### Issue
The API team just added a necessary user_role field to a team with a localized string describing the logged in user's role.

#### Summary
Added the `userRole` to `Team`.
