### PR TITLE
Adding SsoConnections DTO and associated endpoint

### DIFF
--- a/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
+++ b/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
@@ -265,6 +265,23 @@ interface Authenticator {
     ): VimeoRequest
 
     /**
+     * Create a URI which can be used to log in the user via a browser and will redirect to a URI that can be exchanged
+     * using [authenticateWithSso] for a logged in account. Obtain the [SsoConnection] required by this function first
+     * using [checkSsoConnection].
+     *
+     * @param ssoConnection The connection info obtained from the API that specifies the connection URI which will be
+     * used as the base for this URI. NOTE: The connection URI (obtained from [SsoConnectionInteractions.connect]) must
+     * not be null, if a domain is provided with a null connection, then this function will return null.
+     * @param responseCode An arbitrary response code that can be used to verify the origin of the redirect URI. The
+     * API will return this value to later as a security measure in a query string parameter named `state` in the
+     * callback URI.
+     *
+     * @return The URI which can be opened in a browser, or null if the parameters provided were invalid.
+     */
+    @Internal
+    fun createSsoAuthorizationUri(ssoConnection: SsoConnection, responseCode: String): String?
+
+    /**
      * Find a supported SSO domain that matches the [domain] parameter. If this request returns a valid [SsoDomain],
      * then SSO authentication can be initiated, starting with the creation of the SSO authorization URI via
      * [createSsoAuthorizationUri].
@@ -295,6 +312,7 @@ interface Authenticator {
      *
      * @return The URI which can be opened in a browser, or null if the parameters provided were invalid.
      */
+    @Deprecated("Deprecated in favor of the function by the same name that accepts an SsoConnection")
     @Internal
     fun createSsoAuthorizationUri(ssoDomain: SsoDomain, responseCode: String): String?
 

--- a/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
+++ b/auth/src/main/java/com/vimeo/networking2/Authenticator.kt
@@ -249,6 +249,22 @@ interface Authenticator {
     ): VimeoRequest
 
     /**
+     * Find a supported SSO connection that can be used by the [email] provided. If this request returns a valid
+     * [SsoConnection] then SSO authentication can be initiated, starting with the creation of the SSO authorization URI
+     * via [createSsoAuthorizationUri].
+     *
+     * @param email The email of the user that is logging in and might be supported for SSO by the Vimeo API.
+     * @param callback Callback to be notified of the result of the request.
+     *
+     * @return A [VimeoRequest] object to cancel API requests.
+     */
+    @Internal
+    fun checkSsoConnection(
+        email: String,
+        callback: VimeoCallback<SsoConnection>
+    ): VimeoRequest
+
+    /**
      * Find a supported SSO domain that matches the [domain] parameter. If this request returns a valid [SsoDomain],
      * then SSO authentication can be initiated, starting with the creation of the SSO authorization URI via
      * [createSsoAuthorizationUri].
@@ -258,6 +274,7 @@ interface Authenticator {
      *
      * @return A [VimeoRequest] object to cancel API requests.
      */
