### PR TITLE
Support download property on Video

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,19 +6,9 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
-      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-      <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="false" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="120" />
@@ -138,6 +128,7 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="RIGHT_MARGIN" value="120" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/models/detekt_baseline.xml
+++ b/models/detekt_baseline.xml
@@ -547,43 +547,6 @@
     <ID>UndocumentedPublicProperty:UserInteractions.kt$UserInteractions$/** * Information related to the Twitter connected app. */ @Json(name = "twitter_connected_app") val twitterConnectedApp: ConnectedAppInteraction? = null</ID>
     <ID>UndocumentedPublicProperty:UserInteractions.kt$UserInteractions$/** * Information related to the YouTube connected app. */ @Json(name = "youtube_connected_app") val youTubeConnectedApp: ConnectedAppInteraction? = null</ID>
     <ID>UndocumentedPublicProperty:UserInteractions.kt$UserInteractions$/** * Information related to the block status of this user. */ @Json(name = "block") val block: BasicInteraction? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * 360 spatial data. */ @Json(name = "spatial") val spatial: Spatial? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * A brief explanation of the video's content. */ @Json(name = "description") val description: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * A collection of stats associated with this video. */ @Json(name = "stats") val stats: VideoStats? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * An array of all tags assigned to this video. */ @Json(name = "tags") val tags: List&lt;Tag&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information about embedding this video. */ @Json(name = "embed") val embed: VideoEmbed? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information about the Vimeo Create session of a video. */ @Json(name = "edit_session") val editSession: EditSession? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information about the file transfer page associated with this video. This data * requires a bearer token with the private scope. */ @Internal @Json(name = "file_transfer") val fileTransferPage: FileTransferPage? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information about the folder that contains the video, or null if it is in the root directory. */ @Json(name = "parent_project") val parentFolder: Folder? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information about the review page associated with this video. This data requires a * bearer token with the private scope. */ @Internal @Json(name = "review_page") val reviewPage: ReviewPage? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Information for the video's badge. */ @Json(name = "badge") val badge: VideoBadge? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Live playback information. */ @Json(name = "live") val live: Live? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The Creative Commons license used for the video. * @see Video.licenseType */ @Json(name = "license") val license: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The Play representation. */ @Internal @Json(name = "play") val play: Play? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The active picture for this video. */ @Json(name = "pictures") val pictures: PictureCollection? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The categories to which this video belongs. */ @Json(name = "categories") val categories: List&lt;Category&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The content ratings of this video. */ @Json(name = "content_rating") val contentRating: List&lt;String&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The context of the video's subscription, if this video is part of a subscription. */ @Json(name = "context") val context: VideoContext? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The link to the video. */ @Json(name = "link") val link: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The privacy-enabled password to watch this video. * This data requires a bearer token with the private scope. */ @Internal @Json(name = "password") val password: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The resource key string of the video. */ @Json(name = "resource_key") val resourceKey: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The status code for the availability of the video. This field is deprecated in favor * of [upload] and [transcode]. * @see Video.statusType */ @Json(name = "status") @Deprecated("This property is deprecated in favor of upload and transcode.") val status: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The time in ISO 8601 format when the user last modified the video. */ @Json(name = "last_user_action_event_date") val lastUserActionEventDate: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The time in ISO 8601 format when the video metadata was last modified. */ @Json(name = "modified_time") val modifiedTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The time in ISO 8601 format when the video was created. */ @Json(name = "created_time") val createdTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The time in ISO 8601 format when the video was released. */ @Json(name = "release_time") val releaseTime: Date? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The transcode information for a video upload. */ @Json(name = "transcode") val transcode: Transcode? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The upload information for this video. */ @Json(name = "upload") val upload: Upload? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video owner. */ @Json(name = "user") val user: User? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's canonical relative URI. */ @Json(name = "uri") val uri: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's duration in seconds. */ @Json(name = "duration") val duration: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's height in pixels. */ @Json(name = "height") val height: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's metadata. */ @Json(name = "metadata") val metadata: Metadata&lt;VideoConnections, VideoInteractions&gt;? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's primary language. */ @Json(name = "language") val language: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's privacy setting. */ @Json(name = "privacy") val privacy: Privacy? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's title. */ @Json(name = "name") val name: String? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * The video's width in pixels. */ @Json(name = "width") val width: Int? = null</ID>
