### PR TITLE
MPS-3051: Team Permission Endpoint and Entities

### DIFF
--- a/models-parcelable/src/test/java/com/vimeo/networking2/ModelTest.kt
+++ b/models-parcelable/src/test/java/com/vimeo/networking2/ModelTest.kt
@@ -30,6 +30,7 @@ class ModelTest {
         assertThat(models).isNotEmpty
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `models are Parcelable`() {
         models

--- a/models/src/main/java/com/vimeo/networking2/TeamEntity.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamEntity.kt
@@ -1,0 +1,25 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TeamEntity(
+    @Json(name = "type")
+    val type: String? = null,
+
+    @Json(name = "uri")
+    val uri: String? = null,
+
+    @Json(name = "team_user")
+    val teamUser: TeamMembership? = null,
+
+    @Json(name = "team_group")
+    val teamGroup: TeamGroup? = null,
+
+    @Json(name = "owner")
+    val owner: User? = null,
+
+    @Json(name = "display_options")
+    val displayOptions: TeamEntityDisplayOptions? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamEntity.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamEntity.kt
@@ -2,11 +2,26 @@ package com.vimeo.networking2
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.enums.TeamEntityType
+import com.vimeo.networking2.enums.asEnum
 
+/**
+ * Represents a team entity.
+ *
+ * @param rawType a raw string representation of the types defined by [TeamEntityType]
+ * @param uri a uri which returns a singular instance of this [TeamEntity]
+ * @param teamUser when the [TeamEntity] is of type [TeamEntityType.TEAM_USER], this will have a value representing the
+ * data for that type
+ * @param teamGroup when the [TeamEntity] is of type [TeamEntityType.TEAM_GROUP], this will have a value representing
+ * the data for that type
+ * @param owner when the [TeamEntity] is of type [TeamEntityType.ALL_TEAM], this will have a value representing the
+ * owner of the team.
+ * @param displayOptions various client display options that are server driven. See class definition for more detail
+ */
 @JsonClass(generateAdapter = true)
 data class TeamEntity(
     @Json(name = "type")
-    val type: String? = null,
+    val rawType: String? = null,
 
     @Json(name = "uri")
     val uri: String? = null,
@@ -23,3 +38,10 @@ data class TeamEntity(
     @Json(name = "display_options")
     val displayOptions: TeamEntityDisplayOptions? = null
 )
+
+/**
+ * @see [TeamEntity.rawType]
+ * @see TeamEntityType
+ */
+val TeamEntity.type: TeamEntityType
+    get() = rawType.asEnum(TeamEntityType.UNKNOWN)

--- a/models/src/main/java/com/vimeo/networking2/TeamEntityDisplayOptions.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamEntityDisplayOptions.kt
@@ -1,0 +1,10 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TeamEntityDisplayOptions(
+    @Json(name = "color")
+    val color: String
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamEntityDisplayOptions.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamEntityDisplayOptions.kt
@@ -3,6 +3,12 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
+/**
+ * Represents any client side display characteristics which are dictated by the server, or backend.
+ *
+ * @param color Shows the tint or background color used against a view element representing a team entity. Likely some
+ * manner of icon
+ */
 @JsonClass(generateAdapter = true)
 data class TeamEntityDisplayOptions(
     @Json(name = "color")

--- a/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
@@ -1,0 +1,26 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.util.Date
+
+@JsonClass(generateAdapter = true)
+data class TeamGroup(
+    @Json(name = "total")
+    val uri: String? = null,
+
+    @Json(name = "owner_id")
+    val ownerId: String? = null,
+
+    @Json(name = "name")
+    val name: String? = null,
+
+    @Json(name = "created_on")
+    val createdOn: Date? = null,
+
+    @Json(name = "modified_on")
+    val modifiedOn: Date? = null,
+
+    @Json(name = "metadata")
+    val metadata: MetadataConnections<TeamGroupConnections>
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
@@ -4,9 +4,19 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
 
+/**
+ * Represents a team entity which is group of users.
+ *
+ * @param uri the uri for the team group
+ * @param ownerId an Id for the team owner
+ * @param name the name of the team group
+ * @param createdOn the date the team group was created
+ * @param modifiedOn the date the team group was last modified
+ * @param metadata the metadata containing any connections for the team group
+ */
 @JsonClass(generateAdapter = true)
 data class TeamGroup(
-    @Json(name = "total")
+    @Json(name = "uri")
     val uri: String? = null,
 
     @Json(name = "owner_id")

--- a/models/src/main/java/com/vimeo/networking2/TeamGroupConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroupConnections.kt
@@ -3,8 +3,13 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
+/**
+ * Represents the connections associated with a [TeamGroup].
+ *
+ * @param users a connection which returns all users within a [TeamGroup]
+ */
 @JsonClass(generateAdapter = true)
-class TeamGroupConnections(
+data class TeamGroupConnections(
     @Json(name = "users")
     val users: BasicConnection
 )

--- a/models/src/main/java/com/vimeo/networking2/TeamGroupConnections.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroupConnections.kt
@@ -1,0 +1,10 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+class TeamGroupConnections(
+    @Json(name = "users")
+    val users: BasicConnection
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamMembershipList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamMembershipList.kt
@@ -11,8 +11,10 @@ import com.vimeo.networking2.common.Page
 data class TeamMembershipList(
     @Json(name = "total")
     override val total: Int? = null,
+
     @Json(name = "data")
     override val data: List<TeamMembership>? = null,
+
     @Json(name = "filtered_total")
     override val filteredTotal: Int? = null
 ) : Page<TeamMembership>

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -15,7 +15,7 @@ data class TeamPermission(
     val currentPermissions: TeamPermissionCurrentPermissions? = null,
 
     @Json(name = "metadata")
-    val metadata: MetadataInteractions<TeamPermissionInteraction>
+    val metadata: MetadataInteractions<TeamPermissionInteraction>? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -7,10 +7,15 @@ import com.squareup.moshi.JsonClass
 data class TeamPermission(
     @Json(name = "team_entity")
     val teamEntity: TeamEntity? = null,
+
     @Json(name = "applicable_permission_policies")
     val applicablePermissionPolicies: List<PermissionPolicy>? = null,
+
     @Json(name = "current_permissions")
-    val currentPermissions: TeamPermissionCurrentPermissions? = null
+    val currentPermissions: TeamPermissionCurrentPermissions? = null,
+
+    @Json(name = "metadata")
+    val metadata: MetadataInteractions<TeamPermissionInteraction>
 )
 
 @JsonClass(generateAdapter = true)

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -1,0 +1,20 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TeamPermission(
+    @Json(name = "team_entity")
+    val teamEntity: TeamEntity? = null,
+    @Json(name = "applicable_permission_policies")
+    val applicablePermissionPolicies: List<PermissionPolicy>? = null,
+    @Json(name = "current_permissions")
+    val currentPermissions: TeamPermissionCurrentPermissions? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class TeamPermissionCurrentPermissions(
+    @Json(name = "permission_policy_uri")
+    val permissionPolicyUri: String? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -3,6 +3,13 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
+/**
+ * Represents the current permission relationship a [teamEntity] has with a resource. This class expresses any current
+ * way the [TeamEntity] is associated with the resource through [currentPermissions].  This class expresses any way the
+ * [TeamEntity] can have it's permission relationship to a resource edited via the set of potential permissions listed
+ * in [applicablePermissionPolicies]. Any way that the current authenticated user can interact with this [TeamEntity] in
+ * respect to permission changes, is expressed within the interactions located within [metadata]
+ */
 @JsonClass(generateAdapter = true)
 data class TeamPermission(
     @Json(name = "team_entity")
@@ -16,10 +23,4 @@ data class TeamPermission(
 
     @Json(name = "metadata")
     val metadata: MetadataInteractions<TeamPermissionInteraction>? = null
-)
-
-@JsonClass(generateAdapter = true)
-data class TeamPermissionCurrentPermissions(
-    @Json(name = "permission_policy_uri")
-    val permissionPolicyUri: String? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -4,11 +4,16 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 /**
- * Represents the current permission relationship a [teamEntity] has with a resource. This class expresses any current
- * way the [TeamEntity] is associated with the resource through [currentPermissions].  This class expresses any way the
- * [TeamEntity] can have it's permission relationship to a resource edited via the set of potential permissions listed
- * in [applicablePermissionPolicies]. Any way that the current authenticated user can interact with this [TeamEntity] in
- * respect to permission changes, is expressed within the interactions located within [metadata]
+ * Represents the current permission relationship a [teamEntity] has with a resource.
+ *
+ * @param teamEntity The entity which this class expresses a permission relationship towards for the resource passed in
+ * to the call
+ * @param applicablePermissionPolicies set of potential permissions the [teamEntity] can have its permission
+ * relationship to a the resource changed to
+ * @param currentPermissions This class expresses any current way the [TeamEntity] is associated with the resource
+ * through this.
+ * @param metadata Any way that the current authenticated user can interact with this [TeamEntity] in
+ * respect to permission changes, is expressed within the interactions located within this.
  */
 @JsonClass(generateAdapter = true)
 data class TeamPermission(

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionCurrentPermissions.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionCurrentPermissions.kt
@@ -4,8 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 /**
- * Represents the current permission for a [TeamPermission]. This only contains the uri for said permission as denoted
- * by [permissionPolicyUri]
+ * Represents the current permission for a [TeamPermission].
+ *
+ * @param permissionPolicyUri The uri for the permission
  */
 @JsonClass(generateAdapter = true)
 data class TeamPermissionCurrentPermissions(

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionCurrentPermissions.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionCurrentPermissions.kt
@@ -1,0 +1,14 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Represents the current permission for a [TeamPermission]. This only contains the uri for said permission as denoted
+ * by [permissionPolicyUri]
+ */
+@JsonClass(generateAdapter = true)
+data class TeamPermissionCurrentPermissions(
+    @Json(name = "permission_policy_uri")
+    val permissionPolicyUri: String? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
@@ -1,0 +1,13 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+class TeamPermissionInteraction(
+    @Json(name = "edit")
+    val edit: BasicInteraction,
+
+    @Json(name = "remove")
+    val remove: BasicInteraction
+)

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
@@ -3,8 +3,14 @@ package com.vimeo.networking2
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
+/**
+ * Represents any interactions for a [TeamPermission].
+ *
+ * @param edit an interaction denoting the ability to edit the [TeamPermission]
+ * @param remove an interaction denoting the ability to remove the [TeamPermission]
+ */
 @JsonClass(generateAdapter = true)
-class TeamPermissionInteraction(
+data class TeamPermissionInteraction(
     @Json(name = "edit")
     val edit: BasicInteraction? = null,
 

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionInteraction.kt
@@ -6,8 +6,8 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 class TeamPermissionInteraction(
     @Json(name = "edit")
-    val edit: BasicInteraction,
+    val edit: BasicInteraction? = null,
 
     @Json(name = "remove")
-    val remove: BasicInteraction
+    val remove: BasicInteraction? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionList.kt
@@ -1,0 +1,27 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.common.Pageable
+
+@JsonClass(generateAdapter = true)
+data class TeamPermissionList(
+
+    @Json(name = "total")
+    override val total: Int? = null,
+
+    @Json(name = "page")
+    override val page: Int? = null,
+
+    @Json(name = "per_page")
+    override val perPage: Int? = null,
+
+    @Json(name = "paging")
+    override val paging: Paging? = null,
+
+    @Json(name = "data")
+    override val data: List<TeamPermission>? = null,
+
+    @Json(name = "filtered_total")
+    override val filteredTotal: Int? = null
+) : Pageable<TeamPermission>

--- a/models/src/main/java/com/vimeo/networking2/TeamPermissionList.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermissionList.kt
@@ -4,6 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.vimeo.networking2.common.Pageable
 
+/**
+ * Represents a pageable array/list of [TeamPermission].
+ */
 @JsonClass(generateAdapter = true)
 data class TeamPermissionList(
 

--- a/models/src/main/java/com/vimeo/networking2/enums/TeamEntityType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/TeamEntityType.kt
@@ -4,8 +4,23 @@ package com.vimeo.networking2.enums
  * An enumeration of [com.vimeo.networking2.TeamEntity.rawType].
  */
 enum class TeamEntityType(override val value: String?) : StringValue {
+    /**
+     * Team entity representing all users in a team.
+     */
     ALL_TEAM("all_team"),
+
+    /**
+     * Team entity respresenting a single user on a team.
+     */
     TEAM_USER("team_user"),
+
+    /**
+     * Team entity representing a subset of users on a team.
+     */
     TEAM_GROUP("team_group"),
+
+    /**
+     * Unrecognized team entity type.
+     */
     UNKNOWN(null)
 }

--- a/models/src/main/java/com/vimeo/networking2/enums/TeamEntityType.kt
+++ b/models/src/main/java/com/vimeo/networking2/enums/TeamEntityType.kt
@@ -1,0 +1,11 @@
+package com.vimeo.networking2.enums
+
+/**
+ * An enumeration of [com.vimeo.networking2.TeamEntity.rawType].
+ */
+enum class TeamEntityType(override val value: String?) : StringValue {
+    ALL_TEAM("all_team"),
+    TEAM_USER("team_user"),
+    TEAM_GROUP("team_group"),
+    UNKNOWN(null)
+}

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -1913,6 +1913,14 @@ interface VimeoApiClient {
         callback: VimeoCallback<Unit>
     ): VimeoRequest
 
+    fun fetchTeamPermissions(
+        uri: String,
+        fieldFilter: String?,
+        queryParams: Map<String, String>?,
+        cacheControl: CacheControl?,
+        callback: VimeoCallback<TeamPermissionList>
+    ): VimeoRequest
+
     companion object {
 
         private val delegate: MutableVimeoApiClientDelegate = MutableVimeoApiClientDelegate()

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -1913,6 +1913,23 @@ interface VimeoApiClient {
         callback: VimeoCallback<Unit>
     ): VimeoRequest
 
+    /**
+     * An endpoint which can either:
+     *
+     *  - fetch all [TeamEntity] with a current permission association with a resource if no 'query'
+     *  query-string parameter is present
+     *  - or if a 'query' query-string parameter is passed in, return all [TeamEntity]s related to your [Team] which
+     *  match that query value, so long as they are [TeamEntity]s which *can* have a permission action leveraged against
+     *   them.
+     *
+     * @param uri The URI of the endpoint. Typically comes from a 'team_permission' interaction within the metadata for
+     * a folder or video resource
+     * @param queryParams The query parameters to include in the request. 'query' is one potential value here, as
+     * mentioned in the method description.
+     * @param callback The callback which will be notified of the request completion.
+     *
+     * @return A [VimeoRequest] object to cancel API requests.
+     */
     fun fetchTeamPermissions(
         uri: String,
         fieldFilter: String?,

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -395,6 +395,16 @@ internal interface VimeoService {
     ): VimeoCall<FolderList>
 
     @GET
+    fun getTeamPermissions(
+        @Header(AUTHORIZATION) authorization: String,
+        @Url uri: String,
+        @Query(FIELD_FILTER) fieldFilter: String?,
+        @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>,
+        @Header(CACHE_CONTROL) cacheControl: CacheControl?
+    ): VimeoCall<TeamPermissionList>
+
+
+    @GET
     fun getFeedList(
         @Header(AUTHORIZATION) authorization: String,
         @Url uri: String,

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -403,7 +403,6 @@ internal interface VimeoService {
         @Header(CACHE_CONTROL) cacheControl: CacheControl?
     ): VimeoCall<TeamPermissionList>
 
-
     @GET
     fun getFeedList(
         @Header(AUTHORIZATION) authorization: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -53,6 +53,7 @@ import com.vimeo.networking2.Team
 import com.vimeo.networking2.TeamList
 import com.vimeo.networking2.TeamMembership
 import com.vimeo.networking2.TeamMembershipList
+import com.vimeo.networking2.TeamPermissionList
 import com.vimeo.networking2.TextTrackList
 import com.vimeo.networking2.TvodItem
 import com.vimeo.networking2.TvodItemList
@@ -850,4 +851,12 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         queryParams: Map<String, String>,
         callback: VimeoCallback<Unit>
     ): VimeoRequest = client.deleteContent(uri, queryParams, callback)
+
+    override fun fetchTeamPermissions(
+        uri: String,
+        fieldFilter: String?,
+        queryParams: Map<String, String>?,
+        cacheControl: CacheControl?,
+        callback: VimeoCallback<TeamPermissionList>
+    ): VimeoRequest = client.fetchTeamPermissions(uri, fieldFilter, queryParams, cacheControl, callback)
 }

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -57,6 +57,7 @@ import com.vimeo.networking2.Team
 import com.vimeo.networking2.TeamList
 import com.vimeo.networking2.TeamMembership
 import com.vimeo.networking2.TeamMembershipList
+import com.vimeo.networking2.TeamPermissionList
 import com.vimeo.networking2.TextTrackList
 import com.vimeo.networking2.TvodItem
 import com.vimeo.networking2.TvodItemList
@@ -588,6 +589,24 @@ internal class VimeoApiClientImpl(
     ): VimeoRequest {
         val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
         return vimeoService.getFolderList(
+            authHeader,
+            safeUri,
+            fieldFilter,
+            queryParams.orEmpty(),
+            cacheControl
+        ).enqueue(callback)
+    }
+
+    override fun fetchTeamPermissions(
+        uri: String,
+        fieldFilter: String?,
+        queryParams: Map<String, String>?,
+        cacheControl: CacheControl?,
+        callback: VimeoCallback<TeamPermissionList>
+    ): VimeoRequest {
+        val safeUri = uri.validate() ?: return localVimeoCallAdapter.enqueueInvalidUri(callback)
+
+        return vimeoService.getTeamPermissions(
             authHeader,
             safeUri,
             fieldFilter,


### PR DESCRIPTION
https://vimean.atlassian.net/browse/MPS-3051

# Summary
TeamPermission entity(s) and VimeoApiClient method(s).

## Description
Addition of entities and the calls which require them to VimeoApiClient

## How to Test
1. Set networking library version to "MPS-3051-team-permission-SNAPSHOT"
2. You can verify calls with this code snippet when logging in as the iap2@gmail.com test user:

```        
adaptRequest<TeamPermissionList> {
   vimeoApiClient.fetchTeamPermissions(
      uri = "/users/79937352/projects/5826885/team_permissions",
      fieldFilter = null,
      queryParams = null,
      cacheControl = null,
      callback = it
   )
}.subscribeBy {
   if(it is VimeoResponse.Success){
     Log.i("TEAMPERMISSIONS:" + it.data.toString())
   }
}.addTo(compositeDisposable)
```