### PR TITLE
Fixing LiveStatusType.READY enum value

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/enums/LiveStatusType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/LiveStatusType.kt
@@ -28,7 +28,7 @@ enum class LiveStatusType(override val value: String?) : StringValue {
     /**
      * The RTMP URL is ready to receive video content.
      */
-    READY("read"),
+    READY("ready"),
 
     /**
      * The stream is open and receiving content.


### PR DESCRIPTION
# Summary
The `LiveStatusType.READY` enum value has an incorrect string value.

## Description
This PR fixes the string value of the enum.

## How to Test
Verify that the value matches what the API returns.