+    @Deprecated("Deprecated in favor of checkSsoConnection")
     @Internal
     fun fetchSsoDomain(
         domain: String,

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthService.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthService.kt
@@ -24,6 +24,7 @@ package com.vimeo.networking2.internal
 import com.vimeo.networking2.GrantType
 import com.vimeo.networking2.PinCodeInfo
 import com.vimeo.networking2.Scopes
+import com.vimeo.networking2.SsoConnection
 import com.vimeo.networking2.SsoDomain
 import com.vimeo.networking2.TeamToken
 import com.vimeo.networking2.VimeoAccount
@@ -35,6 +36,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.Url
@@ -318,6 +320,21 @@ internal interface AuthService {
     ): VimeoCall<VimeoAccount>
 
     /**
+     * Check whether an [SsoConnection] exists for the provided [email].
+     *
+     * @param authorization Created from the client id and client secret.
+     * @param email The email used to check for the presence of an [SsoConnection].
+     *
+     * @return A [VimeoCall] that provides an [SsoConnection] that can be used to perform SSO.
+     */
+    @FormUrlEncoded
+    @PUT("sso_connections/verify")
+    fun checkSsoConnection(
+        @Header(AUTHORIZATION) authorization: String,
+        @Field(EMAIL) email: String
+    ): VimeoCall<SsoConnection>
+
+    /**
      * Searches Vimeo for the presence of a supported SSO domain that matches the one provided by the [domain]
      * parameter.
      *
@@ -326,6 +343,7 @@ internal interface AuthService {
      *
      * @return A [VimeoCall] that provides a [SsoDomain] that can be used to perform SSO.
      */
+    @Deprecated("deprecated in favor of checkSsoConnection")
     @Internal
     @GET("sso_domains")
     fun getSsoDomain(

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -243,6 +243,15 @@ internal class AuthenticatorImpl(
             ).enqueue(callback)
     }
 
+    override fun createSsoAuthorizationUri(ssoConnection: SsoConnection, responseCode: String): String? {
+        val connectUrl = ssoConnection.metadata?.interactions?.connect?.uri ?: return null
+        return authService.createSsoGrantRequest(
+            uri = connectUrl,
+            redirectUri = redirectUri,
+            state = responseCode
+        ).url
+    }
+
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest {
         val domainParameter = ApiParameter(DOMAIN, domain)
 

--- a/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/AuthenticatorImpl.kt
@@ -25,6 +25,7 @@ import com.vimeo.networking2.Authenticator
 import com.vimeo.networking2.GrantType
 import com.vimeo.networking2.NoOpVimeoRequest
 import com.vimeo.networking2.PinCodeInfo
+import com.vimeo.networking2.SsoConnection
 import com.vimeo.networking2.SsoDomain
 import com.vimeo.networking2.TeamToken
 import com.vimeo.networking2.VimeoAccount
@@ -35,6 +36,7 @@ import com.vimeo.networking2.config.AuthenticationMethod
 import com.vimeo.networking2.internal.AuthService.Companion.AUTHORIZATION_CODE
 import com.vimeo.networking2.internal.AuthService.Companion.CODE
 import com.vimeo.networking2.internal.AuthService.Companion.DEVICE_CODE
+import com.vimeo.networking2.internal.AuthService.Companion.DOMAIN
 import com.vimeo.networking2.internal.AuthService.Companion.EMAIL
 import com.vimeo.networking2.internal.AuthService.Companion.ID_TOKEN
 import com.vimeo.networking2.internal.AuthService.Companion.NAME
@@ -231,8 +233,18 @@ internal class AuthenticatorImpl(
         ).url
     }
 
+    override fun checkSsoConnection(email: String, callback: VimeoCallback<SsoConnection>): VimeoRequest {
+        val emailParameter = ApiParameter(EMAIL, email)
+
+        return localVimeoCallAdapter.validateParameters(callback, "SSO connection check error", emailParameter)
+            ?: authService.checkSsoConnection(
+                authorization = authenticationMethod.basicAuthHeader,
+                email = email
+            ).enqueue(callback)
+    }
+
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest {
-        val domainParameter = ApiParameter(AuthService.DOMAIN, domain)
+        val domainParameter = ApiParameter(DOMAIN, domain)
 
         return localVimeoCallAdapter.validateParameters(callback, "SSO domain fetch error", domainParameter)
             ?: authService.getSsoDomain(

--- a/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
@@ -94,6 +94,9 @@ class MutableAuthenticatorDelegate(var actual: Authenticator? = null) : Authenti
     override fun checkSsoConnection(email: String, callback: VimeoCallback<SsoConnection>): VimeoRequest =
         authenticator.checkSsoConnection(email, callback)
 
+    override fun createSsoAuthorizationUri(ssoConnection: SsoConnection, responseCode: String): String? =
+        authenticator.createSsoAuthorizationUri(ssoConnection, responseCode)
+
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest =
         authenticator.fetchSsoDomain(domain, callback)
 

--- a/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/MutableAuthenticatorDelegate.kt
@@ -23,6 +23,7 @@ package com.vimeo.networking2.internal
 
 import com.vimeo.networking2.Authenticator
 import com.vimeo.networking2.PinCodeInfo
+import com.vimeo.networking2.SsoConnection
 import com.vimeo.networking2.SsoDomain
 import com.vimeo.networking2.TeamToken
 import com.vimeo.networking2.VimeoAccount
@@ -89,6 +90,9 @@ class MutableAuthenticatorDelegate(var actual: Authenticator? = null) : Authenti
 
     override fun authenticateWithCodeGrant(uri: String, callback: VimeoCallback<VimeoAccount>): VimeoRequest =
         authenticator.authenticateWithCodeGrant(uri, callback)
+
+    override fun checkSsoConnection(email: String, callback: VimeoCallback<SsoConnection>): VimeoRequest =
+        authenticator.checkSsoConnection(email, callback)
 
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest =
         authenticator.fetchSsoDomain(domain, callback)

--- a/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
@@ -2,6 +2,7 @@ package com.vimeo.networking2.internal
 
 import com.vimeo.networking2.Authenticator
 import com.vimeo.networking2.PinCodeInfo
+import com.vimeo.networking2.SsoConnection
 import com.vimeo.networking2.SsoDomain
 import com.vimeo.networking2.TeamToken
 import com.vimeo.networking2.VimeoAccount
@@ -63,6 +64,8 @@ class NoOpAuthenticatorImpl(
     override fun createCodeGrantAuthorizationUri(responseCode: String): String = reject()
 
     override fun authenticateWithCodeGrant(uri: String, callback: VimeoCallback<VimeoAccount>): VimeoRequest = reject()
+
+    override fun checkSsoConnection(email: String, callback: VimeoCallback<SsoConnection>): VimeoRequest = reject()
 
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest = reject()
 

--- a/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
+++ b/auth/src/main/java/com/vimeo/networking2/internal/NoOpAuthenticatorImpl.kt
@@ -67,6 +67,8 @@ class NoOpAuthenticatorImpl(
 
     override fun checkSsoConnection(email: String, callback: VimeoCallback<SsoConnection>): VimeoRequest = reject()
 
+    override fun createSsoAuthorizationUri(ssoConnection: SsoConnection, responseCode: String): String = reject()
+
     override fun fetchSsoDomain(domain: String, callback: VimeoCallback<SsoDomain>): VimeoRequest = reject()
 
     override fun createSsoAuthorizationUri(ssoDomain: SsoDomain, responseCode: String): String = reject()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4096M
-version=2.0.0
+version=3.2.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/models/src/main/java/com/vimeo/networking2/SsoConnection.kt
+++ b/models/src/main/java/com/vimeo/networking2/SsoConnection.kt
@@ -1,0 +1,26 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.annotations.Internal
+
+/**
+ * A connection used to log into Vimeo via Single Sign-On.
+ *
+ * @param connectionName The name of the connection.
+ * @param metadata The metadata containing the interactions of the connection.
+ * @param uri The URI of the connection.
+ */
+@Internal
+@JsonClass(generateAdapter = true)
+data class SsoConnection(
+
+    @Json(name = "connection_name")
+    val connectionName: String? = null,
+
+    @Json(name = "metadata")
+    val metadata: MetadataInteractions<SsoConnectionInteractions>? = null,
+
+    @Json(name = "uri")
+    val uri: String? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/SsoConnectionInteractions.kt
+++ b/models/src/main/java/com/vimeo/networking2/SsoConnectionInteractions.kt
@@ -1,0 +1,18 @@
+package com.vimeo.networking2
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.annotations.Internal
+
+/**
+ * The interaction for an Single Sign-On connection.
+ *
+ * @param connect The interaction to connect via Single Sign-On.
+ */
+@Internal
+@JsonClass(generateAdapter = true)
+data class SsoConnectionInteractions(
+
+    @Json(name = "connect")
+    val connect: BasicInteraction? = null
+)

--- a/models/src/main/java/com/vimeo/networking2/SsoDomain.kt
+++ b/models/src/main/java/com/vimeo/networking2/SsoDomain.kt
@@ -34,6 +34,7 @@ import com.vimeo.networking2.annotations.Internal
  */
 @Internal
 @JsonClass(generateAdapter = true)
+@Deprecated("Deprecated in favor of SsoConnection")
 data class SsoDomain(
 
     @Json(name = "uri")

--- a/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
+++ b/models/src/test/java/com/vimeo/networking2/ModelsTest.kt
@@ -131,6 +131,8 @@ class ModelsTest {
         SeasonList::class,
         Space::class,
         Spatial::class,
+        SsoConnection::class,
+        SsoConnectionInteractions::class,
         SsoDomain::class,
         Subscription::class,
         SubscriptionInteraction::class,


### PR DESCRIPTION
# Summary
Some SSO connected accounts are not bound to a specific domain, but are email specific. As a result, these accounts can't log in with the current SSO domain method. This PR introduces a way for these accounts to log in with SSO even if they aren't bound by domain.

## Description
- Added `SsoConnection`
- Added `SsoConnectionInteractions`
- Added `checkSsoConnection` to `Authenticator`
- Added `createSsoAuthorizationUri` that accepts an `SsoConnection` to `Authenticator`.
- Deprecated all the old DTOs and functions associated with SSO in favor of the above.

The SSO flow follows nearly identically to the old one, so I am not going to completely describe it here. The difference is that instead of calling `fetchSsoDomain` by passing a `domain` as a query parameter, we call `checkSsoConnection` and set the `email` parameter. This returns to us an `SsoConnection` instead of an `SsoDomain`. We then call `createSsoAuthorizationUri` by passing the connection instead of the domain and then the flow proceeds the same as it did previously.

## How to Test
- Run the tests
- Verify that login with SSO works by following the steps partially outlined above.
