### PR TITLE
Mps 2393 adding functionality fetch videolist as projectitemlist

### DIFF
--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -947,6 +947,27 @@ interface VimeoApiClient {
     ): VimeoRequest
 
     /**
+     * Fetch a [ProjectItemList] from the provided endpoint which returns a response of [VideoList].
+     *
+     * @param uri The URI from which content will be requested.
+     * @param fieldFilter The fields that should be returned by the server in the response, null indicates all should be
+     * returned.
+     * @param queryParams Optional map used to refine the response from the API.
+     * @param cacheControl The optional cache behavior for the request, null indicates that the default cache behavior
+     * should be used.
+     * @param callback The callback which will be notified of the request completion.
+     *
+     * @return A [VimeoRequest] object to cancel API requests.
+     */
+    fun fetchVideoListAsProjectItemList(
+        uri: String,
+        fieldFilter: String?,
+        queryParams: Map<String, String>?,
+        cacheControl: CacheControl?,
+        callback: VimeoCallback<ProjectItemList>
+    ): VimeoRequest
+
+    /**
      * Fetch a [FeedList] from the provided endpoint.
      *
      * @param uri The URI from which content will be requested.

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -44,7 +44,6 @@ import com.vimeo.networking2.PictureCollection
 import com.vimeo.networking2.Product
 import com.vimeo.networking2.ProductList
 import com.vimeo.networking2.ProgrammedCinemaItemList
-import com.vimeo.networking2.ProjectItem
 import com.vimeo.networking2.ProjectItemList
 import com.vimeo.networking2.PublishJob
 import com.vimeo.networking2.RecommendationList
@@ -66,7 +65,6 @@ import com.vimeo.networking2.VideoStatus
 import com.vimeo.networking2.VimeoApiClient
 import com.vimeo.networking2.VimeoCallback
 import com.vimeo.networking2.VimeoRequest
-import com.vimeo.networking2.VimeoResponse
 import com.vimeo.networking2.common.Followable
 import com.vimeo.networking2.enums.CommentPrivacyType
 import com.vimeo.networking2.enums.ConnectedAppType

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -44,6 +44,7 @@ import com.vimeo.networking2.PictureCollection
 import com.vimeo.networking2.Product
 import com.vimeo.networking2.ProductList
 import com.vimeo.networking2.ProgrammedCinemaItemList
+import com.vimeo.networking2.ProjectItem
 import com.vimeo.networking2.ProjectItemList
 import com.vimeo.networking2.PublishJob
 import com.vimeo.networking2.RecommendationList
@@ -65,6 +66,7 @@ import com.vimeo.networking2.VideoStatus
 import com.vimeo.networking2.VimeoApiClient
 import com.vimeo.networking2.VimeoCallback
 import com.vimeo.networking2.VimeoRequest
+import com.vimeo.networking2.VimeoResponse
 import com.vimeo.networking2.common.Followable
 import com.vimeo.networking2.enums.CommentPrivacyType
 import com.vimeo.networking2.enums.ConnectedAppType
@@ -644,6 +646,14 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         cacheControl: CacheControl?,
         callback: VimeoCallback<VideoList>
     ): VimeoRequest = client.fetchVideoList(uri, fieldFilter, queryParams, cacheControl, callback)
+
+    override fun fetchVideoListAsProjectItemList(
+        uri: String,
+        fieldFilter: String?,
+        queryParams: Map<String, String>?,
+        cacheControl: CacheControl?,
+        callback: VimeoCallback<ProjectItemList>
+    ): VimeoRequest = client.fetchVideoListAsProjectItemList(uri, fieldFilter, queryParams, cacheControl, callback)
 
     override fun fetchFeedList(
         uri: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -1086,7 +1086,7 @@ internal class VimeoApiClientImpl(
         cacheControl: CacheControl?,
         callback: VimeoCallback<ProjectItemList>
     ): VimeoRequest {
-        val videoListCallback = object: VimeoCallback<VideoList> {
+        val videoListCallback = object : VimeoCallback<VideoList> {
             override fun onSuccess(response: VimeoResponse.Success<VideoList>) {
                 callback.onSuccess(
                     VimeoResponse.Success(


### PR DESCRIPTION
# Summary
https://vimean.atlassian.net/browse/MPS-2524 requires updating fetching the list to display Recent videos from the contents of the user's root level project, which returns a `ProjectItemList`, so instead fetching user videos from `me/videos` , which returns a `VideoList`. To allow for code reuse and response flexibility, these changes add functionality to map a `VideoList` response to a `ProjectItemList`

## How to Test
Check out the `MPS-2524-update-recent-videos-endpoint` in `Vimeo-Android`, which points to the `vimeo-networking-java` build on this branch, and ensure that Recent videos are being fetched from the api which returns a `VideoList` and displayed correctly on the Home tab as a `ProjectItemList`.
