### PR TITLE
Bump API version to 3.4.4

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -26,7 +26,7 @@ package com.vimeo.networking2
  */
 object ApiConstants {
 
-    const val API_VERSION = "3.4.2"
+    const val API_VERSION = "3.4.4"
 
     const val BASE_URL = "https://api.vimeo.com"
 


### PR DESCRIPTION
# Summary
Bumps the API version to 3.4.4. 

Version 3.4.3 introduces the `top_level_only` parameter to the folders endpoint. Without adding it, the endpoint will return all folders, including subfolders. We are already utilizing this parameter in the app, so we don't need to make any changes

Version 3.4.4 removes the need to re-enter your password when deleting a live event. This shouldn't affect us since we aren't using the live events endpoint yet.