### PR TITLE
Add messaging to the empty URI error to make it more clear what's wrong

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -1130,8 +1130,10 @@ internal class VimeoApiClientImpl(
 
     private fun <T> LocalVimeoCallAdapter.enqueueEmptyUri(callback: VimeoCallback<T>): VimeoRequest {
         return enqueueError(ApiError(
+            developerMessage = "An empty URI was provided",
             invalidParameters = listOf(InvalidParameter(
-                errorCode = ErrorCodeType.INVALID_URI.value
+                errorCode = ErrorCodeType.INVALID_URI.value,
+                developerMessage = "An empty URI was provided"
             ))
         ), callback)
     }


### PR DESCRIPTION
# Summary
It's not very clear what's wrong when you provide an empty URI when making a request. While the error code is provided, it is easy to overlook. It is also easy to provide an empty URI without meaning to by using one of the `VimeoApiClient` functions that accepts a DTO instead of a URI. Adding a developer message to the error makes it more clear what is wrong.