### PR TITLE
Make connection a data class

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/TeamMembersConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembersConnection.kt
@@ -13,7 +13,7 @@ import com.vimeo.networking2.common.Connection
  * @param total The total number of team members on this connection.
  */
 @JsonClass(generateAdapter = true)
-class TeamMembersConnection(
+data class TeamMembersConnection(
 
     @Json(name = "invites_remaining")
     val invitesRemaining: Int? = null,

--- a/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
@@ -12,7 +12,7 @@ import java.util.Date
  * Stores information related to relevant members of a team.
  */
 @JsonClass(generateAdapter = true)
-data class TeamMembership (
+data class TeamMembership(
 
     /**
      * The URI to independently request this team membership information.
@@ -80,7 +80,8 @@ data class TeamMembership (
     val teamInviteStatus: String? = null,
 
     /**
-     * The resource key that identifies team membership.
+     * The resource key that identifies team membership (this is not unique per membership instance, only unique per
+     * team).
      */
     @Json(name = "resource_key")
     val resourceKey: String? = null,
@@ -97,8 +98,8 @@ data class TeamMembership (
     @Json(name = "metadata")
     val metadata: Metadata<TeamMembershipConnections, BasicInteraction>? = null
 
-): Entity {
-    override val identifier: String? = resourceKey
+) : Entity {
+    override val identifier: String? = uri
 }
 
 /**

--- a/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
@@ -10,91 +10,62 @@ import java.util.Date
 
 /**
  * Stores information related to relevant members of a team.
+ *
+ * @param uri The URI to independently request this team membership information.
+ * @param role The user's role on the team. See [TeamMembership.roleType].
+ * @param localizedRole A localized string for display purposes that names the user's role on the team. See [role].
+ * @param inviteUrl The URL for the invited user to join the team. The value of this field is null if the invited user
+ * has already joined. (e.g. https://vimeo.com/user/seat?code=e7c71ae7f4dc5d71a3bceb4d1d9e)
+ * @param email The team member's email.
+ * @param user The team member. The value of this field is null if the user hasn't joined the team yet.
+ * @param createdTime The time in ISO 8601 format at which the invite was sent.
+ * @param modifiedTime The time in ISO 8601 format at which the team membership was last modified.
+ * @param joinedTime The time in ISO 8601 format at which the invite was accepted.
+ * @param teamInviteStatus The status of the user's team membership. See [TeamMembership.teamInviteStatusType].
+ * @param resourceKey The resource key that identifies team membership (this is not unique per membership instance, only
+ * unique per team).
+ * @param hasFolderAccess Whether the team member has folder access.
+ * @param metadata The team membership metadata.
  */
 @JsonClass(generateAdapter = true)
 data class TeamMembership(
 
-    /**
-     * The URI to independently request this team membership information.
-     */
     @Json(name = "uri")
     val uri: String? = null,
 
-    /**
-     * The user's role on the team.
-     * @see TeamMembership.roleType
-     */
     @Json(name = "permission_level")
     val role: String? = null,
 
-    /**
-     * A localized string for display purposes that names the user's role on the team.
-     * @see role
-     */
     @Json(name = "role")
     val localizedRole: String? = null,
 
-    /**
-     * The URL for the invited user to join the team.
-     * The value of this field is null if the invited user has already joined.
-     * (e.g. https://vimeo.com/user/seat?code=e7c71ae7f4dc5d71a3bceb4d1d9e)
-     */
     @Json(name = "invite_url")
     val inviteUrl: String? = null,
 
-    /**
-     * The team member's email.
-     */
     @Json(name = "email")
     val email: String? = null,
 
-    /**
-     * The team member. The value of this field is null if the user hasn't joined the team yet.
-     */
     @Json(name = "user")
     val user: User? = null,
 
-    /**
-     * The time in ISO 8601 format at which the invite was sent.
-     */
     @Json(name = "created_time")
     val createdTime: Date? = null,
 
-    /**
-     * The time in ISO 8601 format at which the team membership was last modified.
-     */
     @Json(name = "modified_time")
     val modifiedTime: Date? = null,
 
-    /**
-     * The time in ISO 8601 format at which the invite was accepted.
-     */
     @Json(name = "joined_time")
     val joinedTime: Date? = null,
 
-    /**
-     * The status of the user's team membership.
-     * @see TeamMembership.teamInviteStatusType
-     */
     @Json(name = "status")
     val teamInviteStatus: String? = null,
 
-    /**
-     * The resource key that identifies team membership (this is not unique per membership instance, only unique per
-     * team).
-     */
     @Json(name = "resource_key")
     val resourceKey: String? = null,
 
-    /**
-     * Whether the team member has folder access.
-     */
     @Json(name = "has_folder_access")
     val hasFolderAccess: Boolean? = null,
 
-    /**
-     * The team membership metadata.
-     */
     @Json(name = "metadata")
     val metadata: Metadata<TeamMembershipConnections, BasicInteraction>? = null
 

--- a/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
@@ -136,6 +136,7 @@ class ModelsTest {
         TeamMembership::class,
         TeamMembershipList::class,
         TeamMembershipConnections::class,
+        TeamMembersConnection::class,
         TeamOwnerConnection::class,
         TextTrack::class,
         TextTrackList::class,


### PR DESCRIPTION
# Summary
`TeamMembsConnection` should have been a `data` class, so I added it. Additionally, I discovered that there is a bug with the `resource_key` property and as a result we have to use the `uri` property as our identifier instead.