### PR TITLE
Adding filter constant for no live

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -143,5 +143,6 @@ object ApiConstants {
         const val FILTER_TVOD_SUBSCRIPTIONS = "subscription"
         const val FILTER_TVOD_PURCHASES = "purchased"
         const val FILTER_NOTIFICATION_TYPES = "notification_types"
+        const val FILTER_NO_LIVE = "nolive"
     }
 }


### PR DESCRIPTION
# Summary
The changes here are to add a filter constant to filter out all live events, for use in the updated Recent Videos display. The issue being addressed is described in this ticket for iOS: https://vimean.atlassian.net/browse/MPS-2587 .

## How to Test
This new constant is being utilized on the follow branch `MPS-2524-update-recent-videos-endpoint` , and filters out live events from the Recent Videos response.
