### PR TITLE
Add capability to clear the cache for a specific URI to the library

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -83,6 +83,21 @@ object RetrofitSetupModule {
     }
 
     /**
+     * Clear the request cache entry associated with the [VimeoApiConfiguration] and the provided [uri].
+     */
+    @JvmStatic
+    fun clearRequestCacheForUri(vimeoApiConfiguration: VimeoApiConfiguration, uri: String) {
+        val cache = vimeoApiConfiguration.cache ?: return
+
+        val urlIterator = cache.urls()
+        while (urlIterator.hasNext()) {
+            if (urlIterator.next().endsWith(uri)) {
+                urlIterator.remove()
+            }
+        }
+    }
+
+    /**
      * Create [OkHttpClient] with interceptors and timeoutSeconds configurations.
      */
     private fun okHttpClient(

--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -33,6 +33,7 @@ import com.vimeo.networking2.internal.params.StringValueJsonAdapterFactory
 import com.vimeo.networking2.internal.params.VimeoParametersConverterFactory
 import com.vimeo.networking2.logging.VimeoLogger
 import okhttp3.CertificatePinner
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -89,9 +90,17 @@ object RetrofitSetupModule {
     fun clearRequestCacheForUri(vimeoApiConfiguration: VimeoApiConfiguration, uri: String) {
         val cache = vimeoApiConfiguration.cache ?: return
 
+        val url = requireNotNull(HttpUrl.parse(vimeoApiConfiguration.baseUrl)) {
+            "VimeoApiConfiguration.baseUrl must be valid"
+        }
+            .newBuilder()
+            .encodedPath(uri)
+            .build()
+            .toString()
+
         val urlIterator = cache.urls()
         while (urlIterator.hasNext()) {
-            if (urlIterator.next().endsWith(uri)) {
+            if (urlIterator.next().startsWith(url)) {
                 urlIterator.remove()
             }
         }

--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -85,6 +85,9 @@ object RetrofitSetupModule {
 
     /**
      * Clear the request cache entry associated with the [VimeoApiConfiguration] and the provided [uri].
+     *
+     * For example, if the [VimeoApiConfiguration.baseUrl] is set to `https://api.vimeo.com`, and the [uri]
+     * provided is `/users/12345`, then the cache will be cleared for `https://api.vimeo.com/users/12345`.
      */
     @JvmStatic
     fun clearRequestCacheForUri(vimeoApiConfiguration: VimeoApiConfiguration, uri: String) {

--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -86,8 +86,12 @@ object RetrofitSetupModule {
     /**
      * Clear the request cache entry associated with the [VimeoApiConfiguration] and the provided [uri].
      *
-     * For example, if the [VimeoApiConfiguration.baseUrl] is set to `https://api.vimeo.com`, and the [uri]
-     * provided is `/users/12345`, then the cache will be cleared for `https://api.vimeo.com/users/12345`.
+     * For example, if the [VimeoApiConfiguration.baseUrl] is set to `https://api.vimeo.com`, and the [uri] provided is
+     * `/users/12345`, then the cache will be cleared for `https://api.vimeo.com/users/12345`.
+     *
+     * @param vimeoApiConfiguration The configuration, used to initialize the library, containing the cache that will be
+     * partially cleared.
+     * @param uri The URI for which the cache response should be cleared.
      */
     @JvmStatic
     fun clearRequestCacheForUri(vimeoApiConfiguration: VimeoApiConfiguration, uri: String) {


### PR DESCRIPTION
# Summary
We want to be able to invalidate the cache on a granular level. This means we want to be able to invalidate the cache on a per URI bases. This PR adds that capability to the `RetrofitSetupModule`.

It adds the `clearRequestCacheForUri` function which takes the `VimeoApiConfiguration` instance used to initialize the library and the `uri` for which the library will be cleared. For example, providing `/user/12345` as the URI will clear the cache for `https://api.vimeo.com/user/12345`.