### PR TITLE
MPS-2947 new folder attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.2.2 *(2022-03-01)*
+----------------------------
+- Added `isPrivateToUser` and `accessGrant` to `Folder`.
+
 Version 2.2.1 *(2022-02-17)*
 ----------------------------
 - Fixed bug where `getMagistoTeamToken()` wasn't properly authenticating with the API`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-Version 2.2.2 *(2022-03-01)*
+Version 2.3.0 *(2022-03-01)*
 ----------------------------
 - Added `isPrivateToUser` and `accessGrant` to `Folder`.
 

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -35,7 +35,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.2.1"
+    const val SDK_VERSION = "2.2.2"
 
     const val NONE = -1
 

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -35,7 +35,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.2.2"
+    const val SDK_VERSION = "2.3.0"
 
     const val NONE = -1
 

--- a/models/src/main/java/com/vimeo/networking2/Folder.kt
+++ b/models/src/main/java/com/vimeo/networking2/Folder.kt
@@ -20,6 +20,8 @@ import java.util.Date
  * @param metadata The folder's metadata.
  * @param lastModifiedDate The time in ISO 8601 format when the folder was last modified.
  * @param name The name of the folder.
+ * @param isPrivateToUser Whether the folder is private to the user that owns it.
+ * @param accessGrant The grant that gives the team member access to the folder.
  * @param privacy The [FolderPrivacy] that defines the public visibility of the folder.
  * @param resourceKey The resource key string of the folder.
  * @param slackIncomingWebhooksId The Slack webhook ID for the folder.

--- a/models/src/main/java/com/vimeo/networking2/Folder.kt
+++ b/models/src/main/java/com/vimeo/networking2/Folder.kt
@@ -48,6 +48,12 @@ data class Folder(
     @Json(name = "modified_time")
     val lastModifiedDate: Date? = null,
 
+    @Json(name = "is_private_to_user")
+    val isPrivateToUser: Boolean? = null,
+
+    @Json(name = "access_grant")
+    val accessGrant: AccessGrant? = null,
+
     @Json(name = "name")
     val name: String? = null,
 

--- a/models/src/main/java/com/vimeo/networking2/PermissionActions.kt
+++ b/models/src/main/java/com/vimeo/networking2/PermissionActions.kt
@@ -10,6 +10,7 @@ import com.squareup.moshi.JsonClass
  * @param folderEdit True if the user can edit the folder, false otherwise.
  * @param folderInvite True if the user can invite others to the folder, false otherwise.
  * @param folderView True if the user can view the folder, false otherwise.
+ * @param folderAddSubFolders True if the user can add a subfolder, false otherwise.
  */
 @JsonClass(generateAdapter = true)
 data class PermissionActions(
@@ -24,5 +25,9 @@ data class PermissionActions(
     val folderInvite: Boolean? = null,
 
     @Json(name = "folder.view")
-    val folderView: Boolean? = null
+    val folderView: Boolean? = null,
+
+    @Json(name = "folder.add_subfolders")
+    val folderAddSubFolders: Boolean? = null
+
 )


### PR DESCRIPTION
# Summary
Added `isPrivateToUser` and `accessGrant` to `Folder`.

## Description
New logging requirements required this data be available off of the `Folder` object.
