### PR TITLE
Remove unnecessary path parameter

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -213,7 +213,7 @@ internal interface VimeoService {
     ): VimeoCall<Folder>
 
     @FormUrlEncoded
-    @HTTP(method = "DELETE", path = "{path}", hasBody = true)
+    @HTTP(method = "DELETE", hasBody = true)
     fun deleteFolder(
         @Header(AUTHORIZATION) authorization: String,
         @Url uri: String,


### PR DESCRIPTION
# Summary
We removed all path parameters that were better served using `@Url`, but forgot to remove one. This PR removes the last unnecessary path parameter.