### PR TITLE
Custom message team invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==========
+Version 3.10.0 *(2022-06-27)*
+----------------------------
+- Added `customMessage` parameter to `VimeoApiClient.addUserToTeam()`.
+
 Version 3.9.0 *(2022-06-23)*
 ----------------------------
 - Added the `ErrorCodeType.ADD_TEAM_MEMBER_FORBIDDEN` error code.

--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -33,7 +33,7 @@ object ApiConstants {
 
     const val SSL_URL_PATTERN = "*.vimeo.com"
 
-    const val SDK_VERSION = "3.9.0"
+    const val SDK_VERSION = "3.10.0"
 
     const val NONE = -1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4096M
-version=3.9.0
+version=3.10.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoApiClient.kt
@@ -1621,6 +1621,7 @@ interface VimeoApiClient {
      * @param permissionLevel The intended [TeamRoleType] for the user being added.
      * @param folderUri If the user is being added as a [TeamRoleType.CONTRIBUTOR] or [TeamRoleType.VIEWER] a URI for
      * the Folder they can contribute or view also needs to be added.
+     * @param customMessage An optional invite message to show to the user being invited.
      * @param queryParams Optional map used to refine the response from the API.
      * @param callback The callback which will be notified of the request completion.
      *
@@ -1631,6 +1632,7 @@ interface VimeoApiClient {
         email: String,
         permissionLevel: TeamRoleType,
         folderUri: String?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest
@@ -1643,6 +1645,7 @@ interface VimeoApiClient {
      * @param permissionLevel The intended [TeamRoleType] for the user being added.
      * @param folder If the user is being added as a [TeamRoleType.CONTRIBUTOR] or [TeamRoleType.VIEWER] the
      * [Folder] they can contribute or view also needs to be added.
+     * @param customMessage An optional invite message to show to the user being invited.
      * @param queryParams Optional map used to refine the response from the API.
      * @param callback The callback which will be notified of the request completion.
      *
@@ -1653,6 +1656,7 @@ interface VimeoApiClient {
         email: String,
         permissionLevel: TeamRoleType,
         folder: Folder?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest

--- a/request/src/main/java/com/vimeo/networking2/VimeoService.kt
+++ b/request/src/main/java/com/vimeo/networking2/VimeoService.kt
@@ -595,6 +595,7 @@ internal interface VimeoService {
         @Field(PARAMETER_EMAIL) email: String,
         @Field(PARAMETER_PERMISSION_LEVEL) permissionLevel: TeamRoleType,
         @Field(PARAMETER_FOLDER_URI) folderUri: String?,
+        @Field(CUSTOM_MESSAGE) customMessage: String?,
         @QueryMap queryParams: Map<String, @JvmSuppressWildcards String>
     ): VimeoCall<TeamMembership>
 
@@ -727,5 +728,6 @@ internal interface VimeoService {
         private const val SLACK_LANGUAGE_PREF = "slack_language_preference"
         private const val SLACK_USER_PREF = "slack_user_preferences"
         private const val QUERY_STRING_PARAM_QUERY = "query"
+        private const val CUSTOM_MESSAGE = "custom_message"
     }
 }

--- a/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/MutableVimeoApiClientDelegate.kt
@@ -450,18 +450,20 @@ internal class MutableVimeoApiClientDelegate(var actual: VimeoApiClient? = null)
         email: String,
         permissionLevel: TeamRoleType,
         folderUri: String?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
-    ): VimeoRequest = client.addUserToTeam(uri, email, permissionLevel, folderUri, queryParams, callback)
+    ): VimeoRequest = client.addUserToTeam(uri, email, permissionLevel, folderUri, customMessage, queryParams, callback)
 
     override fun addUserToTeam(
         team: Team,
         email: String,
         permissionLevel: TeamRoleType,
         folder: Folder?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
-    ): VimeoRequest = client.addUserToTeam(team, email, permissionLevel, folder, queryParams, callback)
+    ): VimeoRequest = client.addUserToTeam(team, email, permissionLevel, folder, customMessage, queryParams, callback)
 
     override fun removeUserFromTeam(
         uri: String,

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -881,6 +881,7 @@ internal class VimeoApiClientImpl(
         email: String,
         permissionLevel: TeamRoleType,
         folderUri: String?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
@@ -891,6 +892,7 @@ internal class VimeoApiClientImpl(
             email,
             permissionLevel,
             folderUri,
+            customMessage,
             queryParams.orEmpty()
         ).enqueue(callback)
     }
@@ -900,6 +902,7 @@ internal class VimeoApiClientImpl(
         email: String,
         permissionLevel: TeamRoleType,
         folder: Folder?,
+        customMessage: String?,
         queryParams: Map<String, String>?,
         callback: VimeoCallback<TeamMembership>
     ): VimeoRequest {
@@ -911,6 +914,7 @@ internal class VimeoApiClientImpl(
             email,
             permissionLevel,
             folder?.uri,
+            customMessage,
             queryParams.orEmpty()
         ).enqueue(callback)
     }


### PR DESCRIPTION
# Summary
Added the `customMessage` parameter to the two `VimeoApiClient.addUserToTeam()` function variants.

Bumped version to 3.10.0.

## How to Test
Verify that tests pass.
