### PR TITLE
MPS-2415 Update to reflect required survey API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Change Log
 
 Version 2.0.3 *(2021-08-10)*
 ----------------------------
-- Updated support for user survey data by adding `analytics_id` and making some minor semantic changes to models.
+- Updated support for user survey data by adding `analyticsId` and making some other minor semantic changes to survey models.
+- Added `minTierForMovie` field to `EditSession`.
 
 Version 2.0.2 *(2021-08-06)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ Change Log
 
 Version 2.0.3 *(2021-08-10)*
 ----------------------------
-- Updated support for user survey data by adding `analyticsId` and making some other minor semantic changes to survey models.
-- Added `minTierForMovie` field to `EditSession`.
+- Improved support for user survey data by adding an `analyticsId` property to `SurveyQuestion`, `SurveyResponseChoice`, and `UserSegmentSurvey`. This property replaces any `id` properties the class originally had. 
+- Ensured that `SurveyResponseChoice` has a guid-based `resourceId` field that is tied to its `Entity.identifier`.
+- Renamed the `SurveyQuestion.emojiTitle` property to `titleEmoji`.
+- Added a `resourceKey` property to `SurveyResponseChoice`.
 
 Version 2.0.2 *(2021-08-06)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.0.3 *(2021-08-06)*
+----------------------------
+- Updated support for user survey data by adding `analytics_id` and making some minor semantic changes to models.
+
 Version 2.0.2 *(2021-08-06)*
 ----------------------------
 - Changed the `Play.source` property to the correct type, from `List<VideoSourceFile>` to `VideoSourceFile`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-Version 2.0.3 *(2021-08-06)*
+Version 2.0.3 *(2021-08-10)*
 ----------------------------
 - Updated support for user survey data by adding `analytics_id` and making some minor semantic changes to models.
 

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -34,7 +34,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.0.2"
+    const val SDK_VERSION = "2.0.3"
 
     const val NONE = -1
 

--- a/models/src/main/java/com/vimeo/networking2/SurveyQuestion.kt
+++ b/models/src/main/java/com/vimeo/networking2/SurveyQuestion.kt
@@ -10,8 +10,9 @@ import com.vimeo.networking2.enums.asEnum
  * A representation of a user-facing survey question. Questions are expected to be presented to a user with
  * a series of multiple-choice responses to select as an answer.
  *
+ * @param analyticsId The id that should be used when logging this [SurveyQuestion].
  * @param resourceKey A globally unique identifier.
- * @param emojiTitle A unicode emoji character in “surrogate pair” representation (e.g. \uD83D\uDC4B).
+ * @param titleEmoji A unicode emoji character in “surrogate pair” representation (e.g. \uD83D\uDC4B).
  * @param question The survey question that the user should be asked. This string will be localized.
  * @param rawType The type of the survey question. See [SurveyQuestion.type].
  * @param responseChoices A list of [SurveyResponseChoices][SurveyResponseChoice] to present to a user as valid
@@ -21,11 +22,14 @@ import com.vimeo.networking2.enums.asEnum
 @JsonClass(generateAdapter = true)
 data class SurveyQuestion(
 
+    @Json(name = "analytics_id")
+    val analyticsId: String? = null,
+
     @Json(name = "resource_key")
     val resourceKey: String? = null,
 
-    @Json(name = "emoji_title")
-    val emojiTitle: String? = null,
+    @Json(name = "title_emoji")
+    val titleEmoji: String? = null,
 
     @Json(name = "title")
     val question: String? = null,

--- a/models/src/main/java/com/vimeo/networking2/SurveyResponseChoice.kt
+++ b/models/src/main/java/com/vimeo/networking2/SurveyResponseChoice.kt
@@ -7,18 +7,22 @@ import com.vimeo.networking2.common.Entity
 /**
  * A survey response choice associated with a [SurveyQuestion].
  *
- * @param id A unique identifier for the response choice within the context of a [SurveyQuestion].
+ * @param analyticsId The id that should be used when logging this [SurveyResponseChoice].
+ * @param resourceKey A unique identifier for the response choice within the context of a [SurveyQuestion].
  * @param title A user-facing display title that represents the choice. This will be localized by the API.
  */
 @JsonClass(generateAdapter = true)
 data class SurveyResponseChoice(
 
-    @Json(name = "id")
-    val id: String? = null,
+    @Json(name = "analytics_id")
+    val analyticsId: String? = null,
+
+    @Json(name = "resource_key")
+    val resourceKey: String? = null,
 
     @Json(name = "title")
     val title: String? = null
 
 ) : Entity {
-    override val identifier: String? = id
+    override val identifier: String? = resourceKey
 }

--- a/models/src/main/java/com/vimeo/networking2/UserSegmentSurvey.kt
+++ b/models/src/main/java/com/vimeo/networking2/UserSegmentSurvey.kt
@@ -10,7 +10,7 @@ import com.vimeo.networking2.common.Entity
  * @param resourceKey A globally unique identifier.
  * @param uri A uri for the survey.
  * @param title A named title.
- * @param id A named identifier.
+ * @param analyticsId The id that should be used when logging this [UserSegmentSurvey].
  * @param questions A list of [SurveyQuestions][SurveyQuestion] to display to the end user.
  */
 @JsonClass(generateAdapter = true)
@@ -26,7 +26,7 @@ data class UserSegmentSurvey(
     val title: String? = null,
 
     @Json(name = "id")
-    val id: String? = null,
+    val analyticsId: String? = null,
 
     @Json(name = "questions")
     val questions: List<SurveyQuestion>? = null

--- a/models/src/main/java/com/vimeo/networking2/UserSegmentSurvey.kt
+++ b/models/src/main/java/com/vimeo/networking2/UserSegmentSurvey.kt
@@ -25,7 +25,7 @@ data class UserSegmentSurvey(
     @Json(name = "title")
     val title: String? = null,
 
-    @Json(name = "id")
+    @Json(name = "analytics_id")
     val analyticsId: String? = null,
 
     @Json(name = "questions")


### PR DESCRIPTION
# Summary
Several recent changes were made to the survey-related API based on new technical requirements. These changes need to be reflected in the networking library.

## Description
The change primarily required adding an `analyticsId` to a few models and some other minor semantic changes to variable names.


