### PR TITLE
[TECH] Disable incremental compiling for model generator plugin 

### DIFF
--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/tasks/GenerateModelsTask.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/tasks/GenerateModelsTask.kt
@@ -8,7 +8,7 @@ import com.vimeo.modelgenerator.visitor.SerializableClassVisitor
 import com.vimeo.modelgenerator.visitor.SerializableInterfaceVisitor
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileTree
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
@@ -44,7 +44,7 @@ open class GenerateModelsTask : DefaultTask() {
 
     // Output directory path for where the new models will be generated
     private val output =
-        project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.maybeCreate("main").java.srcDirs.first().path
+        project.extensions.getByType(JavaPluginExtension::class.java).sourceSets.maybeCreate("main").java.srcDirs.first().path
 
     // A File tree of all the Files from the original model directory
     val models: ConfigurableFileTree


### PR DESCRIPTION
## Description
When the model generator plugin was originally written it was intended to support incremental compilation of the new models to speed up build time when testing changes to models.  Unfortunately I didn't quite set up incremental support properly and it has a habit of breaking builds sometimes.  This PR removes the broken incremental support. 


## How to Test
Run `gradle clean build` modify a model, run `gradle build` and confirm you don't see a "Cannot query incremental changes` error.
