### PR TITLE
MPS-2939 Adding an id to Live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.4.0 *(2022-03-08)*
+----------------------------
+- Added `id` to `Live`.
+
 Version 2.3.0 *(2022-03-01)*
 ----------------------------
 - Added `isPrivateToUser` and `accessGrant` to `Folder`.

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -35,7 +35,7 @@ object ApiConstants {
 
     const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
 
-    const val SDK_VERSION = "2.3.0"
+    const val SDK_VERSION = "2.4.0"
 
     const val NONE = -1
 

--- a/models/src/main/java/com/vimeo/networking2/Live.kt
+++ b/models/src/main/java/com/vimeo/networking2/Live.kt
@@ -16,6 +16,7 @@ import java.util.Date
  * @param archivedTime The time in ISO 8601 format when the live stream was archived.
  * @param chat Information about the live clip's chat.
  * @param endedTime The time in ISO 8601 format when the live stream ended.
+ * @param id An identifier for the live stream.
  * @param key The streaming key string, which is used in conjunction with the RTMP [link].
  * @param link The upstream RTMP link. Send your live content to this link.
  * @param scheduledStartTime The time in ISO 8601 format when the live stream was scheduled to start.
@@ -42,6 +43,10 @@ data class Live(
     @Internal
     @Json(name = "ended_time")
     val endedTime: Date? = null,
+
+    @Internal
+    @Json(name = "id")
+    val id: Long? = null,
 
     @Internal
     @Json(name = "key")


### PR DESCRIPTION
We needed to expose a Live identifier for logging purposes in the application
