### PR TITLE
Use parent_folder_uri instead of parent_folder_id

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -424,7 +424,7 @@ interface VimeoApiClient {
      * Create a folder that will be used to organize videos.
      *
      * @param uri The URI of the user's folders connection.
-     * @param parentFolderId The ID of the folder in which this folder should be created, null if it should be created
+     * @param parentFolderUri The URI of the folder in which this folder should be created, null if it should be created
      * at the root.
      * @param name The name of the folder.
      * @param privacy The privacy of the folder.
@@ -437,7 +437,7 @@ interface VimeoApiClient {
      */
     fun createFolder(
         uri: String,
-        parentFolderId: String?,
+        parentFolderUri: String?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -191,7 +191,7 @@ internal interface VimeoService {
     fun createFolder(
         @Header(AUTHORIZATION) authorization: String,
         @Url uri: String,
-        @Field(PARENT_FOLDER_ID) parentFolderId: String?,
+        @Field(PARENT_FOLDER_URI) parentFolderUri: String?,
         @Field(PARAMETER_FOLDER_NAME) name: String,
         @Field(PARAMETER_FOLDER_PRIVACY) privacy: FolderViewPrivacyType,
         @Field(SLACK_WEBHOOK_ID) slackWebhookId: String?,
@@ -640,7 +640,7 @@ internal interface VimeoService {
         private const val VIDEO_URI = "videoUri"
         private const val FOLDER_URI = "folderUri"
         private const val FIELD_FILTER = "fields"
-        private const val PARENT_FOLDER_ID = "parent_folder_id"
+        private const val PARENT_FOLDER_URI = "parent_folder_uri"
         private const val SHOULD_DELETE_CLIPS = "should_delete_clips"
         private const val SLACK_WEBHOOK_ID = "slack_incoming_webhooks_id"
         private const val SLACK_LANGUAGE_PREF = "slack_language_preference"

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -332,7 +332,7 @@ internal class VimeoApiClientImpl(
 
     override fun createFolder(
         uri: String,
-        parentFolderId: String?,
+        parentFolderUri: String?,
         name: String,
         privacy: FolderViewPrivacyType,
         slackWebhookId: String?,
@@ -344,7 +344,7 @@ internal class VimeoApiClientImpl(
         return vimeoService.createFolder(
             authHeader,
             safeUri,
-            parentFolderId,
+            parentFolderUri,
             name,
             privacy,
             slackWebhookId,
@@ -365,11 +365,10 @@ internal class VimeoApiClientImpl(
     ): VimeoRequest {
         val safeUri = user.metadata?.connections?.folders?.uri.validate()
             ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
-        val parentFolderId = parentFolder?.uri?.lastPathSegment()
         return vimeoService.createFolder(
             authHeader,
             safeUri,
-            parentFolderId,
+            parentFolder?.uri,
             name,
             privacy,
             slackWebhookId,
@@ -1263,8 +1262,6 @@ internal class VimeoApiClientImpl(
             ))
         ), callback)
     }
-
-    private fun String.lastPathSegment(): String = this.substringAfterLast(delimiter = '/')
 
     /**
      * @return The [String] if it is not empty or blank and does not contain a path traversal, otherwise returns null.


### PR DESCRIPTION
# Summary
We don't want to have to manipulate the URI of a folder in order to create a subfolder in it, so we should use `parent_folder_uri` instead and let the API manipulate it for us.