### PR TITLE
Downgrade to Kotlin 1.3.72

### DIFF
--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     api "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     // Moshi Adapters
     implementation "com.squareup.moshi:moshi-adapters:$moshiVersion"
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -9,6 +9,9 @@ repositories {
 dependencies {
     api project(':api-core')
     compileOnly project(':models')
+    
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileKotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
@@ -18,8 +18,8 @@ plugins {
 
 ext {
     retrofitVersion = '2.9.0'
-    okioVersion =  '2.10.0'
-    moshiVersion = '1.11.0'
+    okioVersion =  '2.7.0'
+    moshiVersion = '1.9.3'
     stagVersion = '2.6.0'
     junitVersion = '4.13.1'
     buildToolsVersion = '29.0.3'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -32,4 +32,7 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/model-generator/integrations/models-input/build.gradle
+++ b/model-generator/integrations/models-input/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 sourceCompatibility = "1.8"

--- a/model-generator/integrations/models-output/build.gradle
+++ b/model-generator/integrations/models-output/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.assertj:assertj-core:3.18.1"

--- a/model-generator/plugin/build.gradle
+++ b/model-generator/plugin/build.gradle
@@ -10,13 +10,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.4.21'
-    implementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.21'
-    implementation 'org.jetbrains.kotlin:kotlin-android-extensions:1.4.21'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.21'
+    def kotlinVersion = '1.3.72'
+    implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation 'com.squareup:kotlinpoet:1.6.0'
-    implementation "com.squareup.moshi:moshi-kotlin:1.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.9.3"
 }
 
 sourceCompatibility = '1.8'

--- a/models-parcelable/build.gradle
+++ b/models-parcelable/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.assertj:assertj-core:3.18.1"
     testImplementation "io.github.classgraph:classgraph:4.8.87"

--- a/models-serializable/build.gradle
+++ b/models-serializable/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.assertj:assertj-core:3.18.1'
     testImplementation 'io.github.classgraph:classgraph:4.8.87'

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     // Okio used by Moshi
     implementation "com.squareup.okio:okio:$okioVersion"
 
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
     // Moshi
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
     implementation "com.squareup.moshi:moshi:$moshiVersion"

--- a/request/build.gradle
+++ b/request/build.gradle
@@ -9,6 +9,9 @@ repositories {
 dependencies {
     compileOnly project(path: ':models', configuration: 'default')
     api project(':auth')
+
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 compileKotlin {


### PR DESCRIPTION
# Summary
We can't use Kotlin 1.4+ yet, so we need to downgrade Kotlin to 1.3.72 and all dependencies that also used Kotlin 1.4+.

As a result, I downgraded
- Kotlin -> 1.3.72
- Moshi -> 1.9.3
- Okio -> 2.7.0