### PR TITLE
Fix detekt issues

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/VimeoCallback.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/VimeoCallback.kt
@@ -31,15 +31,14 @@ interface VimeoCallback<ResponseType_T> {
     /**
      * A successful API response.
      *
-     * @param response  Data returned by the API.
+     * @param response Data returned by the API.
      */
     fun onSuccess(response: VimeoResponse.Success<ResponseType_T>)
 
     /**
      * An error occurred when making the request.
      *
-     * @param error Information on the error. This error could be due to an exception thrown or
-     *              parsing response error.
+     * @param error Information on the error. This error could be due to an exception thrown or parsing response error.
      */
     fun onError(error: VimeoResponse.Error)
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,6 +1,6 @@
 # Fail build if any issues are found
 build:
-  maxIssues: 1
+  maxIssues: 0
 
 #
 # Configure detekt's 8 different rulesets (comments, complexity, empty-blocks, exceptions, naming, performance,

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsExtension.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsExtension.kt
@@ -3,7 +3,7 @@ package com.vimeo.modelgenerator
 import org.gradle.api.Project
 
 /**
- *  Extension object that is used to configure the [GenerateModelsPlugin].
+ * Extension object that is used to configure the [GenerateModelsPlugin].
  */
 open class GenerateModelsExtension(private val project: Project) {
 

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/PsiToPoetHelpers.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/PsiToPoetHelpers.kt
@@ -22,7 +22,7 @@ private const val LAMBDA = "->"
  * like [KtProperty] or [KtNamedFunction].
  *
  * @param annotations a list of [KtAnnotationEntry] that can be pulled from most Kt
- *  prefixed objects, like [KtParameter] or [KtClass].
+ * prefixed objects, like [KtParameter] or [KtClass].
  * @param packageName the current package name of the worked on file.
  */
 internal fun createAnnotations(
@@ -248,8 +248,8 @@ internal fun createTypeName(
  * A recursive method that goes through the given list until completion and
  * creates a parameterized [TypeName] from it.
  *
- *  @param classes a list of [ClassNames][ClassName] that will be parameterized, specifically in order
- *  in which they should be parameterized.  A list of (List, Foo, Bar) will output `List<Foo<Bar>>`
+ * @param classes a list of [ClassNames][ClassName] that will be parameterized, specifically in order
+ * in which they should be parameterized.  A list of (List, Foo, Bar) will output `List<Foo<Bar>>`
  */
 private fun createNestedParameterizedTypes(classes: MutableList<ClassName>): TypeName =
     if (classes.size == 1) {

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/extensions/KotlinPoetExtensions.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/extensions/KotlinPoetExtensions.kt
@@ -35,7 +35,7 @@ internal fun FileSpec.Builder.addProperties(properties: List<PropertySpec>): Fil
     }
 
 /**
- *  Add a list of imports to the given [FileSpec].
+ * Add a list of imports to the given [FileSpec].
  *
  * @param imports a list of Imports.
  */
@@ -60,8 +60,8 @@ internal fun FileSpec.Builder.addAnnotations(annotations: List<AnnotationSpec>):
  * This can be applied to [FileSpec.Builder], [PropertySpec.Builder], [ParameterSpec.Builder] or any class that has
  * [Taggable.Builder] as a super.
  *
- *  @param condition a condition if met will add the [addition] to the given [Taggable.Builder].
- *  @param addition a block of code that can be applied to the [Taggable.Builder] if the [condition] is met.
+ * @param condition a condition if met will add the [addition] to the given [Taggable.Builder].
+ * @param addition a block of code that can be applied to the [Taggable.Builder] if the [condition] is met.
  */
 internal fun <T : Taggable.Builder<T>> T.addIfConditionMet(
     condition: Boolean,
@@ -71,9 +71,9 @@ internal fun <T : Taggable.Builder<T>> T.addIfConditionMet(
 }
 
 /**
- *  Parses [valArgs] to create parameters for AnnotationSpec.Builders [AnnotationSpec.Builder].
+ * Parses [valArgs] to create parameters for AnnotationSpec.Builders [AnnotationSpec.Builder].
  *
- *  @param valArgs a list of [ValueArgument].
+ * @param valArgs a list of [ValueArgument].
  */
 internal fun AnnotationSpec.Builder.addMembers(valArgs: List<ValueArgument>): AnnotationSpec.Builder =
     apply { valArgs.toParams.forEach { addMember(it) } }

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/visitor/SerializableClassVisitor.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/visitor/SerializableClassVisitor.kt
@@ -9,9 +9,9 @@ import org.jetbrains.kotlin.psi.KtClass
 import java.io.Serializable
 
 /**
- *  [ModifyVisitor] for [Serializable] code additions.
+ * [ModifyVisitor] for [Serializable] code additions.
  *
- *  This adds [Serializable] as a class super as well as adding a companion object with a serialVersionUID.
+ * This adds [Serializable] as a class super as well as adding a companion object with a serialVersionUID.
  */
 class SerializableClassVisitor : ModifyVisitor {
 

--- a/models/detekt_baseline.xml
+++ b/models/detekt_baseline.xml
@@ -124,6 +124,7 @@
     <ID>UndocumentedPublicProperty:DashVideoFile.kt$DashVideoFile$/** * The token used for DRM protected streams. */ @Internal @Json(name = "token") val token: String? = null</ID>
     <ID>UndocumentedPublicProperty:Document.kt$Document$/** * The partially stripped html for documents like the terms of service. */ @Json(name = "html") val html: String? = null</ID>
     <ID>UndocumentedPublicProperty:Drm.kt$Drm$/** * The video file containing the info about the DRM protected stream. */ @Json(name = "widevine") val widevine: DashVideoFile? = null</ID>
+    <ID>UndocumentedPublicProperty:EditSession.kt$EditSession$/** * Whether the current version of clip is of max resolution. */ @Json(name = "is_max_resolution") val isMaxResolution: Boolean? = null</ID>
     <ID>UndocumentedPublicProperty:EditSession.kt$EditSession$/** * Whether the video has licensed music. */ @Json(name = "is_music_licensed") val isMusicLicensed: Boolean? = null</ID>
     <ID>UndocumentedPublicProperty:Email.kt$Email$@Json(name = "email") val email: String? = null</ID>
     <ID>UndocumentedPublicProperty:EmbedButtons.kt$EmbedButtons$/** * Whether the Embed button appears in the embeddable player for this video. */ @Json(name = "embed") val embed: Boolean? = null</ID>
@@ -160,6 +161,7 @@
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The folder's metadata. */ @Json(name = "metadata") val metadata: Metadata&lt;FolderConnections, BasicInteraction&gt;? = null</ID>
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The folder's owner. */ @Json(name = "user") val user: User? = null</ID>
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The language preference for Slack notifications about the folder. * @see slackLanguagePreferenceType */ @Json(name = "slack_language_preference") val slackLanguagePreference: String? = null</ID>
+    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The link to the folder on Vimeo. */ @Json(name = "link") val link: String? = null</ID>
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The name of the folder. */ @Json(name = "name") val name: String? = null</ID>
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The resource key string of the folder. */ @Json(name = "resource_key") val resourceKey: String? = null</ID>
     <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The time in ISO 8601 format when a user last performed an action on the folder. */ @Json(name = "last_user_action_event_date") val lastUserActionEventDate: Date? = null</ID>
@@ -636,6 +638,7 @@
     <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's privacy setting. */ @Json(name = "privacy") val privacy: Privacy? = null</ID>
     <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's title. */ @Json(name = "name") val name: String? = null</ID>
     <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's width in pixels. */ @Json(name = "width") val width: Int? = null</ID>
+    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Whether the clip is playable. */ @Json(name = "is_playable") val isPlayable: Boolean? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The badge image. */ @Json(name = "pictures") val pictures: PictureCollection? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The festival that this badge represents. */ @Internal @Json(name = "festival") val festival: String? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The link for the badge */ @Json(name = "link") val link: String? = null</ID>

--- a/models/src/main/java/com/vimeo/networking2/ApiError.kt
+++ b/models/src/main/java/com/vimeo/networking2/ApiError.kt
@@ -8,8 +8,8 @@ import com.vimeo.networking2.enums.ErrorCodeType
 import com.vimeo.networking2.enums.asEnum
 
 /**
- *  This class represents an error response from the Vimeo API. It holds useful getters to
- *  understand why your request might have failed.
+ * This class represents an error response from the Vimeo API. It holds useful getters to
+ * understand why your request might have failed.
  */
 @JsonClass(generateAdapter = true)
 data class ApiError(

--- a/models/src/main/java/com/vimeo/networking2/Folder.kt
+++ b/models/src/main/java/com/vimeo/networking2/Folder.kt
@@ -42,19 +42,19 @@ data class Folder(
     val metadata: Metadata<FolderConnections, BasicInteraction>? = null,
 
     /**
-     *  The time in ISO 8601 format when the folder was last modified.
+     * The time in ISO 8601 format when the folder was last modified.
      */
     @Json(name = "modified_time")
     val lastModifiedDate: Date? = null,
 
     /**
-     *  The name of the folder.
+     * The name of the folder.
      */
     @Json(name = "name")
     val name: String? = null,
 
     /**
-     *  The [FolderPrivacy] that defines the public visibility of the folder.
+     * The [FolderPrivacy] that defines the public visibility of the folder.
      */
     @Json(name = "privacy")
     val privacy: FolderPrivacy? = null,

--- a/models/src/main/java/com/vimeo/networking2/ProjectItem.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProjectItem.kt
@@ -14,19 +14,19 @@ import com.vimeo.networking2.enums.asEnum
 data class ProjectItem(
 
     /**
-     *  The type of the item.
+     * The type of the item.
      */
     @Json(name = "type")
     val rawType: String? = null,
 
     /**
-     *  The item is [Folder] if [type] == [ProjectItemType.FOLDER], `null` otherwise.
+     * The item is [Folder] if [type] == [ProjectItemType.FOLDER], `null` otherwise.
      */
     @Json(name = "folder")
     val folder: Folder? = null,
 
     /**
-     *  The item is [Video] if [type] == [ProjectItemType.VIDEO], `null` otherwise.
+     * The item is [Video] if [type] == [ProjectItemType.VIDEO], `null` otherwise.
      */
     @Json(name = "video")
     val video: Video? = null

--- a/models/src/main/java/com/vimeo/networking2/PublishJobBlockers.kt
+++ b/models/src/main/java/com/vimeo/networking2/PublishJobBlockers.kt
@@ -21,8 +21,8 @@ data class PublishJobBlockers(
     val facebook: List<String>? = null,
 
     /**
-     *  The list of blockers keeping this video from being uploaded to YouTube.
-     *  @see PublishJobBlockers.youTubeTypes
+     * The list of blockers keeping this video from being uploaded to YouTube.
+     * @see PublishJobBlockers.youTubeTypes
      */
 
     @Json(name = "youtube")

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -239,7 +239,7 @@ data class Video(
     val width: Int? = null,
 
     /**
-     *  Information about the Vimeo Create session of a video.
+     * Information about the Vimeo Create session of a video.
      */
     @Json(name = "edit_session")
     val editSession: EditSession? = null,

--- a/models/src/main/java/com/vimeo/networking2/common/Page.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Page.kt
@@ -2,9 +2,9 @@ package com.vimeo.networking2.common
 
 
 /**
- *  Represents a single non-pageable list of data.
+ * Represents a single non-pageable list of data.
  *
- *  @see [Pageable] for lists of data that support pagination.
+ * @see [Pageable] for lists of data that support pagination.
  */
 interface Page<Data_T> {
 

--- a/models/src/main/java/com/vimeo/networking2/params/BatchPublishToSocialMedia.kt
+++ b/models/src/main/java/com/vimeo/networking2/params/BatchPublishToSocialMedia.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 /**
- *  Encapsulates publishing data for each of the supported social media platforms.
+ * Encapsulates publishing data for each of the supported social media platforms.
  */
 @JsonClass(generateAdapter = true)
 data class BatchPublishToSocialMedia(


### PR DESCRIPTION
# Summary
Detekt is failing because of undocumented public properties. Until we can resolve the discrepancies with how we document our properties with how detekt expects them to be documented (we document on the property itself instead of `@param` docs) we need to run `detektBaseline` every time we add new properties. 

This PR adds the missing baselines causing the build to fail.

Additionally, I reduced the max allowable detekt issues to zero, as there isn't a good reason to let any issues make it into the build.

Bonus: I removed some empty spaces I noticed.