### PR TITLE
CXAN-26 Fix Schedule start_time field serialization

### DIFF
--- a/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/config/RetrofitSetupModule.kt
@@ -24,6 +24,7 @@ package com.vimeo.networking2.config
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.vimeo.networking2.internal.ErrorHandlingCallAdapterFactory
+import com.vimeo.networking2.internal.adapters.Iso8601NoMillisAdapter
 import com.vimeo.networking2.internal.adapters.TimeAdapter
 import com.vimeo.networking2.internal.interceptor.AcceptHeaderInterceptor
 import com.vimeo.networking2.internal.interceptor.CacheControlHeaderInterceptor
@@ -56,6 +57,7 @@ object RetrofitSetupModule {
         .add(StringValueJsonAdapterFactory())
         .add(IntValueJsonAdapterFactory())
         .add(TimeAdapter())
+        .add(Iso8601NoMillisAdapter())
         .build()
 
     /**

--- a/api-core/src/main/java/com/vimeo/networking2/internal/adapters/Iso8601NoMillisAdapter.kt
+++ b/api-core/src/main/java/com/vimeo/networking2/internal/adapters/Iso8601NoMillisAdapter.kt
@@ -1,0 +1,62 @@
+package com.vimeo.networking2.internal.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import com.vimeo.networking2.annotations.Iso8601NoMillis
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Json adapter for [Date] properties annotated with [Iso8601NoMillis].
+ * Formats [Date] instance to it's ISO8601 date representations without millis.
+ */
+class Iso8601NoMillisAdapter {
+    private val timeZone = TimeZone.getTimeZone("GMT")
+
+    /**
+     * Converts [Date] instance to it's ISO8601 date representations without millis.
+     * Modified version of https://github.com/square/moshi/blob/a13aa33f12bc7db6ec0c35d042b14ab7f8a89073/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.kt#L48
+     */
+    @ToJson
+    fun toJson(@Iso8601NoMillis date: Date?): String? {
+        if (date == null) return null
+
+        val calendar: Calendar = GregorianCalendar(timeZone, Locale.US).apply {
+            time = date
+        }
+
+        val capacity = "yyyy-MM-ddThh:mm:ssZ".length
+        val formatted = StringBuilder(capacity)
+        formatted.padInt(calendar[Calendar.YEAR], "yyyy".length)
+        formatted.append('-')
+        formatted.padInt(calendar[Calendar.MONTH] + 1, "MM".length)
+        formatted.append('-')
+        formatted.padInt(calendar[Calendar.DAY_OF_MONTH], "dd".length)
+        formatted.append('T')
+        formatted.padInt(calendar[Calendar.HOUR_OF_DAY], "hh".length)
+        formatted.append(':')
+        formatted.padInt(calendar[Calendar.MINUTE], "mm".length)
+        formatted.append(':')
+        formatted.padInt(calendar[Calendar.SECOND], "ss".length)
+        formatted.append('Z')
+        return formatted.toString()
+    }
+
+    /**
+     * Delegates [Date] parsing to previous moshi [Date] adapter.
+     */
+    @FromJson
+    @Iso8601NoMillis
+    fun fromJson(value: Date?): Date? = value
+
+    private fun StringBuilder.padInt(value: Int, length: Int) {
+        val strValue = value.toString()
+        for (i in length - strValue.length downTo 1) {
+            append('0')
+        }
+        append(strValue)
+    }
+}

--- a/models-annotations/src/main/java/com/vimeo/networking2/annotations/Iso8601NoMillis.kt
+++ b/models-annotations/src/main/java/com/vimeo/networking2/annotations/Iso8601NoMillis.kt
@@ -1,0 +1,7 @@
+package com.vimeo.networking2.annotations
+
+import com.squareup.moshi.JsonQualifier
+
+@Retention(AnnotationRetention.RUNTIME)
+@JsonQualifier
+annotation class Iso8601NoMillis

--- a/models/src/main/java/com/vimeo/networking2/params/Schedule.kt
+++ b/models/src/main/java/com/vimeo/networking2/params/Schedule.kt
@@ -2,6 +2,7 @@ package com.vimeo.networking2.params
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.vimeo.networking2.annotations.Iso8601NoMillis
 import com.vimeo.networking2.annotations.Time
 import com.vimeo.networking2.enums.ScheduleType
 import com.vimeo.networking2.enums.Weekday
@@ -21,6 +22,7 @@ data class Schedule(
     @Json(name = "type")
     val type: ScheduleType? = null,
 
+    @Iso8601NoMillis
     @Json(name = "start_time")
     val startTime: Date? = null,
 


### PR DESCRIPTION
# Summary
https://vimean.atlassian.net/browse/CXAN-26

## Description
API is not accepting `.sss` part of timestamp. 
`Iso8601NoMillisAdapter` removes it.
