### PR TITLE
New interactions for VideoInteractions and FolderInteractions

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
@@ -7,10 +7,22 @@ import com.squareup.moshi.JsonClass
  * The interactions for a folder.
  *
  * @param addSubfolder The interaction used to add a subfolder as well as determine capability for adding subfolders.
+ * @param deleteVideo The interaction that shows whether the user can delete videos from the folder.
+ * @param edit The interaction that shows whether the user can edit the folder's settings.
+ * @param invite The interaction that shows whether the user can invite other users to manage the folder.
  */
 @JsonClass(generateAdapter = true)
 data class FolderInteractions(
 
     @Json(name = "add_subfolder")
-    val addSubfolder: AddSubfolderInteraction? = null
+    val addSubfolder: AddSubfolderInteraction? = null,
+
+    @Json(name = "delete_video")
+    val deleteVideo: BasicInteraction? = null,
+
+    @Json(name = "edit")
+    val edit: BasicInteraction? = null,
+
+    @Json(name = "invite")
+    val invite: BasicInteraction? = null,
 )

--- a/models/src/main/java/com/vimeo/networking2/VideoInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/VideoInteractions.kt
@@ -11,6 +11,9 @@ import com.vimeo.networking2.annotations.Internal
  * @param buy The buy interaction for a On Demand video.
  * @param channel When a video is referenced by a channel URI, if the user is a moderator of the channel, include
  * information about removing the video from the channel.
+ * @param delete The interaction that shows whether the user has the ability to delete the video.
+ * @param edit The interaction that shows whether the user has the ability to edit a video or its settings.
+ * @param invite The interaction that shows whether the user has the ability to invite other users to manage the video.
  * @param like Information about whether the authenticated user has liked this video.
  * @param rent The Rent interaction for an On Demand video.
  * @param report Information about where and how to report a video.
@@ -30,6 +33,15 @@ data class VideoInteractions(
     @Internal
     @Json(name = "channel")
     val channel: BasicInteraction? = null,
+
+    @Json(name = "delete")
+    val delete: BasicInteraction? = null,
+
+    @Json(name = "edit")
+    val edit: BasicInteraction? = null,
+
+    @Json(name = "invite")
+    val invite: BasicInteraction? = null,
 
     @Json(name = "like")
     val like: LikeInteraction? = null,


### PR DESCRIPTION
# Summary
In order to properly support permissions on videos and folders, we need to add some interactions that gate certain user actions.

## Description
Added the following interactions on `VideoInteractions`
- `delete`
- `edit`
- `invite`

Added the following interactions on `FolderInteractions`
- `deleteVideo`
- `edit`
- `invite`

## How to Test
Run tests and verify that requests to videos and folders contain these interactions.
