### PR TITLE
[WIP] Kotlin 1.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detekt = "1.18.1"
 moshi = "1.12.0"
-kotlin = "1.5.31"
+kotlin = "1.6.0"
 retrofit = "2.9.0"
 
 [plugins]


### PR DESCRIPTION
# Summary
Bumping Kotlin to the latest (1.6.0)

## Description

This PR just covers bumping Kotlin to 1.6 _but_ there's a [bug in Moshi](https://github.com/square/moshi/issues/1368) that's not compatible with 1.6 so we have to wait until the next Moshi release to merge this. 

## How to Test

Confirm the project builds and all tests still pass.

