### PR TITLE
Making sure parcelable and serializable are both generated

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.vimeo.example"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -26,9 +26,8 @@ android {
 }
 
 dependencies {
-    implementation project(':auth')
-    implementation project(':request')
-    implementation project(':models')
+    implementation project(':models-parcelable')
+    implementation project(':vimeo-networking')
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsPlugin.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsPlugin.kt
@@ -11,32 +11,27 @@ class GenerateModelsPlugin : Plugin<Project> {
         val extension =
             project.extensions.create(EXTENSION_NAME, GenerateModelsExtension::class.java, project)
 
-        // Android projects can also have the JVM plugin applied, so we ensure to only register the task once.
-        if (project.plugins.findPlugin(KOTLIN_ANDROID) != null) {
-            // Sets up task on Android based projects.
-            project.plugins.withId(KOTLIN_ANDROID) {
-                registerTask(project, extension)
-                project.tasks.findByName(PRE_BUILD)?.dependsOn(GENERATE_MODELS)
-            }
-        } else {
-            // Sets up tasks on JVM based projects.
-            project.plugins.withId(KOTLIN_JVM) {
-                registerTask(project, extension)
+        project.pluginManager.withPlugin(KOTLIN_ANDROID) {
+            registerTask(project, extension)
+            project.tasks.findByName(PRE_BUILD)?.dependsOn(GENERATE_MODELS)
+        }
 
-                // kaptGenerateStubsKotlin is used as the set up task instead of build
-                // because kapt code generation happens before build is called and
-                // we need to generate the models prior to kapt so the Moshi adapters
-                // can also be generated.
-                val kaptTask: Task? = project.tasks.findByName(KAPT_GENERATE_STUBS)
+        project.pluginManager.withPlugin(KOTLIN_JVM) {
+            registerTask(project, extension)
 
-                // When generating to a module that doesn't use kapt this task will be null
-                // in that case compileKotlin is the earliest task run when the module is being
-                // built so we can attach generateModels to that instead.
-                if (kaptTask != null) {
-                    kaptTask.dependsOn(GENERATE_MODELS)
-                } else {
-                    project.tasks.findByName(COMPILE_KOTLIN)?.dependsOn(GENERATE_MODELS)
-                }
+            // kaptGenerateStubsKotlin is used as the set up task instead of build
+            // because kapt code generation happens before build is called and
+            // we need to generate the models prior to kapt so the Moshi adapters
+            // can also be generated.
+            val kaptTask: Task? = project.tasks.findByName(KAPT_GENERATE_STUBS)
+
+            // When generating to a module that doesn't use kapt this task will be null
+            // in that case compileKotlin is the earliest task run when the module is being
+            // built so we can attach generateModels to that instead.
+            if (kaptTask != null) {
+                kaptTask.dependsOn(GENERATE_MODELS)
+            } else {
+                project.tasks.findByName(COMPILE_KOTLIN)?.dependsOn(GENERATE_MODELS)
             }
         }
     }

--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsPlugin.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/GenerateModelsPlugin.kt
@@ -13,7 +13,9 @@ class GenerateModelsPlugin : Plugin<Project> {
 
         project.pluginManager.withPlugin(KOTLIN_ANDROID) {
             registerTask(project, extension)
-            project.tasks.findByName(PRE_BUILD)?.dependsOn(GENERATE_MODELS)
+            project.afterEvaluate {
+                project.tasks.findByName(PRE_BUILD)?.dependsOn(project.tasks.findByName(GENERATE_MODELS))
+            }
         }
 
         project.pluginManager.withPlugin(KOTLIN_JVM) {

--- a/models-parcelable/src/test/java/com/vimeo/networking2/ModelTest.kt
+++ b/models-parcelable/src/test/java/com/vimeo/networking2/ModelTest.kt
@@ -26,6 +26,11 @@ class ModelTest {
             .loadClasses()
 
     @Test
+    fun `models exist`() {
+        assertThat(models).isNotEmpty
+    }
+
+    @Test
     fun `models are Parcelable`() {
         models
                 .map {

--- a/models-serializable/src/test/java/com/vimeo/networking2/ModelTest.kt
+++ b/models-serializable/src/test/java/com/vimeo/networking2/ModelTest.kt
@@ -22,6 +22,11 @@ class ModelTest {
             .loadClasses()
 
     @Test
+    fun `models exist`() {
+        assertThat(models).isNotEmpty
+    }
+
+    @Test
     fun `models are Serializable`() {
         models
                 .map {


### PR DESCRIPTION
# Summary
The parcelable models were not being generated for some time, likely due to a change in the gradle version or android plugin. 

I was able to identify that the root cause was that the android plugin could not be found at the time of configuration. The solution was to use the more modern `withPlugin` expression that would run the lambda after the plugin was applied. This exposed another issue, where the `preBuild` task could not have a dependency added to it as we were initially doing it. The solution to this issue was to attach it in `afterEvaluate` and to find the real path of the task dependency after it was configured.

In order to prevent this issue from happening without us knowing it in the future, I added a couple tests to the serializable and parcelable test suites that verifies that the generated files are not empty.

Additionally, I made the example depend on the parcelable models since it is an android project.