### PR TITLE
Avoid allowing empty URI in cache clear function

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -91,10 +91,12 @@ object RetrofitSetupModule {
      *
      * @param vimeoApiConfiguration The configuration, used to initialize the library, containing the cache that will be
      * partially cleared.
-     * @param uri The URI for which the cache response should be cleared.
+     * @param uri The URI for which the cache response should be cleared. If it is blank or empty, this function will
+     * no-op.
      */
     @JvmStatic
     fun clearRequestCacheForUri(vimeoApiConfiguration: VimeoApiConfiguration, uri: String) {
+        val safeUri = uri.takeIf { it.isNotBlank() } ?: return
         val cache = vimeoApiConfiguration.cache ?: return
 
         val url = requireNotNull(HttpUrl.parse(vimeoApiConfiguration.baseUrl)) {


### PR DESCRIPTION
# Summary
Trying to call the `clearCacheForUri` function with an empty `String` will result in a crash. This PR checks whether the URI is blank before trying to create the full path that will be cleared. While a blank URI is invalid and the previous behavior of crashing was technically correct, it's easy to accidentally pass an empty `String` here, so it's a quick safeguard to put in place to handle cases where the consumer probably didn't intentionally try to crash the code.