### PR TITLE
New folder interactions

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
@@ -6,13 +6,16 @@ import com.squareup.moshi.JsonClass
 /**
  * The interactions for a folder.
  *
+ * @param addRemoveVideos The interaction used to determine if the user can add to or remove videos from the folder.
  * @param addSubfolder The interaction used to add a subfolder as well as determine capability for adding subfolders.
  * @param deleteVideo The interaction that shows whether the user can delete videos from the folder.
- * @param edit The interaction that shows whether the user can edit the folder's settings.
  * @param invite The interaction that shows whether the user can invite other users to manage the folder.
  */
 @JsonClass(generateAdapter = true)
 data class FolderInteractions(
+
+    @Json(name = "edit")
+    val addRemoveVideos: BasicInteraction? = null,
 
     @Json(name = "add_subfolder")
     val addSubfolder: AddSubfolderInteraction? = null,
@@ -20,8 +23,6 @@ data class FolderInteractions(
     @Json(name = "delete_video")
     val deleteVideo: BasicInteraction? = null,
 
-    @Json(name = "edit")
-    val edit: BasicInteraction? = null,
 
     @Json(name = "invite")
     val invite: BasicInteraction? = null,

--- a/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/FolderInteractions.kt
@@ -8,7 +8,9 @@ import com.squareup.moshi.JsonClass
  *
  * @param addRemoveVideos The interaction used to determine if the user can add to or remove videos from the folder.
  * @param addSubfolder The interaction used to add a subfolder as well as determine capability for adding subfolders.
+ * @param delete The interaction used to determine if the user can delete the folder.
  * @param deleteVideo The interaction that shows whether the user can delete videos from the folder.
+ * @param editSettings The interaction that shows whether the user can edit the folder's settings.
  * @param invite The interaction that shows whether the user can invite other users to manage the folder.
  */
 @JsonClass(generateAdapter = true)
@@ -20,9 +22,14 @@ data class FolderInteractions(
     @Json(name = "add_subfolder")
     val addSubfolder: AddSubfolderInteraction? = null,
 
+    @Json(name = "delete")
+    val delete: BasicInteraction? = null,
+
     @Json(name = "delete_video")
     val deleteVideo: BasicInteraction? = null,
 
+    @Json(name = "edit_settings")
+    val editSettings: BasicInteraction? = null,
 
     @Json(name = "invite")
     val invite: BasicInteraction? = null,


### PR DESCRIPTION
# Summary
The `edit` interaction is insufficient to cover all the editing actions, this PR adds what is missing.

## Description
`edit` is a misnomer for the interaction, because it actually covers adding and removing videos. We have renamed it to `addRemoveVideos` to account for this.

We are also adding an `editSettings` interaction to cover editing the title of a folder and other settings, as well as a `delete` interaction that covers deleting a folder.

## How to Test
- Verify that tests pass.
