### PR TITLE
Support for subfolders

### DIFF
--- a/models/detekt_baseline.xml
+++ b/models/detekt_baseline.xml
@@ -153,20 +153,6 @@
     <ID>UndocumentedPublicProperty:FeedItem.kt$FeedItem$/** * Video associated with ths feed item. */ @Json(name = "clip") val video: Video? = null</ID>
     <ID>UndocumentedPublicProperty:FeedItemConnections.kt$FeedItemConnections$/** * A list of resource URIs related to the activity. */ @Json(name = "related") val related: BasicConnection? = null</ID>
     <ID>UndocumentedPublicProperty:FileTransferPage.kt$FileTransferPage$/** * The link to the file transfer page. */ @Internal @Json(name = "link") val link: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The Slack integration channel for the folder. */ @Json(name = "slack_integration_channel") val slackIntegrationChannel: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The Slack webhook ID for the folder. */ @Json(name = "slack_incoming_webhooks_id") val slackIncomingWebhooksId: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The [FolderPrivacy] that defines the public visibility of the folder. */ @Json(name = "privacy") val privacy: FolderPrivacy? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The folder's canonical relative URI. */ @Json(name = "uri") val uri: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The folder's metadata. */ @Json(name = "metadata") val metadata: Metadata&lt;FolderConnections, BasicInteraction&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The folder's owner. */ @Json(name = "user") val user: User? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The language preference for Slack notifications about the folder. * @see slackLanguagePreferenceType */ @Json(name = "slack_language_preference") val slackLanguagePreference: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The link to the folder on Vimeo. */ @Json(name = "link") val link: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The name of the folder. */ @Json(name = "name") val name: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The resource key string of the folder. */ @Json(name = "resource_key") val resourceKey: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The time in ISO 8601 format when a user last performed an action on the folder. */ @Json(name = "last_user_action_event_date") val lastUserActionEventDate: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The time in ISO 8601 format when the folder was created. */ @Json(name = "created_time") val createdDate: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * The time in ISO 8601 format when the folder was last modified. */ @Json(name = "modified_time") val lastModifiedDate: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Folder.kt$Folder$/** * User preferences for Slack notifications about the folder. * @see slackUserPreferenceType */ @Json(name = "slack_user_preferences") val slackUserPreference: String? = null</ID>
     <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the project items in the folder. */ @Json(name = "items") val items: BasicConnection? = null</ID>
     <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the sub-folders in the folder. */ @Json(name = "folders") val folders: BasicConnection? = null</ID>
     <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the videos in the folder. */ @Json(name = "videos") val videos: BasicConnection? = null</ID>
@@ -494,19 +480,6 @@
     <ID>UndocumentedPublicProperty:TeamBranding.kt$TeamBranding$/** * The hexadecimal color code for the accent color of the team. */ @Json(name = "accent_color") val acccentColor: String? = null</ID>
     <ID>UndocumentedPublicProperty:TeamBranding.kt$TeamBranding$/** * The name of the team. */ @Json(name = "team_name") val name: String? = null</ID>
     <ID>UndocumentedPublicProperty:TeamBranding.kt$TeamBranding$/** * The team's URI. */ @Json(name = "uri") val uri: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * A localized string for display purposes that names the user's role on the team. * @see role */ @Json(name = "role") val localizedRole: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The URI to independently request this team membership information. */ @Json(name = "uri") val uri: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The URL for the invited user to join the team. * The value of this field is null if the invited user has already joined. * (e.g. https://vimeo.com/user/seat?code=e7c71ae7f4dc5d71a3bceb4d1d9e) */ @Json(name = "invite_url") val inviteUrl: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The resource key that identifies team membership. */ @Json(name = "resource_key") val resourceKey: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The status of the user's team membership. * @see TeamMembership.teamInviteStatusType */ @Json(name = "status") val teamInviteStatus: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The team member's email. */ @Json(name = "email") val email: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The team member. The value of this field is null if the user hasn't joined the team yet. */ @Json(name = "user") val user: User? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The team membership metadata. */ @Json(name = "metadata") val metadata: Metadata&lt;TeamMembershipConnections, BasicInteraction&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The time in ISO 8601 format at which the invite was accepted. */ @Json(name = "joined_time") val joinedTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The time in ISO 8601 format at which the invite was sent. */ @Json(name = "created_time") val createdTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The time in ISO 8601 format at which the team membership was last modified. */ @Json(name = "modified_time") val modifiedTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * The user's role on the team. * @see TeamMembership.roleType */ @Json(name = "permission_level") val role: String? = null</ID>
