### PR TITLE
MPS-1897: Grant Folder Access Fix

### DIFF
--- a/models/detekt_baseline.xml
+++ b/models/detekt_baseline.xml
@@ -673,23 +673,6 @@
     <ID>UndocumentedPublicProperty:VideoSourceFile.kt$VideoSourceFile$/** * The width of the video in pixels. */ @Json(name = "width") val width: Int? = null</ID>
     <ID>UndocumentedPublicProperty:VideoSourceFile.kt$VideoSourceFile$/** * Video logging information. */ @Json(name = "log") val log: VideoLog? = null</ID>
     <ID>UndocumentedPublicProperty:VideoStats.kt$VideoStats$/** * The current total number of times that the video has been played. */ @Json(name = "plays") val plays: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VideoStatus.kt$VideoStatus$/** * The current state of the transcoding process. */ @Json(name = "state") val state: String? = null</ID>
-    <ID>UndocumentedPublicProperty:VideoStatus.kt$VideoStatus$/** * The percentage of the transcoding process that is complete. */ @Json(name = "progress") val progress: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VideoStatus.kt$VideoStatus$/** * The remaining time in seconds before transcoding is complete. */ @Json(name = "time_left") val timeLeft: Long? = null</ID>
     <ID>UndocumentedPublicProperty:VideosPreference.kt$VideosPreference$/** * Privacy values for videos. */ @Json(name = "privacy") val privacy: Privacy? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * An array of HTTP methods permitted on this URI. */ @Json(name = "options") val options: List&lt;String&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * The API URI that resolves to the connection data. */ @Json(name = "uri") val uri: String? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * The total number of albums on this connection. */ @Json(name = "total") val total: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * The total number of extra videos. */ @Json(name = "extra_total") val extraTotal: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * The total number of main videos. */ @Json(name = "main_total") val mainTotal: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VideosTvodItemConnection.kt$VideosTvodItemConnection$/** * The total number of viewable videos. */ @Json(name = "viewable_total") val viewableTotal: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:VimeoAccount.kt$VimeoAccount$/** * The authenticated and logged in user. */ @Json(name = "user") val user: User? = null</ID>
-    <ID>UndocumentedPublicProperty:VimeoAccount.kt$VimeoAccount$/** * The date and time that the token expires. */ @Json(name = "expires_on") val expiresOn: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:VimeoAccount.kt$VimeoAccount$/** * The refresh token string. */ @Json(name = "refresh_token") val refreshToken: String? = null</ID>
-    <ID>UndocumentedPublicProperty:VimeoAccount.kt$VimeoAccount$/** * The scope or scopes that the token supports. */ @Json(name = "scope") val scope: String? = null</ID>
-    <ID>UndocumentedPublicProperty:VimeoAccount.kt$VimeoAccount$/** * The token type. */ @Json(name = "token_type") val tokenType: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Website.kt$Website$/** * The URL of the website. */ @Json(name = "link") val link: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Website.kt$Website$/** * The name of the website. */ @Json(name = "users_with_access") val name: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Website.kt$Website$/** * The website's description. */ @Json(name = "description") val description: String? = null</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/models/src/main/java/com/vimeo/networking2/TeamMembershipList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembershipList.kt
@@ -2,23 +2,17 @@ package com.vimeo.networking2
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.vimeo.networking2.common.Pageable
+import com.vimeo.networking2.common.Page
 
 /**
- * List of [TeamMemberships][TeamMembership] that can be paged.
+ * List of [TeamMemberships][TeamMembership] that cannot be paged.
  */
 @JsonClass(generateAdapter = true)
 data class TeamMembershipList(
     @Json(name = "total")
     override val total: Int? = null,
-    @Json(name = "page")
-    override val page: Int? = null,
-    @Json(name = "per_page")
-    override val perPage: Int? = null,
-    @Json(name = "paging")
-    override val paging: Paging? = null,
     @Json(name = "data")
     override val data: List<TeamMembership>? = null,
     @Json(name = "filtered_total")
     override val filteredTotal: Int? = null
-) : Pageable<TeamMembership>
+) : Page<TeamMembership>

