### PR TITLE
Potential incremental model creation task fix

### DIFF
--- a/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/tasks/GenerateModelsTask.kt
+++ b/model-generator/plugin/src/main/java/com/vimeo/modelgenerator/tasks/GenerateModelsTask.kt
@@ -48,12 +48,15 @@ open class GenerateModelsTask : DefaultTask() {
     private val output =
         project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.maybeCreate("main").java.srcDirs.first().path
 
+
+    private var _models: ConfigurableFileTree? = null
+
     // A File tree of all the Files from the original model directory
     val models: ConfigurableFileTree
         @InputDirectory
         @Incremental
         @PathSensitive(PathSensitivity.RELATIVE)
-        get() = project.fileTree(modelPath)
+        get() = _models ?: project.fileTree(modelPath).also { _models = it }
 
     @get:OutputDirectory
     val outputDir = File(output)


### PR DESCRIPTION
# Summary
Sometimes model generation breaks, this is an attempt to fix it.

## Description
Create a stable handle to the model files, which might potentially work around a concurrency/query problem which might result in the error seen.  Being concurrency related might also explain how sporadic the error is.

## How to Test
Modify some model classes and run models-parcelable:generateModels tasks a bunch of times.  I just added a random fake member, run the task, removed the fake class member, and run the task again.
