### PR TITLE
Fix bug where videos over ~2GB could not be uploaded

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/Gcs.kt
+++ b/models/src/main/java/com/vimeo/networking2/Gcs.kt
@@ -16,14 +16,14 @@ data class Gcs(
      */
     @Internal
     @Json(name = "end_byte")
-    val endByte: Int? = null,
+    val endByte: Long? = null,
 
     /**
      * Expected starting byte size for the current upload_link.
      */
     @Internal
     @Json(name = "start_byte")
-    val startByte: Int? = null,
+    val startByte: Long? = null,
 
     /**
      * Link for uploading file chunk to.


### PR DESCRIPTION
# Summary
There is an issue with the `Gcs` DTO where the `endBytes` type was `Int` instead of `Long`. As a result, only videos up to `Int.MAX` size could be uploaded. The fix is to change the type of the property to `Long`. I also changed the start property to `Long` as well for consistency and in case an upload offset was used greater than `Int.MAX` bytes.