### PR TITLE
Add missing folder URI parameter to change user membership functions

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -1636,6 +1636,8 @@ interface VimeoApiClient {
      *
      * @param uri the URI from which content will be sent to.
      * @param role The [TeamRoleType] that given user will be changed to.
+     * @param folderUri If the user is being changed to a [TeamRoleType.CONTRIBUTOR] or [TeamRoleType.VIEWER] a URI for
+     * the Folder they can contribute or view also needs to be added.
      * @param queryParams Optional map used to refine the response from the API.
      * @param callback The callback which will be notified of the request completion.
      *
@@ -1644,6 +1646,7 @@ interface VimeoApiClient {
     fun changeUserRole(
         uri: String,
         role: TeamRoleType,
+        folderUri: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest
@@ -1653,6 +1656,8 @@ interface VimeoApiClient {
      *
      * @param membership The [TeamMembership] of the User that will have their [TeamRoleType] changed.
      * @param role The [TeamRoleType] that given user will be changed to.
+     * @param folder If the user is being changed to a [TeamRoleType.CONTRIBUTOR] or [TeamRoleType.VIEWER] the [Folder]
+     * they can contribute or view also needs to be added.
      * @param queryParams Optional map used to refine the response from the API.
      * @param callback The callback which will be notified of the request completion.
      *
@@ -1661,6 +1666,7 @@ interface VimeoApiClient {
     fun changeUserRole(
         membership: TeamMembership,
         role: TeamRoleType,
+        folder: Folder?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -529,6 +529,7 @@ internal interface VimeoService {
         @Header(AUTHORIZATION) authorization: String,
         @Url uri: String,
         @Field(PARAMETER_ROLE) role: TeamRoleType,
+        @Field(PARAMETER_FOLDER_URI) folderUri: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<TeamMembership>
 

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -404,16 +404,18 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
     override fun changeUserRole(
         uri: String,
         role: TeamRoleType,
+        folderUri: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
-    ): VimeoRequest = client.changeUserRole(uri, role, queryParams, callback)
+    ): VimeoRequest = client.changeUserRole(uri, role, folderUri, queryParams, callback)
 
     override fun changeUserRole(
         membership: TeamMembership,
         role: TeamRoleType,
+        folder: Folder?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
-    ): VimeoRequest = client.changeUserRole(membership, role, queryParams, callback)
+    ): VimeoRequest = client.changeUserRole(membership, role, folder, queryParams, callback)
 
     override fun grantTeamMembersFolderAccess(
         uri: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -621,21 +621,25 @@ internal class VimeoApiClientImpl(
     override fun changeUserRole(
         uri: String,
         role: TeamRoleType,
+        folderUri: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
         val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        return vimeoService.changeUserRole(authHeader, safeUri, role, queryParams.orEmpty()).enqueue(callback)
+        return vimeoService.changeUserRole(authHeader, safeUri, role, folderUri, queryParams.orEmpty())
+            .enqueue(callback)
     }
 
     override fun changeUserRole(
         membership: TeamMembership,
         role: TeamRoleType,
+        folder: Folder?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
         val safeUri = membership.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        return vimeoService.changeUserRole(authHeader, safeUri, role, queryParams.orEmpty()).enqueue(callback)
+        return vimeoService.changeUserRole(authHeader, safeUri, role, folder?.uri, queryParams.orEmpty())
+            .enqueue(callback)
     }
 
     override fun grantTeamMembersFolderAccess(


### PR DESCRIPTION
# Summary
The `VimeoApiClient.changeUserRole` functions lacked the necessary `folder` parameters to change the user roles to `VIEWER` or `CONTRIBUTOR`. This PR adds those parameters.