-    <ID>UndocumentedPublicProperty:TeamMembership.kt$TeamMembership$/** * Whether the team member has folder access. */ @Json(name = "has_folder_access") val hasFolderAccess: Boolean? = null</ID>
     <ID>UndocumentedPublicProperty:TeamMembershipConnections.kt$TeamMembershipConnections$/** * A connection object indicating how to get the owner of this user. */ @Json(name = "owner") val owner: TeamOwnerConnection? = null</ID>
     <ID>UndocumentedPublicProperty:TeamOwnerConnection.kt$TeamOwnerConnection$/** * The team owner's display name. */ @Json(name = "display_name") val displayName: String? = null</ID>
     <ID>UndocumentedPublicProperty:TeamOwnerConnection.kt$TeamOwnerConnection$/** * The total number of owners on this connection. */ @Json(name = "total") val total: Int? = null</ID>

--- a/models/detekt_baseline.xml
+++ b/models/detekt_baseline.xml
@@ -153,10 +153,6 @@
     <ID>UndocumentedPublicProperty:FeedItem.kt$FeedItem$/** * Video associated with ths feed item. */ @Json(name = "clip") val video: Video? = null</ID>
     <ID>UndocumentedPublicProperty:FeedItemConnections.kt$FeedItemConnections$/** * A list of resource URIs related to the activity. */ @Json(name = "related") val related: BasicConnection? = null</ID>
     <ID>UndocumentedPublicProperty:FileTransferPage.kt$FileTransferPage$/** * The link to the file transfer page. */ @Internal @Json(name = "link") val link: String? = null</ID>
-    <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the project items in the folder. */ @Json(name = "items") val items: BasicConnection? = null</ID>
-    <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the sub-folders in the folder. */ @Json(name = "folders") val folders: BasicConnection? = null</ID>
-    <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * A basic connection object indicating how to return all the videos in the folder. */ @Json(name = "videos") val videos: BasicConnection? = null</ID>
-    <ID>UndocumentedPublicProperty:FolderConnections.kt$FolderConnections$/** * Information about the authenticated user's team. */ @Json(name = "team_members") val teamMembers: BasicConnection? = null</ID>
     <ID>UndocumentedPublicProperty:FolderPrivacy.kt$FolderPrivacy$/** * Who can view the folder. * @see FolderPrivacy.viewPrivacyType */ @Json(name = "view") val viewPrivacy: String? = null</ID>
     <ID>UndocumentedPublicProperty:Followable.kt$Followable$val metadata: Metadata&lt;*, out FollowableInteractions&gt;?</ID>
     <ID>UndocumentedPublicProperty:Gcs.kt$Gcs$/** * Expected ending byte range for the current upload_link. */ @Internal @Json(name = "end_byte") val endByte: Long? = null</ID>

--- a/models/src/main/java/com/vimeo/networking2/AddSubfolderInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/AddSubfolderInteraction.kt
@@ -1,0 +1,31 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.Interaction
+
+/**
+ * The interaction for adding a subfolder to a parent folder.
+ *
+ * @param canAddSubfolders Whether the folder can contain a subfolder.
+ * @param contentType The content type.
+ * @param subfolderDepthLimitReached Whether the user has reached the maximum subfolder depth.
+ */
+@JsonClass(generateAdapter = true)
+data class AddSubfolderInteraction(
+
+    @Json(name = "can_add_subfolders")
+    val canAddSubfolders: Boolean? = null,
+
+    @Json(name = "content_type")
+    val contentType: String? = null,
+
+    @Json(name = "subfolder_depth_limit_reached")
+    val subfolderDepthLimitReached: Boolean? = null,
+
+    @Json(name = "options")
+    override val options: List<String>? = null,
+
+    @Json(name = "uri")
+    override val uri: String? = null
+) : Interaction

