### PR TITLE
Make metadata nullable with default value of null for TeamGroup

### DIFF
--- a/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
+++ b/models/src/main/java/com/vimeo/networking2/TeamGroup.kt
@@ -32,5 +32,5 @@ data class TeamGroup(
     val modifiedOn: Date? = null,
 
     @Json(name = "metadata")
-    val metadata: MetadataConnections<TeamGroupConnections>
+    val metadata: MetadataConnections<TeamGroupConnections>? = null
 )


### PR DESCRIPTION
# Summary
Make metadata nullable with default value of null for TeamGroup

## Description
Make metadata nullable with default value of null for TeamGroup

## How to Test
Library builds successfully.
