### PR TITLE
Bump version to 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.0.7 *(2021-09-24)*
+----------------------------
+- Fixed incorrect value for `LiveStatusType.READY`.
+
 Version 2.0.6 *(2021-08-24)*
 ----------------------------
 - Added a `jitpack.yml` file to run Jitpack builds on JDK 11.

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -34,7 +34,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.0.6"
+    const val SDK_VERSION = "2.0.7"
 
     const val NONE = -1
 


### PR DESCRIPTION
# Summary
Release 2.0.7

## Description
Bumping the version and adding to the changelog.

## How to Test
N/A
