### PR TITLE
MPS-1795: Add filtered_total field to Page

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/AlbumList.kt
+++ b/models/src/main/java/com/vimeo/networking2/AlbumList.kt
@@ -23,6 +23,8 @@ data class AlbumList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Album>? = null
+    override val data: List<Album>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Album>

--- a/models/src/main/java/com/vimeo/networking2/CategoryList.kt
+++ b/models/src/main/java/com/vimeo/networking2/CategoryList.kt
@@ -23,6 +23,8 @@ data class CategoryList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Category>? = null
+    override val data: List<Category>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Category>

--- a/models/src/main/java/com/vimeo/networking2/ChannelList.kt
+++ b/models/src/main/java/com/vimeo/networking2/ChannelList.kt
@@ -23,6 +23,8 @@ data class ChannelList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Channel>? = null
+    override val data: List<Channel>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Channel>

--- a/models/src/main/java/com/vimeo/networking2/CommentList.kt
+++ b/models/src/main/java/com/vimeo/networking2/CommentList.kt
@@ -23,6 +23,8 @@ data class CommentList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Comment>? = null
+    override val data: List<Comment>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Comment>

--- a/models/src/main/java/com/vimeo/networking2/ConnectedAppList.kt
+++ b/models/src/main/java/com/vimeo/networking2/ConnectedAppList.kt
@@ -14,6 +14,8 @@ data class ConnectedAppList(
     override val total: Int? = null,
 
     @Json(name = "data")
-    override val data: List<ConnectedApp>? = null
+    override val data: List<ConnectedApp>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Page<ConnectedApp>

--- a/models/src/main/java/com/vimeo/networking2/FeedList.kt
+++ b/models/src/main/java/com/vimeo/networking2/FeedList.kt
@@ -23,6 +23,8 @@ data class FeedList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<FeedItem>? = null
+    override val data: List<FeedItem>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<FeedItem>

--- a/models/src/main/java/com/vimeo/networking2/FolderList.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderList.kt
@@ -23,6 +23,8 @@ data class FolderList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Folder>? = null
+    override val data: List<Folder>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Folder>

--- a/models/src/main/java/com/vimeo/networking2/NotificationList.kt
+++ b/models/src/main/java/com/vimeo/networking2/NotificationList.kt
@@ -23,6 +23,8 @@ data class NotificationList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Notification>? = null
+    override val data: List<Notification>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Notification>

--- a/models/src/main/java/com/vimeo/networking2/ProductList.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProductList.kt
@@ -23,6 +23,8 @@ data class ProductList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Product>? = null
+    override val data: List<Product>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<Product>

--- a/models/src/main/java/com/vimeo/networking2/ProgrammedContentItemList.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProgrammedContentItemList.kt
@@ -23,6 +23,8 @@ data class ProgrammedContentItemList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<ProgrammedContentItem>? = null
+    override val data: List<ProgrammedContentItem>? = null,
 
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 ) : Pageable<ProgrammedContentItem>

--- a/models/src/main/java/com/vimeo/networking2/ProjectItemList.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProjectItemList.kt
@@ -25,6 +25,9 @@ data class ProjectItemList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<ProjectItem>? = null
+    override val data: List<ProjectItem>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<ProjectItem>

--- a/models/src/main/java/com/vimeo/networking2/RecommendationList.kt
+++ b/models/src/main/java/com/vimeo/networking2/RecommendationList.kt
@@ -23,6 +23,9 @@ data class RecommendationList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Recommendation>? = null
+    override val data: List<Recommendation>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<Recommendation>

--- a/models/src/main/java/com/vimeo/networking2/SearchResultList.kt
+++ b/models/src/main/java/com/vimeo/networking2/SearchResultList.kt
@@ -35,6 +35,9 @@ data class SearchResultList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<SearchResult>? = null
+    override val data: List<SearchResult>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<SearchResult>

--- a/models/src/main/java/com/vimeo/networking2/SeasonList.kt
+++ b/models/src/main/java/com/vimeo/networking2/SeasonList.kt
@@ -23,6 +23,9 @@ data class SeasonList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Season>? = null
+    override val data: List<Season>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<Season>

--- a/models/src/main/java/com/vimeo/networking2/TeamList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamList.kt
@@ -14,6 +14,9 @@ data class TeamList(
     override val total: Int? = null,
 
     @Json(name = "data")
-    override val data: List<Team>? = null
+    override val data: List<Team>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Page<Team>

--- a/models/src/main/java/com/vimeo/networking2/TextTrackList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TextTrackList.kt
@@ -23,6 +23,9 @@ data class TextTrackList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<TextTrack>? = null
+    override val data: List<TextTrack>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<TextTrack>

--- a/models/src/main/java/com/vimeo/networking2/TvodItemList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TvodItemList.kt
@@ -23,6 +23,9 @@ data class TvodItemList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<TvodItem>? = null
+    override val data: List<TvodItem>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<TvodItem>

--- a/models/src/main/java/com/vimeo/networking2/UserList.kt
+++ b/models/src/main/java/com/vimeo/networking2/UserList.kt
@@ -23,6 +23,9 @@ data class UserList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<User>? = null
+    override val data: List<User>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<User>

--- a/models/src/main/java/com/vimeo/networking2/VideoList.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoList.kt
@@ -23,6 +23,9 @@ data class VideoList(
     override val paging: Paging? = null,
 
     @Json(name = "data")
-    override val data: List<Video>? = null
+    override val data: List<Video>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
 
 ) : Pageable<Video>

--- a/models/src/main/java/com/vimeo/networking2/common/Page.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Page.kt
@@ -15,6 +15,14 @@ interface Page<Data_T> {
 
 
     /**
+     * If a filter is applied in the request this will reflect
+     * the total, null if no filters applied.
+     * TODO name this better
+     */
+    val filteredTotal: Int?
+
+
+    /**
      * The data corresponding to this page.
      */
     val data: List<Data_T>?

--- a/models/src/main/java/com/vimeo/networking2/common/Page.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Page.kt
@@ -9,15 +9,13 @@ package com.vimeo.networking2.common
 interface Page<Data_T> {
 
     /**
-     * Total number of items returned.
+     * The total number of items for the request without taking into account any applied filters.
      */
     val total: Int?
 
 
     /**
-     * If a filter is applied in the request this will reflect
-     * the total, null if no filters applied.
-     * TODO name this better
+     * The total number of items in a request taking into account the applied filters.
      */
     val filteredTotal: Int?
 


### PR DESCRIPTION
#### Issue
[MPS-1795](https://vimean.atlassian.net/browse/MPS-1795)

#### Summary
When apply filters to the request the `total` field will always return the total possible items for the request without taking into account the applied filter. `filteredTotal` will return the correct number of items taking the applied filter into account

#### How to Test
Test with PR up to internal Vimeo app
