### PR TITLE
Allow prepopulated query parameters while disallowing path traversal and other hosts

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -27,6 +27,7 @@ import com.vimeo.networking2.ApiConstants
 import com.vimeo.networking2.internal.ErrorHandlingCallAdapterFactory
 import com.vimeo.networking2.internal.interceptor.AcceptHeaderInterceptor
 import com.vimeo.networking2.internal.interceptor.CacheControlHeaderInterceptor
+import com.vimeo.networking2.internal.interceptor.HostValidationInterceptor
 import com.vimeo.networking2.internal.interceptor.LanguageHeaderInterceptor
 import com.vimeo.networking2.internal.interceptor.UserAgentHeaderInterceptor
 import com.vimeo.networking2.internal.params.StringValueJsonAdapterFactory
@@ -62,6 +63,7 @@ object RetrofitSetupModule {
     @JvmStatic
     fun retrofit(vimeoApiConfiguration: VimeoApiConfiguration): Retrofit {
         val interceptors = mutableListOf(
+            HostValidationInterceptor(vimeoApiConfiguration),
             UserAgentHeaderInterceptor(vimeoApiConfiguration.compositeUserAgent),
             AcceptHeaderInterceptor(),
             LanguageHeaderInterceptor(vimeoApiConfiguration.locales)

--- a/api-core/src/main/java/com/vimeo/networking2/internal/interceptor/HostValidationInterceptor.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/internal/interceptor/HostValidationInterceptor.kt
@@ -1,0 +1,25 @@
+package com.vimeo.networking2.internal.interceptor
+
+import com.vimeo.networking2.config.VimeoApiConfiguration
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+import okio.IOException
+
+/**
+ * An interceptor that ensures that only requests to the host specified in the [VimeoApiConfiguration] are made. This
+ * prevents unexpected requests from being made to other hosts.
+ *
+ * @param vimeoApiConfiguration The configuration used to determine the expected host.
+ */
+class HostValidationInterceptor(private val vimeoApiConfiguration: VimeoApiConfiguration) : Interceptor {
+    private val httpUrl = HttpUrl.parse(vimeoApiConfiguration.baseUrl)
+
+    override fun intercept(chain: Interceptor.Chain): Response =
+        if (chain.request().url().host() != httpUrl?.host()) {
+            throw IOException("Host must match specified base URL, was ${chain.request().url().host()}, " +
+                "expected ${httpUrl?.host()}")
+        } else {
+            chain.proceed(chain.request())
+        }
+}

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -81,33 +81,33 @@ internal interface VimeoService {
         @Path(TYPE) type: ConnectedAppType
     ): VimeoCall<Unit>
 
-    @GET("{path}")
+    @GET
     fun getPublishJob(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<PublishJob>
 
-    @PUT("{path}")
+    @PUT
     @Headers(HEADER_NO_CACHE)
     fun putPublishJob(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body publishData: BatchPublishToSocialMedia
     ): VimeoCall<PublishJob>
 
-    @POST("{path}")
+    @POST
     fun createAlbum(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body bodyParams: Map<String, @JvmSuppressWildcards Any>
     ): VimeoCall<Album>
 
-    @PATCH("{path}")
+    @PATCH
     fun editAlbum(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body bodyParams: Map<String, @JvmSuppressWildcards Any>
     ): VimeoCall<Album>
 
@@ -139,28 +139,28 @@ internal interface VimeoService {
         @Body modificationSpecs: ModifyVideoInAlbumsSpecs
     ): VimeoCall<AlbumList>
 
-    @PATCH("{path}")
+    @PATCH
     fun editVideo(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body bodyParams: Map<String, @JvmSuppressWildcards Any>
     ): VimeoCall<Video>
 
     @FormUrlEncoded
-    @PATCH("{path}")
+    @PATCH
     fun editUser(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARAMETER_USERS_NAME) name: String?,
         @Field(PARAMETER_USERS_LOCATION) location: String?,
         @Field(PARAMETER_USERS_BIO) bio: String?
     ): VimeoCall<User>
 
     @FormUrlEncoded
-    @PATCH("{path}")
+    @PATCH
     fun editPictureCollection(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARAMETER_ACTIVE) isActive: Boolean
     ): VimeoCall<PictureCollection>
 
@@ -171,26 +171,26 @@ internal interface VimeoService {
     ): VimeoCall<NotificationSubscriptions>
 
     @FormUrlEncoded
-    @POST("{path}")
+    @POST
     fun createComment(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(PARAMETER_PASSWORD) password: String?,
         @Field(PARAMETER_COMMENT_TEXT_BODY) commentBody: String
     ): VimeoCall<Comment>
 
-    @POST("{path}")
+    @POST
     fun createPictureCollection(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String
+        @Url uri: String
     ): VimeoCall<PictureCollection>
 
     @Suppress("LongParameterList")
     @FormUrlEncoded
-    @POST("{path}")
+    @POST
     fun createFolder(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARENT_FOLDER_ID) parentFolderId: String?,
         @Field(PARAMETER_FOLDER_NAME) name: String,
         @Field(PARAMETER_FOLDER_PRIVACY) privacy: FolderViewPrivacyType,
@@ -201,10 +201,10 @@ internal interface VimeoService {
 
     @Suppress("LongParameterList")
     @FormUrlEncoded
-    @PATCH("{path}")
+    @PATCH
     fun editFolder(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARAMETER_FOLDER_NAME) name: String,
         @Field(PARAMETER_FOLDER_PRIVACY) privacy: FolderViewPrivacyType,
         @Field(SLACK_WEBHOOK_ID) slackWebhookId: String?,
@@ -216,7 +216,7 @@ internal interface VimeoService {
     @HTTP(method = "DELETE", path = "{path}", hasBody = true)
     fun deleteFolder(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(SHOULD_DELETE_CLIPS) shouldDeleteClips: Boolean
     ): VimeoCall<Unit>
 
@@ -234,256 +234,256 @@ internal interface VimeoService {
         @Path(VIDEO_URI, encoded = true) videoUri: String
     ): VimeoCall<Unit>
 
-    @GET("{path}")
+    @GET
     fun getAppConfiguration(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<AppConfiguration>
 
-    @GET("{path}")
+    @GET
     fun getCategory(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Category>
 
-    @GET("{path}")
+    @GET
     fun getChannel(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Channel>
 
-    @GET("{path}")
+    @GET
     fun getComment(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Comment>
 
-    @GET("{path}")
+    @GET
     fun getDocument(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String
+        @Url uri: String
     ): VimeoCall<Document>
 
-    @GET("{path}")
+    @GET
     fun getFolder(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Folder>
 
-    @GET("{path}")
+    @GET
     fun getTvodItem(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<TvodItem>
 
-    @GET("{path}")
+    @GET
     fun getUser(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<User>
 
-    @GET("{path}")
+    @GET
     fun getVideo(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Video>
 
-    @GET("{path}")
+    @GET
     fun getLiveStats(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<LiveStats>
 
-    @GET("{path}")
+    @GET
     fun getProduct(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Product>
 
-    @GET("{path}")
+    @GET
     fun getAlbum(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Album>
 
-    @GET("{path}")
+    @GET
     fun getCategoryList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<CategoryList>
 
-    @GET("{path}")
+    @GET
     fun getChannelList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<ChannelList>
 
-    @GET("{path}")
+    @GET
     fun getCommentList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<CommentList>
 
-    @GET("{path}")
+    @GET
     fun getFolderList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<FolderList>
 
-    @GET("{path}")
+    @GET
     fun getFeedList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<FeedList>
 
-    @GET("{path}")
+    @GET
     fun getProjectItemList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<ProjectItemList>
 
-    @GET("{path}")
+    @GET
     fun getTeamList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<TeamList>
 
-    @GET("{path}")
+    @GET
     fun getNotificationList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<NotificationList>
 
-    @GET("{path}")
+    @GET
     fun getProgramContentItemList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<ProgrammedContentItemList>
 
-    @GET("{path}")
+    @GET
     fun getRecommendationList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<RecommendationList>
 
-    @GET("{path}")
+    @GET
     fun getSearchResultList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<SearchResultList>
 
-    @GET("{path}")
+    @GET
     fun getSeasonList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<SeasonList>
 
-    @GET("{path}")
+    @GET
     fun getTvodItemList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<TvodItemList>
 
-    @GET("{path}")
+    @GET
     fun getUserList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<UserList>
 
-    @GET("{path}")
+    @GET
     fun getVideoList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<VideoList>
 
-    @GET("{path}")
+    @GET
     fun getAlbumList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<AlbumList>
 
-    @GET("{path}")
+    @GET
     fun getTextTrackList(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<TextTrackList>
@@ -495,10 +495,10 @@ internal interface VimeoService {
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<ProductList>
 
-    @GET("{path}")
+    @GET
     fun getVideoStatus(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
@@ -510,10 +510,10 @@ internal interface VimeoService {
         @Path(CODE) code: String
     ): VimeoCall<TeamMembership>
 
-    @GET("{path}")
+    @GET
     fun getTeamMembers(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Query(FIELD_FILTER) fieldFilter: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
@@ -521,105 +521,105 @@ internal interface VimeoService {
 
     @Suppress("LongParameterList")
     @FormUrlEncoded
-    @POST("{path}")
+    @POST
     fun addUserToTeam(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARAMETER_EMAIL) email: String,
         @Field(PARAMETER_PERMISSION_LEVEL) permissionLevel: TeamRoleType,
         @Field(PARAMETER_FOLDER_URI) folderUri: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<TeamMembership>
 
-    @DELETE("{path}")
+    @DELETE
     fun removeUserFromTeam(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<Unit>
 
     @FormUrlEncoded
-    @PATCH("{path}")
+    @PATCH
     fun changeUserRole(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Field(PARAMETER_ROLE) role: TeamRoleType,
         @Field(PARAMETER_FOLDER_URI) folderUri: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<TeamMembership>
 
-    @PUT("{path}")
+    @PUT
     fun grantUsersAccessToFolder(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body usersIds: List<GrantFolderPermissionForUser>,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<Unit>
 
-    @GET("{path}")
+    @GET
     fun getUnit(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<Unit>
 
-    @PUT("{path}")
+    @PUT
     fun putContentWithUserResponse(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Body bodyParams: Any
     ): VimeoCall<User>
 
-    @PUT("{path}")
+    @PUT
     fun putContentWithUserResponse(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<User>
 
-    @PUT("{path}")
+    @PUT
     fun put(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<Unit>
 
-    @PUT("{path}")
+    @PUT
     fun put(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Body bodyParams: Any
     ): VimeoCall<Unit>
 
-    @DELETE("{path}")
+    @DELETE
     fun delete(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<Unit>
 
-    @POST("{path}")
+    @POST
     fun post(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body bodyParams: List<@JvmSuppressWildcards Any>
     ): VimeoCall<Unit>
 
-    @PATCH("{path}")
+    @PATCH
     fun emptyResponsePatch(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
         @Body bodyParams: Any
     ): VimeoCall<Unit>
 
-    @POST("{path}")
+    @POST
     fun emptyResponsePost(
         @Header(AUTHORIZATION) authorization: String,
-        @Path("path", encoded = true) uri: String,
+        @Url uri: String,
         @Body bodyParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<Unit>
 

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -58,7 +58,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Album>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val body = bodyParams.intoMutableMap()
         body[ApiConstants.Parameters.PARAMETER_ALBUM_NAME] = name
         body[ApiConstants.Parameters.PARAMETER_ALBUM_PRIVACY] = albumPrivacy.viewPrivacy
@@ -80,8 +80,8 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Album>
     ): VimeoRequest {
-        val safeUri =
-            user.metadata?.connections?.albums?.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = user.metadata?.connections?.albums?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return createAlbum(safeUri, name, albumPrivacy, description, bodyParams, callback)
     }
 
@@ -93,7 +93,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Album>
     ): VimeoRequest {
-        val uri = album.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = album.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return editAlbum(uri, name, albumPrivacy, description, bodyParams, callback)
     }
 
@@ -105,7 +105,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Album>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val body = bodyParams.intoMutableMap()
         body[ApiConstants.Parameters.PARAMETER_ALBUM_NAME] = name
         body[ApiConstants.Parameters.PARAMETER_ALBUM_PRIVACY] = albumPrivacy.viewPrivacy
@@ -120,31 +120,31 @@ internal class VimeoApiClientImpl(
     }
 
     override fun deleteAlbum(album: Album, callback: VimeoCallback<Unit>): VimeoRequest {
-        val uri = album.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = album.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return deleteContent(uri, emptyMap(), callback)
     }
 
     override fun addToAlbum(album: Album, video: Video, callback: VimeoCallback<Unit>): VimeoRequest {
-        val albumUri = album.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val videoUri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val albumUri = album.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val videoUri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return addToAlbum(albumUri, videoUri, callback)
     }
 
     override fun addToAlbum(albumUri: String, videoUri: String, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeAlbumUri = albumUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val safeVideoUri = videoUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeAlbumUri = albumUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val safeVideoUri = videoUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.addToAlbum(authHeader, safeAlbumUri, safeVideoUri).enqueue(callback)
     }
 
     override fun removeFromAlbum(album: Album, video: Video, callback: VimeoCallback<Unit>): VimeoRequest {
-        val albumUri = album.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val videoUri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val albumUri = album.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val videoUri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return removeFromAlbum(albumUri, videoUri, callback)
     }
 
     override fun removeFromAlbum(albumUri: String, videoUri: String, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeAlbumUri = albumUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val safeVideoUri = videoUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeAlbumUri = albumUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val safeVideoUri = videoUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.removeFromAlbum(authHeader, safeAlbumUri, safeVideoUri).enqueue(callback)
     }
 
@@ -153,7 +153,7 @@ internal class VimeoApiClientImpl(
         modificationSpecs: ModifyVideosInAlbumSpecs,
         callback: VimeoCallback<VideoList>
     ): VimeoRequest {
-        val uri = album.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = album.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return modifyVideosInAlbum(uri, modificationSpecs, callback)
     }
 
@@ -162,7 +162,7 @@ internal class VimeoApiClientImpl(
         modificationSpecs: ModifyVideosInAlbumSpecs,
         callback: VimeoCallback<VideoList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.modifyVideosInAlbum(authHeader, safeUri, modificationSpecs).enqueue(callback)
     }
 
@@ -171,7 +171,7 @@ internal class VimeoApiClientImpl(
         modificationSpecs: ModifyVideoInAlbumsSpecs,
         callback: VimeoCallback<AlbumList>
     ): VimeoRequest {
-        val uri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return modifyVideoInAlbums(uri, modificationSpecs, callback)
     }
 
@@ -180,7 +180,7 @@ internal class VimeoApiClientImpl(
         modificationSpecs: ModifyVideoInAlbumsSpecs,
         callback: VimeoCallback<AlbumList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.modifyVideoInAlbums(authHeader, safeUri, modificationSpecs).enqueue(callback)
     }
 
@@ -198,7 +198,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Video>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val body = bodyParams.intoMutableMap()
         if (title != null) {
             body[ApiConstants.Parameters.PARAMETER_VIDEO_NAME] = title
@@ -248,7 +248,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, Any>?,
         callback: VimeoCallback<Video>
     ): VimeoRequest {
-        val uri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return editVideo(
             uri,
             title,
@@ -271,7 +271,7 @@ internal class VimeoApiClientImpl(
         bio: String?,
         callback: VimeoCallback<User>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.editUser(authHeader, safeUri, name, location, bio).enqueue(callback)
     }
 
@@ -282,7 +282,7 @@ internal class VimeoApiClientImpl(
         bio: String?,
         callback: VimeoCallback<User>
     ): VimeoRequest {
-        val uri = user.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = user.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return editUser(uri, name, location, bio, callback)
     }
 
@@ -340,7 +340,7 @@ internal class VimeoApiClientImpl(
         slackUserPreference: SlackUserPreferenceType?,
         callback: VimeoCallback<Folder>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.createFolder(
             authHeader,
             safeUri,
@@ -363,8 +363,8 @@ internal class VimeoApiClientImpl(
         slackUserPreference: SlackUserPreferenceType?,
         callback: VimeoCallback<Folder>
     ): VimeoRequest {
-        val safeUri = user.metadata?.connections?.folders?.uri.notEmpty()
-            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = user.metadata?.connections?.folders?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val parentFolderId = parentFolder?.uri?.lastPathSegment()
         return vimeoService.createFolder(
             authHeader,
@@ -383,7 +383,7 @@ internal class VimeoApiClientImpl(
         shouldDeleteClips: Boolean,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val uri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = folder.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.deleteFolder(authHeader, uri, shouldDeleteClips).enqueue(callback)
     }
 
@@ -396,7 +396,7 @@ internal class VimeoApiClientImpl(
         slackUserPreference: SlackUserPreferenceType?,
         callback: VimeoCallback<Folder>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.editFolder(
             authHeader,
             safeUri,
@@ -417,7 +417,7 @@ internal class VimeoApiClientImpl(
         slackUserPreference: SlackUserPreferenceType?,
         callback: VimeoCallback<Folder>
     ): VimeoRequest {
-        val safeUri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = folder.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.editFolder(
             authHeader,
             safeUri,
@@ -430,26 +430,26 @@ internal class VimeoApiClientImpl(
     }
 
     override fun addToFolder(folder: Folder, video: Video, callback: VimeoCallback<Unit>): VimeoRequest {
-        val folderUri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val videoUri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val folderUri = folder.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val videoUri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return addToFolder(folderUri, videoUri, callback)
     }
 
     override fun addToFolder(folderUri: String, videoUri: String, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeFolderUri = folderUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val safeVideoUri = videoUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeFolderUri = folderUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val safeVideoUri = videoUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.addToFolder(authHeader, safeFolderUri, safeVideoUri).enqueue(callback)
     }
 
     override fun removeFromFolder(folder: Folder, video: Video, callback: VimeoCallback<Unit>): VimeoRequest {
-        val folderUri = folder.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val videoUri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val folderUri = folder.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val videoUri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return removeFromFolder(folderUri, videoUri, callback)
     }
 
     override fun removeFromFolder(folderUri: String, videoUri: String, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeFolderUri = folderUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
-        val safeVideoUri = videoUri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeFolderUri = folderUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+        val safeVideoUri = videoUri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.removeFromFolder(authHeader, safeFolderUri, safeVideoUri).enqueue(callback)
     }
 
@@ -459,7 +459,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<PublishJob>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getPublishJob(authHeader, safeUri, fieldFilter, cacheControl)
             .enqueue(callback)
     }
@@ -469,7 +469,7 @@ internal class VimeoApiClientImpl(
         publishData: BatchPublishToSocialMedia,
         callback: VimeoCallback<PublishJob>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.putPublishJob(authHeader, safeUri, publishData).enqueue(callback)
     }
 
@@ -478,7 +478,7 @@ internal class VimeoApiClientImpl(
         publishData: BatchPublishToSocialMedia,
         callback: VimeoCallback<PublishJob>
     ): VimeoRequest {
-        val uri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return putPublishJob(uri, publishData, callback)
     }
 
@@ -499,7 +499,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Document>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getDocument(authHeader, safeUri).enqueue(callback)
     }
 
@@ -509,7 +509,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Folder>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getFolder(authHeader, safeUri, fieldFilter, cacheControl).enqueue(callback)
     }
 
@@ -520,7 +520,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<FolderList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getFolderList(
             authHeader,
             safeUri,
@@ -536,7 +536,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<TextTrackList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getTextTrackList(authHeader, safeUri, fieldFilter, cacheControl)
             .enqueue(callback)
     }
@@ -548,7 +548,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<VideoStatus>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getVideoStatus(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -560,7 +560,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<TeamMembershipList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getTeamMembers(
             authHeader,
             safeUri,
@@ -571,7 +571,7 @@ internal class VimeoApiClientImpl(
     }
 
     override fun acceptTeamInvite(code: String, callback: VimeoCallback<TeamMembership>): VimeoRequest {
-        val safeCode = code.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeCode = code.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.acceptTeamInvite(authHeader, safeCode).enqueue(callback)
     }
 
@@ -583,7 +583,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.addUserToTeam(
             authHeader,
             safeUri,
@@ -602,8 +602,8 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
-        val safeUri = team.owner?.metadata?.connections?.teamMembers?.uri.notEmpty()
-            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = team.owner?.metadata?.connections?.teamMembers?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.addUserToTeam(
             authHeader,
             safeUri,
@@ -619,7 +619,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.removeUserFromTeam(authHeader, safeUri, queryParams.orEmpty()).enqueue(callback)
     }
 
@@ -628,7 +628,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = membership.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = membership.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.removeUserFromTeam(authHeader, safeUri, queryParams.orEmpty()).enqueue(callback)
     }
 
@@ -639,7 +639,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.changeUserRole(authHeader, safeUri, role, folderUri, queryParams.orEmpty())
             .enqueue(callback)
     }
@@ -651,7 +651,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
-        val safeUri = membership.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = membership.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.changeUserRole(authHeader, safeUri, role, folder?.uri, queryParams.orEmpty())
             .enqueue(callback)
     }
@@ -662,7 +662,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.grantUsersAccessToFolder(
             authHeader,
             safeUri,
@@ -677,8 +677,8 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = folder.metadata?.connections?.teamMembers?.uri.notEmpty()
-            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = folder.metadata?.connections?.teamMembers?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.grantUsersAccessToFolder(
             authHeader,
             safeUri,
@@ -692,7 +692,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getUnit(authHeader, safeUri, emptyMap(), cacheControl).enqueue(callback)
     }
 
@@ -759,12 +759,12 @@ internal class VimeoApiClientImpl(
     }
 
     override fun createPictureCollection(uri: String, callback: VimeoCallback<PictureCollection>): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.createPictureCollection(authHeader, safeUri).enqueue(callback)
     }
 
     override fun activatePictureCollection(uri: String, callback: VimeoCallback<PictureCollection>): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.editPictureCollection(
             authHeader,
             safeUri,
@@ -776,12 +776,12 @@ internal class VimeoApiClientImpl(
         pictureCollection: PictureCollection,
         callback: VimeoCallback<PictureCollection>
     ): VimeoRequest {
-        val uri = pictureCollection.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = pictureCollection.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return activatePictureCollection(uri, callback)
     }
 
     override fun updateFollow(isFollowing: Boolean, uri: String, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return if (isFollowing) {
             vimeoService.put(authHeader, safeUri, emptyMap()).enqueue(callback)
         } else {
@@ -794,8 +794,8 @@ internal class VimeoApiClientImpl(
         followable: Followable,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val uri = followable.metadata?.interactions?.follow?.uri.notEmpty()
-            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = followable.metadata?.interactions?.follow?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return updateFollow(isFollowing, uri, callback)
     }
 
@@ -805,7 +805,7 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val optionsMap = password.asPasswordParameter()
         return if (isLiked) {
             vimeoService.put(authHeader, safeUri, optionsMap).enqueue(callback)
@@ -820,7 +820,7 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val uri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return updateVideoLike(isLiked, uri, password, callback)
     }
 
@@ -830,7 +830,7 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         val optionsMap = password.asPasswordParameter()
         return if (isWatchLater) {
             vimeoService.put(authHeader, safeUri, optionsMap).enqueue(callback)
@@ -845,7 +845,7 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val uri = video.uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return updateVideoWatchLater(isWatchLater, uri, password, callback)
     }
 
@@ -855,7 +855,7 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Comment>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.createComment(authHeader, safeUri, password, comment).enqueue(callback)
     }
 
@@ -865,8 +865,8 @@ internal class VimeoApiClientImpl(
         password: String?,
         callback: VimeoCallback<Comment>
     ): VimeoRequest {
-        val uri = video.metadata?.connections?.comments?.uri.notEmpty()
-            ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val uri = video.metadata?.connections?.comments?.uri.validate()
+            ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return createComment(uri, comment, password, callback)
     }
 
@@ -884,7 +884,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Product>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getProduct(authHeader, safeUri, fieldFilter, cacheControl).enqueue(callback)
     }
 
@@ -902,7 +902,7 @@ internal class VimeoApiClientImpl(
     }
 
     override fun postContent(uri: String, bodyParams: List<Any>, callback: VimeoCallback<Unit>): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.post(authHeader, safeUri, bodyParams).enqueue(callback)
     }
 
@@ -911,7 +911,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Map<String, String>,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.emptyResponsePost(authHeader, safeUri, bodyParams).enqueue(callback)
     }
 
@@ -921,7 +921,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Any,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.emptyResponsePatch(authHeader, safeUri, queryParams, bodyParams).enqueue(callback)
     }
 
@@ -931,7 +931,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Any?,
         callback: VimeoCallback<User>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return if (bodyParams != null) {
             vimeoService.putContentWithUserResponse(authHeader, safeUri, queryParams, bodyParams).enqueue(callback)
         } else {
@@ -945,7 +945,7 @@ internal class VimeoApiClientImpl(
         bodyParams: Any?,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return if (bodyParams != null) {
             vimeoService.put(authHeader, safeUri, queryParams, bodyParams).enqueue(callback)
         } else {
@@ -958,7 +958,7 @@ internal class VimeoApiClientImpl(
         queryParams: Map<String, String>,
         callback: VimeoCallback<Unit>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.delete(authHeader, safeUri, queryParams).enqueue(callback)
     }
 
@@ -969,7 +969,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Video>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getVideo(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -981,7 +981,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<LiveStats>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getLiveStats(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -993,7 +993,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<VideoList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getVideoList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1005,7 +1005,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<FeedList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getFeedList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1017,7 +1017,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<ProjectItemList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getProjectItemList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1029,7 +1029,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<TeamList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getTeamList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1041,7 +1041,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<ProgrammedContentItemList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getProgramContentItemList(
             authHeader,
             safeUri,
@@ -1058,7 +1058,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<RecommendationList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getRecommendationList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1070,7 +1070,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<SearchResultList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getSearchResultList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1082,7 +1082,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<SeasonList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getSeasonList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1094,7 +1094,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<NotificationList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getNotificationList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1105,7 +1105,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<User>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getUser(authHeader, safeUri, fieldFilter, cacheControl)
             .enqueue(callback)
     }
@@ -1117,7 +1117,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<UserList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getUserList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1129,7 +1129,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Category>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getCategory(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1141,7 +1141,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<CategoryList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getCategoryList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1153,7 +1153,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Channel>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getChannel(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1165,7 +1165,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<ChannelList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getChannelList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1177,7 +1177,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<AppConfiguration>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getAppConfiguration(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1189,7 +1189,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Album>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getAlbum(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1201,7 +1201,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<AlbumList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getAlbumList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1213,7 +1213,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<TvodItem>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getTvodItem(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1225,7 +1225,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<TvodItemList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getTvodItemList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1237,7 +1237,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<Comment>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getComment(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
@@ -1249,17 +1249,17 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<CommentList>
     ): VimeoRequest {
-        val safeUri = uri.notEmpty() ?: return localVimeoCallAdapter.enqueueEmptyUri(callback)
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getCommentList(authHeader, safeUri, fieldFilter, queryParams.orEmpty(), cacheControl)
             .enqueue(callback)
     }
 
-    private fun <T> LocalVimeoCallAdapter.enqueueEmptyUri(callback: VimeoCallback<T>): VimeoRequest {
+    private fun <T> LocalVimeoCallAdapter.enqueueInvalidUri(callback: VimeoCallback<T>): VimeoRequest {
         return enqueueError(ApiError(
-            developerMessage = "An empty URI was provided",
+            developerMessage = "An invalid URI was provided, cannot be empty or contain ..",
             invalidParameters = listOf(InvalidParameter(
                 errorCode = ErrorCodeType.INVALID_URI.value,
-                developerMessage = "An empty URI was provided"
+                developerMessage = "An invalid URI was provided, cannot be empty or contain .."
             ))
         ), callback)
     }
@@ -1267,9 +1267,9 @@ internal class VimeoApiClientImpl(
     private fun String.lastPathSegment(): String = this.substringAfterLast(delimiter = '/')
 
     /**
-     * @return The [String] if it is not empty or blank, otherwise returns null.
+     * @return The [String] if it is not empty or blank and does not contain a path traversal, otherwise returns null.
      */
-    private fun String?.notEmpty(): String? = this?.takeIf { it.isNotBlank() }
+    private fun String?.validate(): String? = this?.takeIf { it.isNotBlank() && !it.contains("..") }
 
     private fun <T : StringValue> T.validate(): T =
         this.takeIf { it.value?.isNotEmpty() == true } ?: error(INVALID_ENUM_MESSAGE)


### PR DESCRIPTION
Recent changes to disallow path traversal and making requests to hosts other than the Vimeo API were made. Unfortunately these changes prevent prepopulated query params from being attached to a URI and a request being made to that URI. Since we rely heavily on making request to a URI that already has these params populated (for example the next page URI in a paging request, which has the field filters) we need to support this use case.

The solution I found was to revert to using `@Url` instead of `@Path` and manually prevent path traversal by using the existing validation code we had to validate that a non empty URI was used. Now the `notEmpty` function is `validate` and it avoids us making a request to a URI with a path traversal. In order to prevent erroneously making a request to a non Vimeo URL, I added the `HostValdidatorInterceptor`, which throws an `IOException` when the host does not match the host specified in the `VimeoApiConfiguration`.