### PR TITLE
VCANDROID-1583: Keep access token on server with flag in logOut

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -5,6 +5,12 @@ apply from: '../publish.gradle'
 dependencies {
     api project(':api-core')
     compileOnly project(':models')
+
+    // Test dependencies
+    testImplementation project(':models')
+    testImplementation libs.junit
+    testImplementation libs.mockito
+    testImplementation libs.mockito.inline
 }
 
 compileKotlin {

--- a/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
+++ b/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
@@ -328,10 +328,11 @@ interface Authenticator {
      * Log out of the currently authenticated account.
      *
      * @param callback Callback to be notified of the result of the request.
+     * @param keepOnServer The flag if set to true, won't delete access token on server.
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
-    fun logOut(callback: VimeoCallback<Unit>): VimeoRequest
+    fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean = false): VimeoRequest
 
     /**
      * Factory to create an instance of [Authenticator].

--- a/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
+++ b/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
@@ -328,11 +328,15 @@ interface Authenticator {
      * Log out of the currently authenticated account.
      *
      * @param callback Callback to be notified of the result of the request.
-     * @param keepOnServer The flag if set to true, won't delete access token on server.
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
-    fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean = false): VimeoRequest
+    fun logOut(callback: VimeoCallback<Unit>): VimeoRequest
+
+    /**
+     * Logs out of the currently authenticated account in the library, but keeps access token on server.
+     */
+    fun logOutLocally()
 
     /**
      * Factory to create an instance of [Authenticator].

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -303,10 +303,14 @@ internal class AuthenticatorImpl(
         ).enqueueWithAccountStore(callback)
     }
 
-    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest {
+    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest {
         val accessToken = currentAccount?.accessToken
         accountStore.removeAccount()
         accessToken ?: return NoOpVimeoRequest
+
+        if (keepOnServer) {
+            return NoOpVimeoRequest
+        }
 
         return authService.logOut(authorization = "Bearer $accessToken").enqueue(callback)
     }

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -303,16 +303,16 @@ internal class AuthenticatorImpl(
         ).enqueueWithAccountStore(callback)
     }
 
-    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest {
+    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest {
         val accessToken = currentAccount?.accessToken
         accountStore.removeAccount()
         accessToken ?: return NoOpVimeoRequest
 
-        if (keepOnServer) {
-            return NoOpVimeoRequest
-        }
-
         return authService.logOut(authorization = "Bearer $accessToken").enqueue(callback)
+    }
+
+    override fun logOutLocally() {
+        accountStore.removeAccount()
     }
 
     private fun VimeoCall<VimeoAccount>.enqueueWithAccountStore(callback: VimeoCallback<VimeoAccount>): VimeoRequest =

--- a/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
@@ -109,6 +109,6 @@ class MutableAuthenticatorDelegate(var actual: Authenticator? = null) : Authenti
         callback: VimeoCallback<VimeoAccount>
     ): VimeoRequest = authenticator.authenticateWithPinCode(pinCodeInfo, callback)
 
-    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest =
-        authenticator.logOut(callback)
+    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest =
+        authenticator.logOut(callback, keepOnServer)
 }

--- a/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
@@ -109,6 +109,7 @@ class MutableAuthenticatorDelegate(var actual: Authenticator? = null) : Authenti
         callback: VimeoCallback<VimeoAccount>
     ): VimeoRequest = authenticator.authenticateWithPinCode(pinCodeInfo, callback)
 
-    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest =
-        authenticator.logOut(callback, keepOnServer)
+    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest = authenticator.logOut(callback)
+
+    override fun logOutLocally() = authenticator.logOutLocally()
 }

--- a/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
@@ -80,7 +80,7 @@ class NoOpAuthenticatorImpl(
         callback: VimeoCallback<VimeoAccount>
     ): VimeoRequest = reject()
 
-    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest = reject()
+    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest = reject()
 
     private fun reject(): Nothing = error("Authentication is not supported when using a fixed access token")
 }

--- a/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
@@ -80,7 +80,9 @@ class NoOpAuthenticatorImpl(
         callback: VimeoCallback<VimeoAccount>
     ): VimeoRequest = reject()
 
-    override fun logOut(callback: VimeoCallback<Unit>, keepOnServer: Boolean): VimeoRequest = reject()
+    override fun logOut(callback: VimeoCallback<Unit>): VimeoRequest = reject()
+
+    override fun logOutLocally() = Unit
 
     private fun reject(): Nothing = error("Authentication is not supported when using a fixed access token")
 }

--- a/auth/src/test/java/com/vimeo/networking2/internal/AuthenticatorImplTest.kt
+++ b/auth/src/test/java/com/vimeo/networking2/internal/AuthenticatorImplTest.kt
@@ -1,0 +1,50 @@
+package com.vimeo.networking2.internal
+
+import com.vimeo.networking2.Scopes
+import com.vimeo.networking2.VimeoAccount
+import com.vimeo.networking2.VimeoCallback
+import com.vimeo.networking2.account.CachingAccountStore
+import com.vimeo.networking2.config.AuthenticationMethod
+import com.vimeo.networking2.vimeoCallback
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class AuthenticatorImplTest {
+
+    private val accessToken = "token"
+    private val vimeoAccount = VimeoAccount(accessToken)
+    private val authService: AuthService = mock {
+        on { logOut(any()) } doReturn mock()
+    }
+    private val clientCredentials = AuthenticationMethod.ClientCredentials("id", "secret", Scopes(listOf()))
+    private val cachingAccountStorage: CachingAccountStore = mock {
+        on { loadAccount() } doReturn vimeoAccount
+    }
+    private val callback: VimeoCallback<Unit> = vimeoCallback(onSuccess = {}, onError = {})
+    private val localVimeoCallAdapter = mock(LocalVimeoCallAdapter::class.java)
+
+    private val authenticator = AuthenticatorImpl(
+        authService,
+        clientCredentials,
+        "test://redirect",
+        cachingAccountStorage,
+        localVimeoCallAdapter
+    )
+
+    @Test
+    fun `log out removes access token on server`() {
+        authenticator.logOut(callback)
+        verify(authService).logOut("Bearer $accessToken")
+    }
+
+    @Test
+    fun `log out keeps access token on server given flag passed`() {
+        authenticator.logOut(callback, keepOnServer = true)
+        verifyNoInteractions(authService)
+    }
+}

--- a/auth/src/test/java/com/vimeo/networking2/internal/AuthenticatorImplTest.kt
+++ b/auth/src/test/java/com/vimeo/networking2/internal/AuthenticatorImplTest.kt
@@ -37,14 +37,16 @@ class AuthenticatorImplTest {
     )
 
     @Test
-    fun `log out removes access token on server`() {
+    fun `logOut removes access token on server`() {
         authenticator.logOut(callback)
         verify(authService).logOut("Bearer $accessToken")
+        verify(cachingAccountStorage).removeAccount()
     }
 
     @Test
-    fun `log out keeps access token on server given flag passed`() {
-        authenticator.logOut(callback, keepOnServer = true)
+    fun `logOutLocally keeps access token on server`() {
+        authenticator.logOutLocally()
+        verify(cachingAccountStorage).removeAccount()
         verifyNoInteractions(authService)
     }
 }

--- a/auth/src/test/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegateTest.kt
+++ b/auth/src/test/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegateTest.kt
@@ -1,0 +1,36 @@
+package com.vimeo.networking2.internal
+
+import com.vimeo.networking2.Authenticator
+import com.vimeo.networking2.VimeoCallback
+import com.vimeo.networking2.VimeoRequest
+import com.vimeo.networking2.vimeoCallback
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class MutableAuthenticatorDelegateTest {
+
+    private val request = mock(VimeoRequest::class.java)
+    private val authenticator: Authenticator = mock {
+        on { logOut(any()) } doReturn request
+    }
+    private val callback: VimeoCallback<Unit> = vimeoCallback(onSuccess = {}, onError = {})
+
+    private val delegate = MutableAuthenticatorDelegate(authenticator)
+
+    @Test
+    fun `logOut delegates to actual`() {
+        assertEquals(request, delegate.logOut(callback))
+        verify(authenticator).logOut(callback)
+    }
+
+    @Test
+    fun `logOutLocally delegates to actual`() {
+        delegate.logOutLocally()
+        verify(authenticator).logOutLocally()
+    }
+}

--- a/auth/src/test/java/com/vimeo/networking2/internal/NoOpAuthenticatorImplTest.kt
+++ b/auth/src/test/java/com/vimeo/networking2/internal/NoOpAuthenticatorImplTest.kt
@@ -1,0 +1,29 @@
+package com.vimeo.networking2.internal
+
+import com.vimeo.networking2.VimeoCallback
+import com.vimeo.networking2.account.AccountStore
+import com.vimeo.networking2.vimeoCallback
+import org.junit.Assert.*
+
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verifyNoInteractions
+
+class NoOpAuthenticatorImplTest {
+
+    private val callback: VimeoCallback<Unit> = vimeoCallback(onSuccess = {}, onError = {})
+    private val accountStore = mock(AccountStore::class.java)
+
+    private val authenticator = NoOpAuthenticatorImpl(accountStore)
+
+    @Test(expected = IllegalStateException::class)
+    fun `logOut throws error`() {
+        authenticator.logOut(callback)
+    }
+
+    @Test
+    fun `logOutLocally does nothing`() {
+        authenticator.logOutLocally()
+        verifyNoInteractions(accountStore)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,3 +43,5 @@ assertj = { module = "org.assertj:assertj-core", version = "3.21.0" }
 podam = { module = "uk.co.jemos.podam:podam", version = "7.2.7.RELEASE" }
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.137" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.7.3" }
+mockito = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
+mockito-inline = { module = "org.mockito:mockito-inline", version = "4.3.1" }


### PR DESCRIPTION
# Summary
Don't delete access token on server if corresponding flag is passed to logOut.

## Description
New parameter added. Added tests to cover the flows.

## How to Test
./gradlew test