-    <ID>UndocumentedPublicProperty:Video.kt$Video$/** * Whether the clip is playable. */ @Json(name = "is_playable") val isPlayable: Boolean? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The badge image. */ @Json(name = "pictures") val pictures: PictureCollection? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The festival that this badge represents. */ @Internal @Json(name = "festival") val festival: String? = null</ID>
     <ID>UndocumentedPublicProperty:VideoBadge.kt$VideoBadge$/** * The link for the badge */ @Json(name = "link") val link: String? = null</ID>

--- a/models/src/main/java/com/vimeo/networking2/Billing.kt
+++ b/models/src/main/java/com/vimeo/networking2/Billing.kt
@@ -1,3 +1,5 @@
+@file:JvmName("BillingUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/DashVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DashVideoFile.kt
@@ -3,7 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.annotations.Internal
-import com.vimeo.networking2.common.VideoFile
+import com.vimeo.networking2.common.LoggingVideoFile
 import java.util.Date
 
 /**
@@ -44,4 +44,4 @@ data class DashVideoFile(
     @Internal
     @Json(name = "license_link")
     val licenseLink: String? = null
-) : VideoFile
+) : LoggingVideoFile

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -1,3 +1,5 @@
+@file:JvmName("DownloadVideoFileUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -54,7 +54,7 @@ data class DownloadableVideoFile(
     override val linkExpirationTime: Date? = null,
 
     @Json(name = "fps")
-    val fps: Float? = null,
+    val fps: Double? = null,
 
     @Json(name = "type")
     val rawType: String? = null

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -4,6 +4,7 @@ package com.vimeo.networking2
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.VideoFile
 import com.vimeo.networking2.enums.VideoQualityType
 import com.vimeo.networking2.enums.VideoSourceType
 import com.vimeo.networking2.enums.asEnum
@@ -16,11 +17,9 @@ import java.util.Date
  * @param size The size of the file, in bytes.
  * @param sizeShort A short description of the file size, accurate to two decimal places.
  * @param md5 The MD5 hash of the file.
- * @param link The link from which the file can be downloaded.
  * @param width The width of the video content, in pixels.
  * @param height The height of the video content, in pixels.
  * @param videoQuality The quality of the video file. See [qualityType].
- * @param expires The expiration date of the file's [link].
  * @param fps The FPS of the video file.
  * @param rawType The type of the video file. See [type].
  */
@@ -40,7 +39,7 @@ data class DownloadableVideoFile(
     val md5: String? = null,
 
     @Json(name = "link")
-    val link: String? = null,
+    override val link: String? = null,
 
     @Json(name = "width")
     val width: Int? = null,
@@ -52,14 +51,14 @@ data class DownloadableVideoFile(
     val videoQuality: String? = null,
 
     @Json(name = "expires")
-    val expires: Date? = null,
+    override val linkExpirationTime: Date? = null,
 
     @Json(name = "fps")
     val fps: Float? = null,
 
     @Json(name = "type")
     val rawType: String? = null
-)
+) : VideoFile
 
 /**
  * @see DownloadableVideoFile.videoQuality

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -1,0 +1,74 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.enums.VideoQualityType
+import com.vimeo.networking2.enums.VideoSourceType
+import com.vimeo.networking2.enums.asEnum
+import java.util.Date
+
+/**
+ * A downloadable video file.
+ *
+ * @param publicName A name describing the file, suitable for display.
+ * @param size The size of the file, in bytes.
+ * @param sizeShort A short description of the file size, accurate to two decimal places.
+ * @param md5 The MD5 hash of the file.
+ * @param link The link from which the file can be downloaded.
+ * @param width The width of the video content, in pixels.
+ * @param height The height of the video content, in pixels.
+ * @param videoQuality The quality of the video file. See [qualityType].
+ * @param expires The expiration date of the file's [link].
+ * @param fps The FPS of the video file.
+ * @param rawType The type of the video file. See [type].
+ */
+@JsonClass(generateAdapter = true)
+data class DownloadableVideoFile(
+
+    @Json(name = "public_name")
+    val publicName: String? = null,
+
+    @Json(name = "size")
+    val size: Long? = null,
+
+    @Json(name = "size_short")
+    val sizeShort: String? = null,
+
+    @Json(name = "md5")
+    val md5: String? = null,
+
+    @Json(name = "link")
+    val link: String? = null,
+
+    @Json(name = "width")
+    val width: Int? = null,
+
+    @Json(name = "height")
+    val height: Int? = null,
+
+    @Json(name = "quality")
+    val videoQuality: String? = null,
+
+    @Json(name = "expires")
+    val expires: Date? = null,
+
+    @Json(name = "fps")
+    val fps: Float? = null,
+
+    @Json(name = "type")
+    val rawType: String? = null
+)
+
+/**
+ * @see DownloadableVideoFile.videoQuality
+ * @see VideoQualityType
+ */
+val DownloadableVideoFile.qualityType: VideoQualityType
+    get() = videoQuality.asEnum(VideoQualityType.UNKNOWN)
+
+/**
+ * @see DownloadableVideoFile.rawType
+ * @see VideoQualityType
+ */
+val DownloadableVideoFile.type: VideoSourceType
+    get() = rawType.asEnum(VideoSourceType.UNKNOWN)

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -1,4 +1,4 @@
-@file:JvmName("DownloadVideoFileUtils")
+@file:JvmName("DownloadableVideoFileUtils")
 
 package com.vimeo.networking2
 

--- a/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/DownloadableVideoFile.kt
@@ -69,7 +69,7 @@ val DownloadableVideoFile.qualityType: VideoQualityType
 
 /**
  * @see DownloadableVideoFile.rawType
- * @see VideoQualityType
+ * @see VideoSourceType
  */
 val DownloadableVideoFile.type: VideoSourceType
     get() = rawType.asEnum(VideoSourceType.UNKNOWN)

--- a/models/src/main/java/com/vimeo/networking2/HlsVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/HlsVideoFile.kt
@@ -3,7 +3,7 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.annotations.Internal
-import com.vimeo.networking2.common.VideoFile
+import com.vimeo.networking2.common.LoggingVideoFile
 import java.util.Date
 
 /**
@@ -31,4 +31,4 @@ data class HlsVideoFile(
     @Internal
     @Json(name = "live")
     val live: LiveHeartbeat? = null
-) : VideoFile
+) : LoggingVideoFile

--- a/models/src/main/java/com/vimeo/networking2/Play.kt
+++ b/models/src/main/java/com/vimeo/networking2/Play.kt
@@ -10,58 +10,44 @@ import com.vimeo.networking2.enums.asEnum
 
 /**
  * Play information.
+ *
+ * @param dash The DASH video file.
+ * @param hls HLS video files.
+ * @param progress The play progress in seconds.
+ * @param progressive Progressive files.
+ * @param source The source file of the video.
+ * @param videoPlayStatus The play status of the video. See [Play.videoPlayStatusType].
+ * @param drm The DRM play data for a protected stream.
  */
 @Internal
 @JsonClass(generateAdapter = true)
 data class Play(
 
-    /**
-     * The DASH video file.
-     */
     @Internal
     @Json(name = "dash")
     val dash: DashVideoFile? = null,
 
-    /**
-     * HLS video files.
-     */
     @Internal
     @Json(name = "hls")
     val hls: HlsVideoFile? = null,
 
-    /**
-     * The play progress in seconds.
-     */
     @Internal
     @Json(name = "progress")
     val progress: PlayProgress? = null,
 
-    /**
-     * Progressive files.
-     */
     @Deprecated("Use the download property on a Video instead")
     @Internal
     @Json(name = "progressive")
     val progressive: List<ProgressiveVideoFile>? = null,
 
-    /**
-     * The source file of the video.
-     */
     @Internal
     @Json(name = "source")
     val source: List<VideoSourceFile>? = null,
 
-    /**
-     * The play status of the video.
-     * @see Play.videoPlayStatusType
-     */
     @Internal
     @Json(name = "status")
     val videoPlayStatus: String? = null,
 
-    /**
-     * The DRM play data for a protected stream.
-     */
     @Internal
     @Json(name = "drm")
     val drm: Drm? = null

--- a/models/src/main/java/com/vimeo/networking2/Play.kt
+++ b/models/src/main/java/com/vimeo/networking2/Play.kt
@@ -39,6 +39,7 @@ data class Play(
     /**
      * Progressive files.
      */
+    @Deprecated("Use the download property on a Video instead")
     @Internal
     @Json(name = "progressive")
     val progressive: List<ProgressiveVideoFile>? = null,

--- a/models/src/main/java/com/vimeo/networking2/ProgrammedContentItem.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProgrammedContentItem.kt
@@ -1,4 +1,4 @@
-@file:JvmName("CinemaUtils")
+@file:JvmName("ProgrammedContentItemUtils")
 
 package com.vimeo.networking2
 

--- a/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
@@ -4,7 +4,7 @@ package com.vimeo.networking2
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.vimeo.networking2.common.VideoFile
+import com.vimeo.networking2.common.LoggingVideoFile
 import com.vimeo.networking2.enums.VideoQualityType
 import com.vimeo.networking2.enums.VideoSourceType
 import com.vimeo.networking2.enums.asEnum
@@ -81,7 +81,7 @@ data class ProgressiveVideoFile(
     @Json(name = "width")
     val width: Int? = null
 
-) : VideoFile
+) : LoggingVideoFile
 
 /**
  * @see ProgressiveVideoFile.videoQuality

--- a/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/ProgressiveVideoFile.kt
@@ -13,6 +13,7 @@ import java.util.Date
 /**
  * The representation of a video file that could be one of a number of types.
  */
+@Deprecated("Use DownloadableVideoFile instead")
 @JsonClass(generateAdapter = true)
 data class ProgressiveVideoFile(
 

--- a/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembership.kt
@@ -1,3 +1,5 @@
+@file:JvmName("TeamMembershipUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -22,8 +22,12 @@ import java.util.Date
  * @param description A brief explanation of the video's content.
  * @param download A list of downloadable files.
  * @param duration The video's duration in seconds.
+ * @param editSession Information about the Vimeo Create session of a video.
  * @param embed Information about embedding this video.
+ * @param fileTransferPage Information about the file transfer page associated with this video. This data requires a
+ * bearer token with the private scope.
  * @param height The video's height in pixels.
+ * @param isPlayable Whether the clip is playable.
  * @param language The video's primary language.
  * @param lastUserActionEventDate The time in ISO 8601 format when the user last modified the video.
  * @param license The Creative Commons license used for the video. See [Video.licenseType].
@@ -42,8 +46,6 @@ import java.util.Date
  * @param resourceKey The resource key string of the video.
  * @param reviewPage Information about the review page associated with this video. This data requires a bearer token
  * with the private scope.
- * @param fileTransferPage Information about the file transfer page associated with this video. This data requires a
- * bearer token with the private scope.
  * @param spatial 360 spatial data.
  * @param stats A collection of stats associated with this video.
  * @param status The status code for the availability of the video. This field is deprecated in favor of [upload] and
@@ -54,8 +56,6 @@ import java.util.Date
  * @param uri The video's canonical relative URI.
  * @param user The video owner.
  * @param width The video's width in pixels.
- * @param editSession Information about the Vimeo Create session of a video.
- * @param isPlayable Whether the clip is playable.
  */
 @JsonClass(generateAdapter = true)
 data class Video(
@@ -84,11 +84,21 @@ data class Video(
     @Json(name = "duration")
     val duration: Int? = null,
 
+    @Json(name = "edit_session")
+    val editSession: EditSession? = null,
+
     @Json(name = "embed")
     val embed: VideoEmbed? = null,
 
+    @Internal
+    @Json(name = "file_transfer")
+    val fileTransferPage: FileTransferPage? = null,
+
     @Json(name = "height")
     val height: Int? = null,
+
+    @Json(name = "is_playable")
+    val isPlayable: Boolean? = null,
 
     @Json(name = "language")
     val language: String? = null,
@@ -141,10 +151,6 @@ data class Video(
     @Json(name = "review_page")
     val reviewPage: ReviewPage? = null,
 
-    @Internal
-    @Json(name = "file_transfer")
-    val fileTransferPage: FileTransferPage? = null,
-
     @Json(name = "spatial")
     val spatial: Spatial? = null,
 
@@ -171,13 +177,7 @@ data class Video(
     val user: User? = null,
 
     @Json(name = "width")
-    val width: Int? = null,
-
-    @Json(name = "edit_session")
-    val editSession: EditSession? = null,
-
-    @Json(name = "is_playable")
-    val isPlayable: Boolean? = null
+    val width: Int? = null
 
 ) : Entity {
 

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -54,6 +54,12 @@ data class Video(
     val description: String? = null,
 
     /**
+     * A list of downloadable files.
+     */
+    @Json(name = "download")
+    val download: List<DownloadableVideoFile>? = null,
+
+    /**
      * The video's duration in seconds.
      */
     @Json(name = "duration")

--- a/models/src/main/java/com/vimeo/networking2/Video.kt
+++ b/models/src/main/java/com/vimeo/networking2/Video.kt
@@ -13,246 +13,169 @@ import java.util.Date
 
 /**
  * Video data.
+ *
+ * @param badge Information for the video's badge.
+ * @param categories The categories to which this video belongs.
+ * @param contentRating The content ratings of this video.
+ * @param context The context of the video's subscription, if this video is part of a subscription.
+ * @param createdTime The time in ISO 8601 format when the video was created.
+ * @param description A brief explanation of the video's content.
+ * @param download A list of downloadable files.
+ * @param duration The video's duration in seconds.
+ * @param embed Information about embedding this video.
+ * @param height The video's height in pixels.
+ * @param language The video's primary language.
+ * @param lastUserActionEventDate The time in ISO 8601 format when the user last modified the video.
+ * @param license The Creative Commons license used for the video. See [Video.licenseType].
+ * @param link The link to the video.
+ * @param live Live playback information.
+ * @param metadata The video's metadata.
+ * @param modifiedTime The time in ISO 8601 format when the video metadata was last modified.
+ * @param name The video's title.
+ * @param parentFolder Information about the folder that contains the video, or null if it is in the root directory.
+ * @param password The privacy-enabled password to watch this video. This data requires a bearer token with the private
+ * scope.
+ * @param pictures The active picture for this video.
+ * @param play The Play representation.
+ * @param privacy The video's privacy setting.
+ * @param releaseTime The time in ISO 8601 format when the video was released.
+ * @param resourceKey The resource key string of the video.
+ * @param reviewPage Information about the review page associated with this video. This data requires a bearer token
+ * with the private scope.
+ * @param fileTransferPage Information about the file transfer page associated with this video. This data requires a
+ * bearer token with the private scope.
+ * @param spatial 360 spatial data.
+ * @param stats A collection of stats associated with this video.
+ * @param status The status code for the availability of the video. This field is deprecated in favor of [upload] and
+ * [transcode]. See [Video.statusType].
+ * @param tags An array of all tags assigned to this video.
+ * @param transcode The transcode information for a video upload.
+ * @param upload The upload information for this video.
+ * @param uri The video's canonical relative URI.
+ * @param user The video owner.
+ * @param width The video's width in pixels.
+ * @param editSession Information about the Vimeo Create session of a video.
+ * @param isPlayable Whether the clip is playable.
  */
 @JsonClass(generateAdapter = true)
 data class Video(
 
-    /**
-     * Information for the video's badge.
-     */
     @Json(name = "badge")
     val badge: VideoBadge? = null,
 
-    /**
-     * The categories to which this video belongs.
-     */
     @Json(name = "categories")
     val categories: List<Category>? = null,
 
-    /**
-     * The content ratings of this video.
-     */
     @Json(name = "content_rating")
     val contentRating: List<String>? = null,
 
-    /**
-     * The context of the video's subscription, if this video is part of a subscription.
-     */
     @Json(name = "context")
     val context: VideoContext? = null,
 
-    /**
-     * The time in ISO 8601 format when the video was created.
-     */
     @Json(name = "created_time")
     val createdTime: Date? = null,
 
-    /**
-     * A brief explanation of the video's content.
-     */
     @Json(name = "description")
     val description: String? = null,
 
-    /**
-     * A list of downloadable files.
-     */
     @Json(name = "download")
     val download: List<DownloadableVideoFile>? = null,
 
-    /**
-     * The video's duration in seconds.
-     */
     @Json(name = "duration")
     val duration: Int? = null,
 
-    /**
-     * Information about embedding this video.
-     */
     @Json(name = "embed")
     val embed: VideoEmbed? = null,
 
-    /**
-     * The video's height in pixels.
-     */
     @Json(name = "height")
     val height: Int? = null,
 
-    /**
-     * The video's primary language.
-     */
     @Json(name = "language")
     val language: String? = null,
 
-    /**
-     * The time in ISO 8601 format when the user last modified the video.
-     */
     @Json(name = "last_user_action_event_date")
     val lastUserActionEventDate: Date? = null,
 
-    /**
-     * The Creative Commons license used for the video.
-     * @see Video.licenseType
-     */
     @Json(name = "license")
     val license: String? = null,
 
-    /**
-     * The link to the video.
-     */
     @Json(name = "link")
     val link: String? = null,
 
-    /**
-     * Live playback information.
-     */
     @Json(name = "live")
     val live: Live? = null,
 
-    /**
-     * The video's metadata.
-     */
     @Json(name = "metadata")
     val metadata: Metadata<VideoConnections, VideoInteractions>? = null,
 
-    /**
-     * The time in ISO 8601 format when the video metadata was last modified.
-     */
     @Json(name = "modified_time")
     val modifiedTime: Date? = null,
 
-    /**
-     * The video's title.
-     */
     @Json(name = "name")
     val name: String? = null,
 
-    /**
-     * Information about the folder that contains the video, or null if it is in the root directory.
-     */
     @Json(name = "parent_project")
     val parentFolder: Folder? = null,
 
-    /**
-     * The privacy-enabled password to watch this video.
-     * This data requires a bearer token with the private scope.
-     */
     @Internal
     @Json(name = "password")
     val password: String? = null,
 
-    /**
-     * The active picture for this video.
-     */
     @Json(name = "pictures")
     val pictures: PictureCollection? = null,
 
-    /**
-     * The Play representation.
-     */
     @Internal
     @Json(name = "play")
     val play: Play? = null,
 
-    /**
-     * The video's privacy setting.
-     */
     @Json(name = "privacy")
     val privacy: Privacy? = null,
 
-    /**
-     * The time in ISO 8601 format when the video was released.
-     */
     @Json(name = "release_time")
     val releaseTime: Date? = null,
 
-    /**
-     * The resource key string of the video.
-     */
     @Json(name = "resource_key")
     val resourceKey: String? = null,
 
-    /**
-     * Information about the review page associated with this video. This data requires a
-     * bearer token with the private scope.
-     */
     @Internal
     @Json(name = "review_page")
     val reviewPage: ReviewPage? = null,
 
-    /**
-     * Information about the file transfer page associated with this video. This data
-     * requires a bearer token with the private scope.
-     */
     @Internal
     @Json(name = "file_transfer")
     val fileTransferPage: FileTransferPage? = null,
 
-    /**
-     * 360 spatial data.
-     */
     @Json(name = "spatial")
     val spatial: Spatial? = null,
 
-    /**
-     * A collection of stats associated with this video.
-     */
     @Json(name = "stats")
     val stats: VideoStats? = null,
 
-    /**
-     * The status code for the availability of the video. This field is deprecated in favor
-     * of [upload] and [transcode].
-     * @see Video.statusType
-     */
     @Json(name = "status")
     @Deprecated("This property is deprecated in favor of upload and transcode.")
     val status: String? = null,
 
-    /**
-     * An array of all tags assigned to this video.
-     */
     @Json(name = "tags")
     val tags: List<Tag>? = null,
 
-    /**
-     * The transcode information for a video upload.
-     */
     @Json(name = "transcode")
     val transcode: Transcode? = null,
 
-    /**
-     * The upload information for this video.
-     */
     @Json(name = "upload")
     val upload: Upload? = null,
 
-    /**
-     * The video's canonical relative URI.
-     */
     @Json(name = "uri")
     val uri: String? = null,
 
-    /**
-     * The video owner.
-     */
     @Json(name = "user")
     val user: User? = null,
 
-    /**
-     * The video's width in pixels.
-     */
     @Json(name = "width")
     val width: Int? = null,
 
-    /**
-     * Information about the Vimeo Create session of a video.
-     */
     @Json(name = "edit_session")
     val editSession: EditSession? = null,
 
-    /**
-     * Whether the clip is playable.
-     */
     @Json(name = "is_playable")
     val isPlayable: Boolean? = null
 

--- a/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoStatus.kt
@@ -1,3 +1,5 @@
+@file:JvmName("VideoStatusUtils")
+
 package com.vimeo.networking2
 
 import com.squareup.moshi.Json

--- a/models/src/main/java/com/vimeo/networking2/common/Connection.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/Connection.kt
@@ -19,6 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@file:JvmName("ConnectionUtils")
+
 package com.vimeo.networking2.common
 
 import com.vimeo.networking2.enums.ApiOptionsType

--- a/models/src/main/java/com/vimeo/networking2/common/LoggingVideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/LoggingVideoFile.kt
@@ -1,0 +1,11 @@
+package com.vimeo.networking2.common
+
+/**
+ * A [VideoFile] that supports logging.
+ */
+interface LoggingVideoFile : VideoFile {
+    /**
+     * The URL for logging events.
+     */
+    val log: String?
+}

--- a/models/src/main/java/com/vimeo/networking2/common/VideoFile.kt
+++ b/models/src/main/java/com/vimeo/networking2/common/VideoFile.kt
@@ -16,9 +16,4 @@ interface VideoFile {
      * The time in ISO 8601 format when the link to the playable file expires.
      */
     val linkExpirationTime: Date?
-
-    /**
-     * The URL for logging events.
-     */
-    val log: String?
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/VideoQualityType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/VideoQualityType.kt
@@ -13,5 +13,7 @@ enum class VideoQualityType(override val value: String?) : StringValue {
 
     SD("sd"),
 
+    SOURCE("source"),
+
     UNKNOWN(null)
 }


### PR DESCRIPTION
# Summary
We need to move away from using the `video.play.progressive` representation and to start using the `video.download` representation. The first stop of this is to add the `download` property to `Video`. This property introduces a new `DownloadableVideoFile` which differs slightly from existing video files. It does not have a log link to log playback. The `Video.download` property is of the type `List<DownloadableVideoFile>`. I also had to add a new `VideoQualityType` that we were not representing in the enum.

## Other changes
- Updated code style guidelines to support new android studio
- Fixed existing detekt warnings in `Video`.
- Fixed naming issues with files used in a JVM environment for `Billing`, `ProgrammedContentItem`, `TeamMembership`, `VideoStatus`, and `Connection`.