### PR TITLE
Updating build dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ ksp = { id = "com.google.devtools.ksp", version = "1.6.10-1.0.4" }
 [libraries]
 
 #Plugins
-android-gradle = { module = "com.android.tools.build:gradle", version = "7.1.2" }
+android-gradle = { module = "com.android.tools.build:gradle", version = "7.1.3" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 bintray-gradle = { module = "com.jfrog.bintray.gradle:gradle-bintray-plugin", version = "1.8.5" }
 
@@ -40,8 +40,8 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 
 junit = { module = "junit:junit", version = "4.13.2" }
 assertj = { module = "org.assertj:assertj-core", version = "3.22.0" }
-podam = { module = "uk.co.jemos.podam:podam", version = "7.2.8.RELEASE" }
-classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.139" }
+podam = { module = "uk.co.jemos.podam:podam", version = "7.2.9.RELEASE" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.143" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.7.3" }
 mockito = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
-mockito-inline = { module = "org.mockito:mockito-inline", version = "4.3.1" }
+mockito-inline = { module = "org.mockito:mockito-inline", version = "4.4.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Apr 11 14:29:44 EDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Summary
Updates a number of dependencies.
- AGP -> 7.1.3
- PODAM -> 7.2.9
- ClassGraph -> 4.8.143
- Mockito Inline -> 4.4.0
- Gradle -> 7.4.2

I intentionally did not update Kotlin to the latest version as we don't want to force downstream consumers to have to use the latest since it was just pushed out.

## How to Test
Verify that tests pass.
