### PR TITLE
Remove certificate pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ In the below sections, we cover examples of ways to customize the `VimeoApiClien
 
 We recommend the following for all apps when configuring the SDK with the `VimeoApiConfiguration.Builder`:
 - Provide a user agent to identify your app and the device using `withUserAgent(String)`. By default the library creates its own user agent, but supplementing it with more info provides the Vimeo API with a better picture of what devices are accessing it. Not required, and we provide a default if none is provided.
-- Decide if you need certificate pinning. If you don't care about certificate pinning, or if it's not working on the Android version you're working with, we suggest to disable it using `withCertPinning(Boolean)`. It is enabled by default.
 - Provide a cache directory with `withCacheDirectory(File)`. By default the SDK does not set the cache directory and **responses will not be cached**, so you'll have to choose one to get the best performance.
 - Provide an `AccountStore` using `withAccountStore(AccountStore)`. Unless you are accessing the API with a fixed access token, then you should probably provide a store that is disk backed. The default used by the SDK is an in-memory store that **will not remember the logged in account** after the app is restarted.
 

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -33,8 +33,6 @@ object ApiConstants {
 
     const val SSL_URL_PATTERN = "*.vimeo.com"
 
-    const val SSL_PUBLIC_KEY = "sha256/5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w="
-
     const val SDK_VERSION = "2.4.0"
 
     const val NONE = -1

--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -23,7 +23,6 @@ package com.vimeo.networking2.config
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.vimeo.networking2.ApiConstants
 import com.vimeo.networking2.internal.ErrorHandlingCallAdapterFactory
 import com.vimeo.networking2.internal.interceptor.AcceptHeaderInterceptor
 import com.vimeo.networking2.internal.interceptor.CacheControlHeaderInterceptor
@@ -33,7 +32,6 @@ import com.vimeo.networking2.internal.interceptor.UserAgentHeaderInterceptor
 import com.vimeo.networking2.internal.params.StringValueJsonAdapterFactory
 import com.vimeo.networking2.internal.params.VimeoParametersConverterFactory
 import com.vimeo.networking2.logging.VimeoLogger
-import okhttp3.CertificatePinner
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -139,18 +137,7 @@ object RetrofitSetupModule {
 
         interceptors().addAll(applicationInterceptors)
         networkInterceptors().addAll(networkInterceptors)
-
-        if (vimeoApiConfiguration.isCertPinningEnabled) {
-            certificatePinner(createCertificatePinner())
-        }
     }.build()
-
-    /**
-     * Create certificate pinner to configure OkHttpClient.
-     */
-    private fun createCertificatePinner() = CertificatePinner.Builder()
-        .add(ApiConstants.SSL_URL_PATTERN, ApiConstants.SSL_PUBLIC_KEY)
-        .build()
 
     /**
      * Create [Retrofit] with OkHttpClient and Moshi.

--- a/api-core/src/main/java/com/vimeo/networking2/config/VimeoApiConfiguration.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/VimeoApiConfiguration.kt
@@ -52,8 +52,6 @@ import java.util.Locale
  * @param userAgent The supplemental user agent string which will be added to the internal user agent, identifying the
  * client.
  * @param requestTimeoutSeconds The maximum number of seconds a request will wait to complete before timing out.
- * @param isCertPinningEnabled True if the library should pin certificates, false otherwise. Note: should be turned off
- * when debugging.
  * @param logDelegate The instance to which logging will be delegated.
  * @param logLevel The level of logging which will be performed by the library.
  * @param cacheDirectory The optional directory in which requests will be cached.
@@ -77,8 +75,6 @@ data class VimeoApiConfiguration(
     val userAgent: String,
 
     val requestTimeoutSeconds: Long,
-
-    val isCertPinningEnabled: Boolean,
 
     val logDelegate: LogDelegate?,
     val logLevel: LogDelegate.Level,
@@ -115,8 +111,6 @@ data class VimeoApiConfiguration(
         private var userAgent: String = DEFAULT_USER_AGENT
 
         private var requestTimeoutSeconds: Long = DEFAULT_TIMEOUT
-
-        private var isCertPinningEnabled: Boolean = true
 
         private var logDelegate: LogDelegate? = DefaultLogDelegate()
         private var logLevel: LogDelegate.Level = LogDelegate.Level.NONE
@@ -214,13 +208,6 @@ data class VimeoApiConfiguration(
         }
 
         /**
-         * Enable or disable certificate pinning. Defaults to true.
-         *
-         * @see VimeoApiConfiguration.isCertPinningEnabled
-         */
-        fun withCertPinning(certPinningEnabled: Boolean) = apply { this.isCertPinningEnabled = certPinningEnabled }
-
-        /**
          * Specify a log delegate, or none at all. Defaults to [DefaultLogDelegate] which logs to the system output.
          *
          * @see VimeoApiConfiguration.logDelegate
@@ -268,7 +255,6 @@ data class VimeoApiConfiguration(
             applicationInterceptors = applicationInterceptors,
             userAgent = userAgent,
             requestTimeoutSeconds = requestTimeoutSeconds,
-            isCertPinningEnabled = isCertPinningEnabled,
             logDelegate = logDelegate,
             logLevel = logLevel,
             cacheDirectory = cacheDirectory,

--- a/auth/README.md
+++ b/auth/README.md
@@ -127,16 +127,3 @@ onError = {
 ```
 
 The HTTP status code and any possible data returned from the API can extracted from the `VimeoResponse.Error.Unknown` class.
-
-
-## Certificate Pinning
-
-By default certificate pinning is enabled for every request. If you would like to disable it, you may specify it when configuring the SDK.
-
-```kotlin
-val vimeoApiConfiguration = VimeoApiConfiguration.Builder(CLIENT_ID, CLIENT_SECRET, scopes)
-  .withCertPinning(certPinningEnabled = false)
-  .build()
-```
-
-When using the SDK on KitKat, you will have to turn off certificate pinning, since TLS is disabled by default.


### PR DESCRIPTION
# Summary
The PR completely removes the certificate pinning ability from the library.

## Description
We are no longer using certificate pinning as it creates problems for the Vimeo security team around managing certificates. It does not allow us to automatically swap to a new certificate on the fly and requires careful coordination with the apps using certificate pinning to avoid breaking those apps when a certificate needs to be renewed.

While we could leave in certificate pinning and default the value to false, we don't want to encourage anyone to use certificate pinning so that API certificates can be renewed without updating this library. As a result, we are completely removing the ability to pin certificates, as it is no longer recommended.

This is a breaking change and will be versioned behind a 3.0 version. Previous 2.x and 1.x versions of this library will stop working with certificate pinning enabled when the current intermediate certificate expires on **3 March 2023**. For any consumers that are still on those versions of the networking library, they will need to either disable certificate pinning explicitly, or upgrade to a 3.x version.

## How to Test
Verify that tests pass.