### PR TITLE
[TECH] Add convenience extension for TeamPermission data class for getting the current PermissionPolicy

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
@@ -32,5 +32,5 @@ data class TeamGroup(
     val modifiedOn: Date? = null,
 
     @Json(name = "metadata")
-    val metadata: MetadataConnections<TeamGroupConnections>
+    val metadata: MetadataConnections<TeamGroupConnections>? = null
 )

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -32,3 +32,16 @@ data class TeamPermission(
 ) : Entity {
     override val identifier: String? = teamEntity?.identifier
 }
+
+/**
+ * Get the current [PermissionPolicy] if possible; This search is predicated upon
+ * [TeamPermission.applicablePermissionPolicies] containing an item with the same uri as
+ * [TeamPermission.currentPermissions], [TeamPermissionCurrentPermissions.permissionPolicyUri].
+ */
+val TeamPermission.currentPermissionPolicy: PermissionPolicy? get() {
+    if (currentPermissions?.permissionPolicyUri == null) {
+        return null
+    }
+
+    return applicablePermissionPolicies?.firstOrNull { it.uri == currentPermissions.permissionPolicyUri }
+}

--- a/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamPermission.kt
@@ -38,10 +38,9 @@ data class TeamPermission(
  * [TeamPermission.applicablePermissionPolicies] containing an item with the same uri as
  * [TeamPermission.currentPermissions], [TeamPermissionCurrentPermissions.permissionPolicyUri].
  */
-val TeamPermission.currentPermissionPolicy: PermissionPolicy? get() {
+val TeamPermission.currentPermissionPolicy: PermissionPolicy? get() =
     if (currentPermissions?.permissionPolicyUri == null) {
-        return null
+        null
+    } else {
+        applicablePermissionPolicies?.firstOrNull { it.uri == currentPermissions.permissionPolicyUri }
     }
-
-    return applicablePermissionPolicies?.firstOrNull { it.uri == currentPermissions.permissionPolicyUri }
-}


### PR DESCRIPTION
# Summary
Unfortunately we only have the uri provided for the current permission policy.  Applicable permission policies however do most likely contain the name of the policy the uri belongs to. It's possible you could have an assigned policy which is no longer available to select again. In that case you wouldn't produce a match using this method and result in a null PermissionPolicy. For the sake of how this is used, I believe this is an acceptable quirk.  

## How to Test

Make sure the app compiles right, and analyze the code for any logical faults.