### PR TITLE
Jitpack fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.0.6 *(2021-08-24)*
+----------------------------
+- Added a `jitpack.yml` file to run Jitpack builds on JDK 11.
+
 Version 2.0.5 *(2021-08-24)*
 ----------------------------
 - Fixed incorrect values for `BillingPeriodType`.

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -34,7 +34,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.0.5"
+    const val SDK_VERSION = "2.0.6"
 
     const val NONE = -1
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
# Summary
The 2.0.5 [build failed in Jitpack](https://jitpack.io/com/github/vimeo/vimeo-networking-java/2.0.5/build.log) because of a recent dependency update PR bumping the AGP to 7.0.0 (#506)

This PR just adds a `jitpack.yml` file that makes builds run on JDK 11.

