### PR TITLE
CXAN-44 Add stream_title param to editLiveEvent API

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/ApiConstants.kt
@@ -99,6 +99,7 @@ object ApiConstants {
         const val PARAMETER_TEAM_ENTITY_TYPE = "team_entity_type"
         const val PARAMETER_TEAM_ENTITY_URI = "team_entity_uri"
         const val PARAMETER_LIVE_EVENT_TITLE = "title"
+        const val PARAMETER_LIVE_EVENT_STREAM_TITLE = "stream_title"
         const val PARAMETER_LIVE_EVENT_DESCRIPTION = "stream_description"
         const val PARAMETER_LIVE_EVENT_PASSWORD = "stream_password"
         const val PARAMETER_AUTOMATICALLY_TITLE_STREAM = "automatically_title_stream"

--- a/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
+++ b/request/src/main/java/com/vimeo/networking2/internal/VimeoApiClientImpl.kt
@@ -369,6 +369,7 @@ internal class VimeoApiClientImpl(
         val body = bodyParams.intoMutableMap()
         if (title != null) {
             body[ApiConstants.Parameters.PARAMETER_LIVE_EVENT_TITLE] = title
+            body[ApiConstants.Parameters.PARAMETER_LIVE_EVENT_STREAM_TITLE] = title
         }
         if (description != null) {
             body[ApiConstants.Parameters.PARAMETER_LIVE_EVENT_DESCRIPTION] = description


### PR DESCRIPTION
# Summary
https://vimean.atlassian.net/browse/CXAN-26

## Description
https://vimean.atlassian.net/browse/CXAN-26?focusedCommentId=716558

API requires `stream_title` param when `automatically_title_stream` is false
