### PR TITLE
Add missing property to the Folder DTO

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/Folder.kt
+++ b/models/src/main/java/com/vimeo/networking2/Folder.kt
@@ -30,6 +30,12 @@ data class Folder(
     val lastUserActionEventDate: Date? = null,
 
     /**
+     * The link to the folder on Vimeo.
+     */
+    @Json(name = "link")
+    val link: String? = null,
+
+    /**
      * The folder's metadata.
      */
     @Json(name = "metadata")


### PR DESCRIPTION
# Summary
The `link` property, which provides the user shareable URL for a `Folder`, was missing from the `Folder` DTO. I believe it was added after we initially created it last year. This PR adds it. I also verified that were were not missing any other properties from `Folder`.