--- a/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
@@ -9,6 +9,7 @@ import com.vimeo.networking2.common.Connection
  */
 @JsonClass(generateAdapter = true)
 data class DefaultConnection(
+
     @Json(name = "options")
     override val options: List<String>? = null,
 

--- a/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
@@ -8,7 +8,7 @@ import com.vimeo.networking2.common.Connection
  * The default implementation of a connection that does not add any other properties.
  */
 @JsonClass(generateAdapter = true)
-class DefaultConnection(
+data class DefaultConnection(
     @Json(name = "options")
     override val options: List<String>? = null,
 

--- a/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/DefaultConnection.kt
@@ -1,0 +1,17 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.Connection
+
+/**
+ * The default implementation of a connection that does not add any other properties.
+ */
+@JsonClass(generateAdapter = true)
+class DefaultConnection(
+    @Json(name = "options")
+    override val options: List<String>? = null,
+
+    @Json(name = "uri")
+    override val uri: String? = null
+) : Connection

--- a/models/src/main/java/com/vimeo/networking2/Folder.kt
+++ b/models/src/main/java/com/vimeo/networking2/Folder.kt
@@ -13,93 +13,65 @@ import java.util.Date
 /**
  * A folder that acts as a container for a list of [Videos][Video] that can be fetched via
  * a uri defined in [Metadata.connections].
+ *
+ * @param createdDate The time in ISO 8601 format when the folder was created.
+ * @param lastUserActionEventDate The time in ISO 8601 format when a user last performed an action on the folder.
+ * @param link The link to the folder on Vimeo.
+ * @param metadata The folder's metadata.
+ * @param lastModifiedDate The time in ISO 8601 format when the folder was last modified.
+ * @param name The name of the folder.
+ * @param privacy The [FolderPrivacy] that defines the public visibility of the folder.
+ * @param resourceKey The resource key string of the folder.
+ * @param slackIncomingWebhooksId The Slack webhook ID for the folder.
+ * @param slackIntegrationChannel The Slack integration channel for the folder.
+ * @param slackLanguagePreference The language preference for Slack notifications about the folder. See
+ * [slackLanguagePreferenceType].
+ * @param slackUserPreference User preferences for Slack notifications about the folder. See [slackUserPreferenceType].
+ * @param uri The folder's canonical relative URI.
+ * @param user The folder's owner.
  */
 @JsonClass(generateAdapter = true)
 data class Folder(
 
-    /**
-     * The time in ISO 8601 format when the folder was created.
-     */
     @Json(name = "created_time")
     val createdDate: Date? = null,
 
-    /**
-     * The time in ISO 8601 format when a user last performed an action on the folder.
-     */
     @Json(name = "last_user_action_event_date")
     val lastUserActionEventDate: Date? = null,
 
-    /**
-     * The link to the folder on Vimeo.
-     */
     @Json(name = "link")
     val link: String? = null,
 
-    /**
-     * The folder's metadata.
-     */
     @Json(name = "metadata")
-    val metadata: Metadata<FolderConnections, BasicInteraction>? = null,
+    val metadata: Metadata<FolderConnections, FolderInteractions>? = null,
 
-    /**
-     * The time in ISO 8601 format when the folder was last modified.
-     */
     @Json(name = "modified_time")
     val lastModifiedDate: Date? = null,
 
-    /**
-     * The name of the folder.
-     */
     @Json(name = "name")
     val name: String? = null,
 
-    /**
-     * The [FolderPrivacy] that defines the public visibility of the folder.
-     */
     @Json(name = "privacy")
     val privacy: FolderPrivacy? = null,
 
-    /**
-     * The resource key string of the folder.
-     */
     @Json(name = "resource_key")
     val resourceKey: String? = null,
 
-    /**
-     * The Slack webhook ID for the folder.
-     */
     @Json(name = "slack_incoming_webhooks_id")
     val slackIncomingWebhooksId: String? = null,
 
-    /**
-     * The Slack integration channel for the folder.
-     */
     @Json(name = "slack_integration_channel")
     val slackIntegrationChannel: String? = null,
 
-    /**
-     * The language preference for Slack notifications about the folder.
-     * @see slackLanguagePreferenceType
-     */
     @Json(name = "slack_language_preference")
     val slackLanguagePreference: String? = null,
 
-    /**
-     * User preferences for Slack notifications about the folder.
-     * @see slackUserPreferenceType
-     */
     @Json(name = "slack_user_preferences")
     val slackUserPreference: String? = null,
 
-    /**
-     * The folder's canonical relative URI.
-     */
     @Json(name = "uri")
     val uri: String? = null,
 
-    /**
-     * The folder's owner.
-     */
     @Json(name = "user")
     val user: User? = null
 ) : Entity {

--- a/models/src/main/java/com/vimeo/networking2/FolderAncestorConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderAncestorConnection.kt
@@ -1,0 +1,20 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * The connection to a parent folder in the ancestor hierarchy of a folder.
+ *
+ * @param uri The URI of the parent folder.
+ * @param name The name of the parent folder.
+ */
+@JsonClass(generateAdapter = true)
+data class FolderAncestorConnection(
+
+    @Json(name = "uri")
+    val uri: String? = null,
+
+    @Json(name = "name")
+    val name: String? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/FolderConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderConnections.kt
@@ -8,6 +8,8 @@ import com.squareup.moshi.JsonClass
 /**
  * All of the connections for a folder.
  *
+ * @param ancestorPath An ordered list of connections to the parent folders of a folder. The zeroth index in the list
+ * will be the immediate parent of the folder.
  * @param folders A basic connection object indicating how to return all the sub-folders in the folder.
  * @param items A basic connection object indicating how to return all the project items in the folder.
  * @param teamMembers Information about the authenticated user's team.
@@ -16,6 +18,9 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class FolderConnections(
+
+    @Json(name = "ancestor_path")
+    val ancestorPath: List<FolderAncestorConnection>? = null,
 
     @Json(name = "folders")
     val folders: BasicConnection? = null,

--- a/models/src/main/java/com/vimeo/networking2/FolderConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderConnections.kt
@@ -7,31 +7,28 @@ import com.squareup.moshi.JsonClass
 
 /**
  * All of the connections for a folder.
+ *
+ * @param folders A basic connection object indicating how to return all the sub-folders in the folder.
+ * @param items A basic connection object indicating how to return all the project items in the folder.
+ * @param teamMembers Information about the authenticated user's team.
+ * @param parentFolder Information about the folder's parent folder if there is one.
+ * @param videos A basic connection object indicating how to return all the videos in the folder.
  */
 @JsonClass(generateAdapter = true)
 data class FolderConnections(
 
-    /**
-     * A basic connection object indicating how to return all the sub-folders in the folder.
-     */
     @Json(name = "folders")
     val folders: BasicConnection? = null,
 
-    /**
-     * A basic connection object indicating how to return all the project items in the folder.
-     */
     @Json(name = "items")
     val items: BasicConnection? = null,
 
-    /**
-     * Information about the authenticated user's team.
-     */
     @Json(name = "team_members")
     val teamMembers: BasicConnection? = null,
 
-    /**
-     * A basic connection object indicating how to return all the videos in the folder.
-     */
+    @Json(name = "parent_folder")
+    val parentFolder: DefaultConnection? = null,
+
     @Json(name = "videos")
     val videos: BasicConnection? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
@@ -10,6 +10,7 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class FolderInteractions(
+
     @Json(name = "add_subfolder")
     val addSubfolder: AddSubfolderInteraction? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
@@ -1,0 +1,15 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * The interactions for a folder.
+ *
+ * @param addSubfolder The interaction used to add a subfolder as well as determine capability for adding subfolders.
+ */
+@JsonClass(generateAdapter = true)
+data class FolderInteractions(
+    @Json(name = "add_subfolder")
+    val addSubfolder: AddSubfolderInteraction? = null
+)

--- a/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
@@ -53,6 +53,7 @@ class ModelsTest {
         FeedItemConnections::class,
         FeedList::class,
         Folder::class,
+        FolderAncestorConnection::class,
         FolderInteractions::class,
         FolderList::class,
         FolderConnections::class,

--- a/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
@@ -7,6 +7,7 @@ import kotlin.reflect.full.primaryConstructor
 class ModelsTest {
 
     private val models = listOf(
+        AddSubfolderInteraction::class,
         Album::class,
         AlbumConnections::class,
         AlbumEmbed::class,
@@ -39,6 +40,7 @@ class ModelsTest {
         BasicConnection::class,
         Credit::class,
         DashVideoFile::class,
+        DefaultConnection::class,
         Document::class,
         Drm::class,
         Email::class,
@@ -51,6 +53,7 @@ class ModelsTest {
         FeedItemConnections::class,
         FeedList::class,
         Folder::class,
+        FolderInteractions::class,
         FolderList::class,
         FolderConnections::class,
         FolderPrivacy::class,

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -475,12 +475,15 @@ interface VimeoApiClient {
      * Delete a folder.
      *
      * @param folder The folder being deleted.
+     * @param shouldDeleteClips True if the videos in the folder should also be deleted, false if they should not and
+     * instead should be moved to the root folder.
      * @param callback The callback which will be notified of the request completion.
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
     fun deleteFolder(
         folder: Folder,
+        shouldDeleteClips: Boolean,
         callback: VimeoCallback<Unit>
     ): VimeoRequest
 

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -424,6 +424,8 @@ interface VimeoApiClient {
      * Create a folder that will be used to organize videos.
      *
      * @param uri The URI of the user's folders connection.
+     * @param parentFolderId The ID of the folder in which this folder should be created, null if it should be created
+     * at the root.
      * @param name The name of the folder.
      * @param privacy The privacy of the folder.
      * @param slackWebhookId The ID of the Slack webhook for notifications.
@@ -435,6 +437,7 @@ interface VimeoApiClient {
      */
     fun createFolder(
         uri: String,
+        parentFolderId: String?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -447,6 +450,7 @@ interface VimeoApiClient {
      * Create a folder that will be used to organize videos.
      *
      * @param user The user whose folders connection will be used for the request.
+     * @param parentFolder The folder in which this folder should be created, null if it should be created at the root.
      * @param name The name of the folder.
      * @param privacy The privacy of the folder.
      * @param slackWebhookId The ID of the Slack webhook for notifications.
@@ -458,6 +462,7 @@ interface VimeoApiClient {
      */
     fun createFolder(
         user: User,
+        parentFolder: Folder?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -191,6 +191,7 @@ internal interface VimeoService {
     fun createFolder(
         @Header(AUTHORIZATION) authorization: String,
         @Url uri: String,
+        @Field(PARENT_FOLDER_ID) parentFolderId: String?,
         @Field(PARAMETER_FOLDER_NAME) name: String,
         @Field(PARAMETER_FOLDER_PRIVACY) privacy: FolderViewPrivacyType,
         @Field(SLACK_WEBHOOK_ID) slackWebhookId: String?,
@@ -631,6 +632,7 @@ internal interface VimeoService {
         private const val VIDEO_URI = "videoUri"
         private const val FOLDER_URI = "folderUri"
         private const val FIELD_FILTER = "fields"
+        private const val PARENT_FOLDER_ID = "parent_folder_id"
         private const val SLACK_WEBHOOK_ID = "slack_incoming_webhooks_id"
         private const val SLACK_LANGUAGE_PREF = "slack_language_preference"
         private const val SLACK_USER_PREF = "slack_user_preferences"

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -212,6 +212,14 @@ internal interface VimeoService {
         @Field(SLACK_USER_PREF) slackUserPref: SlackUserPreferenceType?
     ): VimeoCall<Folder>
 
+    @FormUrlEncoded
+    @HTTP(method = "DELETE", hasBody = true)
+    fun deleteFolder(
+        @Header(AUTHORIZATION) authorization: String,
+        @Url uri: String,
+        @Field(SHOULD_DELETE_CLIPS) shouldDeleteClips: Boolean
+    ): VimeoCall<Unit>
+
     @PUT("{$FOLDER_URI}/{$VIDEO_URI}")
     fun addToFolder(
         @Header(AUTHORIZATION) authorization: String,
@@ -633,6 +641,7 @@ internal interface VimeoService {
         private const val FOLDER_URI = "folderUri"
         private const val FIELD_FILTER = "fields"
         private const val PARENT_FOLDER_ID = "parent_folder_id"
+        private const val SHOULD_DELETE_CLIPS = "should_delete_clips"
         private const val SLACK_WEBHOOK_ID = "slack_incoming_webhooks_id"
         private const val SLACK_LANGUAGE_PREF = "slack_language_preference"
         private const val SLACK_USER_PREF = "slack_user_preferences"

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -214,6 +214,7 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
 
     override fun createFolder(
         uri: String,
+        parentFolderId: String?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -222,6 +223,7 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         callback: VimeoCallback<Folder>
     ): VimeoRequest = client.createFolder(
         uri,
+        parentFolderId,
         name,
         privacy,
         slackWebhookId,
@@ -232,6 +234,7 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
 
     override fun createFolder(
         user: User,
+        parentFolder: Folder?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -240,6 +243,7 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         callback: VimeoCallback<Folder>
     ): VimeoRequest = client.createFolder(
         user,
+        parentFolder,
         name,
         privacy,
         slackWebhookId,

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -252,8 +252,8 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         callback
     )
 
-    override fun deleteFolder(folder: Folder, callback: VimeoCallback<Unit>): VimeoRequest =
-        client.deleteFolder(folder, callback)
+    override fun deleteFolder(folder: Folder, shouldDeleteClips: Boolean, callback: VimeoCallback<Unit>): VimeoRequest =
+        client.deleteFolder(folder, shouldDeleteClips, callback)
 
     override fun editFolder(
         uri: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -332,6 +332,7 @@ internal class VimeoApiClientImpl(
 
     override fun createFolder(
         uri: String,
+        parentFolderId: String?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -343,6 +344,7 @@ internal class VimeoApiClientImpl(
         return vimeoService.createFolder(
             authHeader,
             safeUri,
+            parentFolderId,
             name,
             privacy,
             slackWebhookId,
@@ -353,6 +355,7 @@ internal class VimeoApiClientImpl(
 
     override fun createFolder(
         user: User,
+        parentFolder: Folder?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -362,9 +365,11 @@ internal class VimeoApiClientImpl(
     ): VimeoRequest {
         val safeUri = user.metadata?.connections?.folders?.uri.notEmpty()
             ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val parentFolderId = parentFolder?.uri?.lastPathSegment()
         return vimeoService.createFolder(
             authHeader,
             safeUri,
+            parentFolderId,
             name,
             privacy,
             slackWebhookId,
@@ -1254,6 +1259,8 @@ internal class VimeoApiClientImpl(
             ))
         ), callback)
     }
+
+    private fun String.lastPathSegment(): String = this.substringAfterLast(delimiter = '/')
 
     /**
      * @return The [String] if it is not empty or blank, otherwise returns null.

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -378,9 +378,13 @@ internal class VimeoApiClientImpl(
         ).enqueue(callback)
     }
 
-    override fun deleteFolder(folder: Folder, callback: VimeoCallback<Unit>): VimeoRequest {
+    override fun deleteFolder(
+        folder: Folder,
+        shouldDeleteClips: Boolean,
+        callback: VimeoCallback<Unit>
+    ): VimeoRequest {
         val uri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        return deleteContent(uri, emptyMap(), callback)
+        return vimeoService.deleteFolder(authHeader, uri, shouldDeleteClips).enqueue(callback)
     }
 
     override fun editFolder(


### PR DESCRIPTION
# Summary
- Added the `metadata.interactions.add_subfolder` interaction to the `Folder`, creating the `AddSubfolderInteraction` and `FolderInteractions` classes.
- Added the `metadata.connections.ancestor_path` connection to the `Folder`, creating the `FolderAncestorConnection`.
- Added the `metadata.connections.parent_folder` connection to the `Folder`, creating the `DefaultConnection` for that.
- Updated the `addFolder` function to `VimeoApiClient` to accept a `parentFolder: Folder?` or a `parentFolderId: String?` to support adding subfolders.
- Added a `shouldDeleteClips: Boolean` parameter to `deleteFolder` to support conditionally deleting all the content in a folder when deleting it.