### PR TITLE
[TECH] Version Catalogs

### DIFF
--- a/api-core/build.gradle
+++ b/api-core/build.gradle
@@ -6,17 +6,17 @@ dependencies {
     compileOnly project(':models')
 
     // Retrofit
-    api "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
+    api libs.retrofit
+    implementation libs.retrofit.moshi.converter
 
     // Moshi Adapters
-    implementation "com.squareup.moshi:moshi-adapters:$moshiVersion"
+    implementation libs.moshi.adapters
 
     // Okio used by Moshi
-    implementation "com.squareup.okio:okio:$okioVersion"
+    implementation libs.okio
 
     // Test dependencies
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }
 
 compileKotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,18 @@
 buildscript {
-    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath libs.android.gradle
+        classpath libs.bintray.gradle
+        classpath libs.kotlin.gradle
     }
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "1.18.1"
-    id "com.github.ben-manes.versions" version "0.39.0"
-}
-
-ext {
-    retrofitVersion = '2.9.0'
-    okioVersion =  '2.10.0'
-    moshiVersion = '1.12.0'
-    stagVersion = '2.6.0'
-    junitVersion = '4.13.2'
-    buildToolsVersion = '29.0.3'
-    classgraphVersion = '4.8.117'
-    assertJVersion = '3.21.0'
-    robolectricVersion = "4.6.1"
-    podamVersion = "7.2.7.RELEASE"
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ben.manes)
 }
 
 subprojects {
@@ -40,7 +26,7 @@ subprojects {
     apply from: "../detekt_configuration.gradle"
 
     dependencies {
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+        detektPlugins(libs.detekt.formatting)
     }
 
     tasks.register("detektFormat", io.gitlab.arturbosch.detekt.Detekt) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion buildToolsVersion
 
     defaultConfig {
         applicationId "com.vimeo.example"
@@ -31,6 +30,6 @@ dependencies {
     implementation project(':models-parcelable')
     implementation project(':vimeo-networking')
 
-    implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.constraint
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detekt = "1.18.1"
 moshi = "1.12.0"
-kotlin = "1.5.21"
+kotlin = "1.5.31"
 retrofit = "2.9.0"
 
 [plugins]
@@ -13,7 +13,7 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
 #Plugins
 android-gradle = { module = "com.android.tools.build:gradle", version = "7.0.2" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.5.30" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 bintray-gradle = { module = "com.jfrog.bintray.gradle:gradle-bintray-plugin", version = "1.8.5" }
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.3.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ retrofit = "2.9.0"
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ben-manes = { id = "com.github.ben-manes.versions", version = "0.39.0" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
 [libraries]
 
@@ -19,12 +20,17 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.3.1
 androidx-constraint = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.0" }
 
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+kotlin-android-extensions = { module = "org.jetbrains.kotlin:kotlin-android-extensions", version.ref = "kotlin" }
 
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 
 okio = { module = "com.squareup.okio:okio", version = "2.10.0" }
+kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.10.1" }
 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-moshi-converter = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,38 @@
+[versions]
+detekt = "1.18.1"
+moshi = "1.12.0"
+kotlin = "1.5.21"
+retrofit = "2.9.0"
+
+[plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ben-manes = { id = "com.github.ben-manes.versions", version = "0.39.0" }
+
+[libraries]
+
+#Plugins
+android-gradle = { module = "com.android.tools.build:gradle", version = "7.0.2" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.5.30" }
+bintray-gradle = { module = "com.jfrog.bintray.gradle:gradle-bintray-plugin", version = "1.8.5" }
+
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.3.1" }
+androidx-constraint = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.0" }
+
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+
+okio = { module = "com.squareup.okio:okio", version = "2.10.0" }
+
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-moshi-converter = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+junit = { module = "junit:junit", version = "4.13.2" }
+assertj = { module = "org.assertj:assertj-core", version = "3.20.2" }
+podam = { module = "uk.co.jemos.podam:podam", version = "7.2.7.RELEASE" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.117" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.6.1" }

--- a/model-generator/integrations/models-input/build.gradle
+++ b/model-generator/integrations/models-input/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'kotlin-kapt'
 
 
 dependencies {
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    implementation libs.moshi
+    kapt libs.moshi.codegen
 }
 
 sourceCompatibility = "1.8"

--- a/model-generator/integrations/models-output/build.gradle
+++ b/model-generator/integrations/models-output/build.gradle
@@ -13,14 +13,14 @@ generated {
 }
 
 dependencies {
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    implementation libs.moshi
+    kapt libs.moshi.codegen
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation "io.github.classgraph:classgraph:$classgraphVersion"
-    testImplementation "uk.co.jemos.podam:podam:$podamVersion"
+    testImplementation libs.junit
+    testImplementation libs.kotlin.reflect
+    testImplementation libs.assertj
+    testImplementation libs.classgraph
+    testImplementation libs.podam
 }
 
 sourceCompatibility = "1.8"

--- a/model-generator/plugin/build.gradle
+++ b/model-generator/plugin/build.gradle
@@ -1,20 +1,16 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
-    id 'io.gitlab.arturbosch.detekt' version '1.18.1'
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.detekt)
     id 'java-gradle-plugin'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.5.31'
-    implementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.31'
-    implementation 'org.jetbrains.kotlin:kotlin-android-extensions:1.5.31'
+    implementation libs.kotlin.gradle.plugin.api
+    implementation libs.kotlin.compiler.embeddable
+    implementation libs.kotlin.android.extensions
 
-    implementation 'com.squareup:kotlinpoet:1.10.1'
-    implementation "com.squareup.moshi:moshi-kotlin:1.12.0"
+    implementation libs.kotlinpoet
+    implementation libs.moshi.kotlin
 }
 
 sourceCompatibility = '1.8'

--- a/model-generator/plugin/settings.gradle
+++ b/model-generator/plugin/settings.gradle
@@ -1,0 +1,12 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+    repositories {
+        mavenCentral()
+    }
+}

--- a/models-parcelable/build.gradle
+++ b/models-parcelable/build.gradle
@@ -17,7 +17,6 @@ generated {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion buildToolsVersion
 
     defaultConfig {
         minSdkVersion 23
@@ -51,12 +50,12 @@ android {
 }
 
 dependencies {
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    implementation libs.moshi
+    kapt libs.moshi.codegen
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation "io.github.classgraph:classgraph:$classgraphVersion"
-    testImplementation "uk.co.jemos.podam:podam:$podamVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.assertj
+    testImplementation libs.classgraph
+    testImplementation libs.podam
+    testImplementation libs.robolectric
 }

--- a/models-serializable/build.gradle
+++ b/models-serializable/build.gradle
@@ -14,13 +14,14 @@ generated {
 }
 
 dependencies {
-    implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    implementation libs.moshi
+    kapt libs.moshi.codegen
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation "io.github.classgraph:classgraph:$classgraphVersion"
-    testImplementation "uk.co.jemos.podam:podam:$podamVersion"
+    testImplementation libs.junit
+    testImplementation libs.assertj
+    testImplementation libs.classgraph
+    testImplementation libs.podam
+    testImplementation libs.robolectric
 }
 
 sourceCompatibility = '1.8'

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -4,15 +4,15 @@ apply from: '../publish.gradle'
 
 dependencies {
     // Okio used by Moshi
-    implementation "com.squareup.okio:okio:$okioVersion"
+    implementation libs.okio
 
     // Moshi
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
-    implementation "com.squareup.moshi:moshi:$moshiVersion"
+    kapt libs.moshi.codegen
+    implementation libs.moshi
 
     // Test dependencies
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation libs.junit
+    testImplementation libs.kotlin.reflect
 
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+enableFeaturePreview("VERSION_CATALOGS")
+
 includeBuild('model-generator/plugin')
 include ':vimeo-networking',
         ':auth',


### PR DESCRIPTION
## Description

This PR focusing on adopting the new [Gradle Version Catalog API](https://docs.gradle.org/current/userguide/platforms.html).

Dependency management was moved from the root `build.gradle` into a `libs.versions.toml` file that can be shared with the model generator plugin. 

## How to Test
Confirm the project still builds and works as expected. 
