### PR TITLE
Fix BillingPeriodType values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change Log
 ==========
+
+Version 2.0.5 *(2021-08-24)*
+----------------------------
+- Fixed incorrect values for `BillingPeriodType`.
+
 Version 2.0.4 *(2021-08-10)*
 ----------------------------
 - Added `minTierForMovie` field to `EditSession`.

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -34,7 +34,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.0.4"
+    const val SDK_VERSION = "2.0.5"
 
     const val NONE = -1
 

--- a/models/src/main/java/com/vimeo/networking2/enums/BillingPeriodType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/BillingPeriodType.kt
@@ -8,12 +8,12 @@ enum class BillingPeriodType(override val value: String?) : StringValue {
     /**
      * User will be charged monthly.
      */
-    MONTHLY("monthly"),
+    MONTHLY("month"),
 
     /**
      * User will be charged yearly.
      */
-    YEARLY("yearly"),
+    YEARLY("year"),
 
     /**
      * Unknown billing period.


### PR DESCRIPTION
# Summary
The `values` for the `BillingPeriodType` didn't match what we're seeing in the API response. This PR just fix that.