--- a/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
@@ -7,24 +7,20 @@ import com.vimeo.networking2.enums.asEnum
 
 /**
  * The current status of the video transcoding process.
+ *
+ * @param state The current state of the transcoding process.
+ * @param progress The percentage of the transcoding process that is complete.
+ * @param timeLeft The remaining time in seconds before transcoding is complete.
  */
 @JsonClass(generateAdapter = true)
 data class VideoStatus(
-    /**
-     * The current state of the transcoding process.
-     */
+
     @Json(name = "state")
     val state: String? = null,
 
-    /**
-     * The percentage of the transcoding process that is complete.
-     */
     @Json(name = "progress")
     val progress: Int? = null,
 
-    /**
-     * The remaining time in seconds before transcoding is complete.
-     */
     @Json(name = "time_left")
     val timeLeft: Long? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/VideosTvodItemConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideosTvodItemConnection.kt
@@ -5,43 +5,32 @@ import com.squareup.moshi.JsonClass
 
 /**
  * All connections for a [TvodItem].
+ *
+ * @param extraTotal The total number of extra videos.
+ * @param mainTotal The total number of main videos.
+ * @param options An array of HTTP methods permitted on this URI.
+ * @param total The total number of albums on this connection.
+ * @param uri The API URI that resolves to the connection data.
+ * @param viewableTotal The total number of viewable videos.
  */
 @JsonClass(generateAdapter = true)
 data class VideosTvodItemConnection(
 
-    /**
-     * The total number of extra videos.
-     */
     @Json(name = "extra_total")
     val extraTotal: Int? = null,
 
-    /**
-     * The total number of main videos.
-     */
     @Json(name = "main_total")
     val mainTotal: Int? = null,
 
-    /**
-     * An array of HTTP methods permitted on this URI.
-     */
     @Json(name = "options")
     val options: List<String>? = null,
 
-    /**
-     * The total number of albums on this connection.
-     */
     @Json(name = "total")
     val total: Int? = null,
 
-    /**
-     * The API URI that resolves to the connection data.
-     */
     @Json(name = "uri")
     val uri: String? = null,
 
-    /**
-     * The total number of viewable videos.
-     */
     @Json(name = "viewable_total")
     val viewableTotal: Int? = null
 

--- a/models/src/main/java/com/vimeo/networking2/VimeoAccount.kt
+++ b/models/src/main/java/com/vimeo/networking2/VimeoAccount.kt
@@ -9,6 +9,12 @@ import java.util.Date
 
 /**
  * This class represents an authenticated user of Vimeo, either logged in or logged out.
+ *
+ * @param expiresOn The date and time that the token expires.
+ * @param refreshToken The refresh token string.
+ * @param scope The scope or scopes that the token supports.
+ * @param user The authenticated and logged in user.
+ * @param tokenType The token type.
  */
 @JsonClass(generateAdapter = true)
 data class VimeoAccount(
@@ -16,33 +22,18 @@ data class VimeoAccount(
     @Json(name = "access_token")
     override val accessToken: String,
 
-    /**
-     * The date and time that the token expires.
-     */
     @Json(name = "expires_on")
     val expiresOn: Date? = null,
 
-    /**
-     * The refresh token string.
-     */
     @Json(name = "refresh_token")
     val refreshToken: String? = null,
 
-    /**
-     * The scope or scopes that the token supports.
-     */
     @Json(name = "scope")
     val scope: String? = null,
 
-    /**
-     * The authenticated and logged in user.
-     */
     @Json(name = "user")
     val user: User? = null,
 
-    /**
-     * The token type.
-     */
     @Json(name = "token_type")
     val tokenType: String? = null
 

--- a/models/src/main/java/com/vimeo/networking2/Website.kt
+++ b/models/src/main/java/com/vimeo/networking2/Website.kt
@@ -5,25 +5,20 @@ import com.squareup.moshi.JsonClass
 
 /**
  * User's website information.
+ *
+ * @param description The website's description.
+ * @param link The URL of the website.
+ * @param name The name of the website.
  */
 @JsonClass(generateAdapter = true)
 data class Website(
 
-    /**
-     * The website's description.
-     */
     @Json(name = "description")
     val description: String? = null,
 
-    /**
-     * The URL of the website.
-     */
     @Json(name = "link")
     val link: String? = null,
 
-    /**
-     * The name of the website.
-     */
     @Json(name = "users_with_access")
     val name: String? = null
 )

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -1666,10 +1666,10 @@ interface VimeoApiClient {
     ): VimeoRequest
 
     /**
-     * Grants permission for the given users to access the given folder.
+     * Grants permission for the given team members to access the given folder.
      *
      * @param uri the URI from which content will be sent to.
-     * @param usersIds A list of URIs for the users who will be granted access.
+     * @param teamMemberIds A list of URIs for the users who will be granted access.
      * to the given folder, if a user who currently has access to this folder is not present in this list they will have
      * their folder permission revoked.
      * @param queryParams Optional map used to refine the response from the API.
@@ -1677,18 +1677,18 @@ interface VimeoApiClient {
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
-    fun grantUsersAccessToFolder(
+    fun grantTeamMembersFolderAccess(
         uri: String,
-        usersIds: List<String>,
+        teamMemberIds: List<String>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest
 
     /**
-     * Grants permission for the given users to access the given folder.
+     * Grants permission for the given team members to access the given folder.
      *
-     * @param folder The [Folder] that [users] will be granted access to.
-     * @param users A list of [Users][User]  who will be granted access.
+     * @param folder The [Folder] that [teamMembers] will be granted access to.
+     * @param teamMembers A list of [TeamMemberships][TeamMembership]  who will be granted access.
      * to the given folder, if a user who currently has access to this folder is not present in this list they will have
      * their folder permission revoked.
      * @param queryParams Optional map used to refine the response from the API.
@@ -1696,9 +1696,9 @@ interface VimeoApiClient {
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
-    fun grantUsersAccessToFolder(
+    fun grantTeamMembersFolderAccess(
         folder: Folder,
-        users: List<User>,
+        teamMembers: List<TeamMembership>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -415,13 +415,13 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest = client.changeUserRole(membership, role, queryParams, callback)
 
-    override fun grantUsersAccessToFolder(
+    override fun grantTeamMembersFolderAccess(
         uri: String,
-        usersIds: List<String>,
+        teamMemberIds: List<String>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest =
-        client.grantUsersAccessToFolder(uri, usersIds, queryParams, callback)
+        client.grantTeamMembersFolderAccess(uri, teamMemberIds, queryParams, callback)
 
     override fun fetchEmpty(
         uri: String,
@@ -429,12 +429,12 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         callback: VimeoCallback<Unit>
     ): VimeoRequest = client.fetchEmpty(uri, cacheControl, callback)
 
-    override fun grantUsersAccessToFolder(
+    override fun grantTeamMembersFolderAccess(
         folder: Folder,
-        users: List<User>,
+        teamMembers: List<TeamMembership>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
-    ): VimeoRequest = client.grantUsersAccessToFolder(folder, users, queryParams, callback)
+    ): VimeoRequest = client.grantTeamMembersFolderAccess(folder, teamMembers, queryParams, callback)
 
     override fun search(
         query: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -638,9 +638,9 @@ internal class VimeoApiClientImpl(
         return vimeoService.changeUserRole(authHeader, safeUri, role, queryParams.orEmpty()).enqueue(callback)
     }
 
-    override fun grantUsersAccessToFolder(
+    override fun grantTeamMembersFolderAccess(
         uri: String,
-        usersIds: List<String>,
+        teamMemberIds: List<String>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
@@ -648,14 +648,14 @@ internal class VimeoApiClientImpl(
         return vimeoService.grantUsersAccessToFolder(
             authHeader,
             safeUri,
-            usersIds.map(::GrantFolderPermissionForUser),
+            teamMemberIds.map(::GrantFolderPermissionForUser),
             queryParams.orEmpty()
         ).enqueue(callback)
     }
 
-    override fun grantUsersAccessToFolder(
+    override fun grantTeamMembersFolderAccess(
         folder: Folder,
-        users: List<User>,
+        teamMembers: List<TeamMembership>,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
@@ -664,7 +664,7 @@ internal class VimeoApiClientImpl(
         return vimeoService.grantUsersAccessToFolder(
             authHeader,
             safeUri,
-            users.map { GrantFolderPermissionForUser(it.uri.orEmpty()) },
+            teamMembers.map { GrantFolderPermissionForUser(it.uri.orEmpty()) },
             queryParams.orEmpty()
         ).enqueue(callback)
     }

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -659,7 +659,8 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = folder.metadata?.connections?.teamMembers?.uri.notEmpty()
+            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
         return vimeoService.grantUsersAccessToFolder(
             authHeader,
             safeUri,


### PR DESCRIPTION


#### Summary
While working on [MPS-1897](https://vimean.atlassian.net/browse/MPS-1897) I noticed some issues from my initial networking PR.

- The URI being pulled from the `Folder` for granting/revoking folder access was incorrect and needed to be pulled from the `teamMembers` connection.
- URIs being passed for granting/revoking folder access to team members needed to be the URI for the `TeamMembership` object and not the `User` object, `grantTeamMembersFolderAccess` has been updated to take the correct model. 
- I also moved some kdocs to using `@param`

